### PR TITLE
fix(mcp): preserve public variables and expose stdio headers

### DIFF
--- a/src/backend/base/langflow/api/v1/mcp_utils.py
+++ b/src/backend/base/langflow/api/v1/mcp_utils.py
@@ -79,11 +79,59 @@ def _public_mcp_session_namespace(server: Any, project_id: UUID, flow_id: UUID) 
     return str(compute_virtual_flow_id(identifier, flow_id, principal_type="client"))
 
 
-async def _prepare_public_mcp_execution_flow(flow: Flow) -> Flow:
+def _restore_public_mcp_request_variable_references(
+    source: Any,
+    sanitized: Any,
+    request_variables: dict[str, str],
+) -> None:
+    """Restore sanitized variable names only when the current request supplies them.
+
+    Public MCP execution scrubs all secret-looking values before building the flow. A
+    ``load_from_db`` field or table cell contains a variable *name*, not the stored
+    secret, and the build needs that name to resolve a request-scoped override. Restore
+    only references that have a matching request value so anonymous execution cannot
+    fall back to an owner's database variables or ambient environment credentials.
+    """
+    if isinstance(source, dict) and isinstance(sanitized, dict):
+        source_value = source.get("value")
+        if source.get("load_from_db") is True and isinstance(source_value, str) and source_value in request_variables:
+            sanitized["value"] = source_value
+
+        row_load_from_db_fields = source.get("__load_from_db_fields")
+        if isinstance(row_load_from_db_fields, dict):
+            variable_fields = [name for name, enabled in row_load_from_db_fields.items() if enabled is True]
+        elif isinstance(row_load_from_db_fields, list):
+            variable_fields = row_load_from_db_fields
+        else:
+            variable_fields = []
+        for field_name in variable_fields:
+            variable_name = source.get(field_name)
+            if isinstance(field_name, str) and isinstance(variable_name, str) and variable_name in request_variables:
+                sanitized[field_name] = variable_name
+
+        for key, source_child in source.items():
+            if key in sanitized:
+                _restore_public_mcp_request_variable_references(
+                    source_child,
+                    sanitized[key],
+                    request_variables,
+                )
+    elif isinstance(source, list) and isinstance(sanitized, list):
+        for source_item, sanitized_item in zip(source, sanitized, strict=False):
+            _restore_public_mcp_request_variable_references(source_item, sanitized_item, request_variables)
+
+
+async def _prepare_public_mcp_execution_flow(
+    flow: Flow,
+    request_variables: dict[str, str] | None = None,
+) -> Flow:
     """Apply the shared anonymous-flow policy to a detached MCP execution graph."""
     validate_public_flow_no_code_execution(flow.data)
     prepared_data = await prepare_public_flow_build(flow.data)
-    sanitized_data = strip_secret_field_values(prepared_data if prepared_data is not None else flow.data)
+    source_data = prepared_data if prepared_data is not None else flow.data
+    sanitized_data = strip_secret_field_values(source_data)
+    if request_variables:
+        _restore_public_mcp_request_variable_references(source_data, sanitized_data, request_variables)
     return flow.model_copy(update={"data": sanitized_data}, deep=True)
 
 
@@ -357,7 +405,7 @@ async def handle_call_tool(
         execution_user = current_user
         if is_public_project_call:
             try:
-                execution_flow = await _prepare_public_mcp_execution_flow(flow)
+                execution_flow = await _prepare_public_mcp_execution_flow(flow, request_variables)
             except CustomComponentValidationError as exc:
                 await logger.awarning(f"Public MCP tool call blocked for flow {flow.id}: {exc!s}")
                 msg = "This flow cannot be executed through a public MCP project."

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -596,10 +596,15 @@ async def test_handle_call_tool_keeps_unmatched_public_secret_references_scrubbe
                                 "table_schema": [{"name": "value", "type": "str", "load_from_db": True}],
                                 "value": [
                                     {
+                                        "key": "X-Langflow-Global-Var-OWNER_ONLY_TABLE_TOKEN",
+                                        "value": "OWNER_ONLY_TABLE_TOKEN",
+                                        "__load_from_db_fields": {"value": True},
+                                    },
+                                    {
                                         "key": "X-Langflow-Global-Var-LITERAL_TOKEN",
                                         "value": "LITERAL_TOKEN",
                                         "__load_from_db_fields": {"value": False},
-                                    }
+                                    },
                                 ],
                             },
                         }
@@ -628,6 +633,7 @@ async def test_handle_call_tool_keeps_unmatched_public_secret_references_scrubbe
     forwarded_template = forwarded_flow.data["nodes"][0]["data"]["node"]["template"]
     assert forwarded_template["api_key"]["value"] is None
     assert forwarded_template["headers"]["value"][0]["value"] is None
+    assert forwarded_template["headers"]["value"][1]["value"] is None
 
 
 async def test_handle_call_tool_rejects_public_flow_validation_failure(monkeypatch):

--- a/src/backend/tests/unit/api/v1/test_mcp_utils.py
+++ b/src/backend/tests/unit/api/v1/test_mcp_utils.py
@@ -413,6 +413,7 @@ async def _invoke_handle_call_tool(
     authenticated_caller="user-1",
     project_id=None,
     flow_data=None,
+    request_variables: dict[str, str] | None = None,
     expected_error: str | None = None,
 ) -> AsyncMock:
     """Run handle_call_tool with all external deps stubbed; return the simple_run_flow mock.
@@ -456,6 +457,7 @@ async def _invoke_handle_call_tool(
 
     token = mcp_utils.current_user_ctx.set(SimpleNamespace(id="user-1"))
     caller_token = mcp_utils.authenticated_caller_ctx.set(authenticated_caller)
+    request_variables_token = mcp_utils.current_request_variables_ctx.set(request_variables)
     try:
         if expected_error is None:
             await mcp_utils.handle_call_tool(
@@ -473,6 +475,7 @@ async def _invoke_handle_call_tool(
                     project_id=project_id,
                 )
     finally:
+        mcp_utils.current_request_variables_ctx.reset(request_variables_token)
         mcp_utils.authenticated_caller_ctx.reset(caller_token)
         mcp_utils.current_user_ctx.reset(token)
 
@@ -508,6 +511,123 @@ async def test_handle_call_tool_applies_public_policy_and_scopes_session(monkeyp
     assert forwarded_request.session_id.endswith(":owner-private")
     assert forwarded_user.id == uuid5(NAMESPACE_URL, "urn:langflow:principal:anonymous-public")
     assert forwarded_user.is_superuser is False
+
+
+async def test_handle_call_tool_preserves_request_backed_secret_references_for_public_flow(monkeypatch):
+    variable_name = "OPENRAG_INGEST_TOKEN"
+    flow_data = {
+        "nodes": [
+            {
+                "id": "openrag",
+                "data": {
+                    "id": "openrag",
+                    "type": "OpenRAG",
+                    "node": {
+                        "template": {
+                            "api_key": {
+                                "name": "api_key",
+                                "password": True,
+                                "load_from_db": True,
+                                "value": variable_name,
+                            },
+                            "headers": {
+                                "name": "headers",
+                                "type": "table",
+                                "table_schema": [
+                                    {"name": "key", "type": "str"},
+                                    {"name": "value", "type": "str", "load_from_db": True},
+                                ],
+                                "value": [
+                                    {
+                                        "key": f"X-Langflow-Global-Var-{variable_name}",
+                                        "value": variable_name,
+                                        "__load_from_db_fields": {"value": True},
+                                    }
+                                ],
+                            },
+                        }
+                    },
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(mcp_utils, "validate_public_flow_no_code_execution", MagicMock())
+    monkeypatch.setattr(mcp_utils, "prepare_public_flow_build", AsyncMock(return_value=flow_data))
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello"},
+        authenticated_caller=None,
+        project_id=uuid4(),
+        flow_data=flow_data,
+        request_variables={variable_name: "request-scoped-secret"},  # pragma: allowlist secret
+    )
+
+    forwarded_flow = simple_run_flow_mock.await_args.kwargs["flow"]
+    forwarded_template = forwarded_flow.data["nodes"][0]["data"]["node"]["template"]
+    assert forwarded_template["api_key"]["value"] == variable_name
+    assert forwarded_template["headers"]["value"][0]["value"] == variable_name
+    assert simple_run_flow_mock.await_args.kwargs["context"] == {
+        "request_variables": {variable_name: "request-scoped-secret"}  # pragma: allowlist secret
+    }
+
+
+async def test_handle_call_tool_keeps_unmatched_public_secret_references_scrubbed(monkeypatch):
+    variable_name = "OWNER_ONLY_TOKEN"
+    flow_data = {
+        "nodes": [
+            {
+                "id": "private-token",
+                "data": {
+                    "id": "private-token",
+                    "type": "SecretConsumer",
+                    "node": {
+                        "template": {
+                            "api_key": {
+                                "name": "api_key",
+                                "password": True,
+                                "load_from_db": True,
+                                "value": variable_name,
+                            },
+                            "headers": {
+                                "name": "headers",
+                                "type": "table",
+                                "table_schema": [{"name": "value", "type": "str", "load_from_db": True}],
+                                "value": [
+                                    {
+                                        "key": "X-Langflow-Global-Var-LITERAL_TOKEN",
+                                        "value": "LITERAL_TOKEN",
+                                        "__load_from_db_fields": {"value": False},
+                                    }
+                                ],
+                            },
+                        }
+                    },
+                },
+            }
+        ],
+        "edges": [],
+    }
+    monkeypatch.setattr(mcp_utils, "validate_public_flow_no_code_execution", MagicMock())
+    monkeypatch.setattr(mcp_utils, "prepare_public_flow_build", AsyncMock(return_value=flow_data))
+
+    simple_run_flow_mock = await _invoke_handle_call_tool(
+        monkeypatch,
+        arguments={"input_value": "hello"},
+        authenticated_caller=None,
+        project_id=uuid4(),
+        flow_data=flow_data,
+        request_variables={
+            "DIFFERENT_TOKEN": "request-scoped-secret",  # pragma: allowlist secret
+            "LITERAL_TOKEN": "must-not-be-used",  # pragma: allowlist secret
+        },
+    )
+
+    forwarded_flow = simple_run_flow_mock.await_args.kwargs["flow"]
+    forwarded_template = forwarded_flow.data["nodes"][0]["data"]["node"]["template"]
+    assert forwarded_template["api_key"]["value"] is None
+    assert forwarded_template["headers"]["value"][0]["value"] is None
 
 
 async def test_handle_call_tool_rejects_public_flow_validation_failure(monkeypatch):

--- a/src/frontend/src/modals/addMcpServerModal/__tests__/addMcpServerModal.test.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/__tests__/addMcpServerModal.test.tsx
@@ -188,13 +188,19 @@ jest.mock(
     default: ({
       onChange,
       testId,
+      value,
+      enableGlobalVariables,
     }: {
       onChange: (value: Array<unknown>) => void;
       testId?: string;
+      value: Array<unknown>;
+      enableGlobalVariables?: boolean;
     }) => (
       <button
         type="button"
         data-testid={`${testId}-clear`}
+        data-enable-global-variables={enableGlobalVariables}
+        data-value={JSON.stringify(value)}
         onClick={() => onChange([])}
       >
         Clear
@@ -273,6 +279,74 @@ describe("AddMcpServerModal", () => {
     );
 
     expect(screen.getByTestId("stdio-name-input")).toBeDisabled();
+  });
+
+  it("persists global-variable-aware headers when editing a STDIO server", async () => {
+    const user = userEvent.setup();
+    const initialData: MCPServerType = {
+      name: "my-server",
+      command: "uvx",
+      args: ["mcp-proxy", "http://host/mcp"],
+      headers: {
+        "X-Langflow-Global-Var-OPENRAG_INGEST_TOKEN": "OPENRAG_INGEST_TOKEN",
+      },
+    };
+
+    render(
+      <AddMcpServerModal
+        open={true}
+        setOpen={jest.fn()}
+        initialData={initialData}
+      />,
+    );
+
+    expect(screen.getByTestId("stdio-headers-clear")).toHaveAttribute(
+      "data-enable-global-variables",
+      "true",
+    );
+    expect(screen.getByTestId("stdio-headers-clear")).toHaveAttribute(
+      "data-value",
+      expect.stringContaining("OPENRAG_INGEST_TOKEN"),
+    );
+
+    await user.click(screen.getByTestId("add-mcp-server-button"));
+
+    expect(mockPatchMCPServer).toHaveBeenCalledWith({
+      name: "my-server",
+      command: "uvx",
+      args: ["mcp-proxy", "http://host/mcp"],
+      headers: {
+        "X-Langflow-Global-Var-OPENRAG_INGEST_TOKEN": "OPENRAG_INGEST_TOKEN",
+      },
+    });
+  });
+
+  it("sends empty headers when deleting the last STDIO header", async () => {
+    const user = userEvent.setup();
+    const initialData: MCPServerType = {
+      name: "my-server",
+      command: "uvx",
+      args: ["mcp-server"],
+      headers: { Authorization: "TOKEN_VARIABLE" },
+    };
+
+    render(
+      <AddMcpServerModal
+        open={true}
+        setOpen={jest.fn()}
+        initialData={initialData}
+      />,
+    );
+
+    await user.click(screen.getByTestId("stdio-headers-clear"));
+    await user.click(screen.getByTestId("add-mcp-server-button"));
+
+    expect(mockPatchMCPServer).toHaveBeenCalledWith({
+      name: "my-server",
+      command: "uvx",
+      args: ["mcp-server"],
+      headers: {},
+    });
   });
 
   it("patches the original server name when editing, instead of creating a duplicate", async () => {

--- a/src/frontend/src/modals/addMcpServerModal/index.tsx
+++ b/src/frontend/src/modals/addMcpServerModal/index.tsx
@@ -128,6 +128,7 @@ export default function AddMcpServerModal({
     setStdioCommand("");
     setStdioArgs([""]);
     setStdioEnv([{ key: "", value: "", id: nanoid(), error: false }]);
+    setStdioHeaders([{ key: "", value: "", id: nanoid(), error: false }]);
     setHttpName("");
     setHttpUrl("");
     setHttpEnv([{ key: "", value: "", id: nanoid(), error: false }]);
@@ -142,6 +143,9 @@ export default function AddMcpServerModal({
   );
   const [stdioEnv, setStdioEnv] = useState<KeyPairRow[]>(
     objectToKeyPairRow(initialData?.env) || [],
+  );
+  const [stdioHeaders, setStdioHeaders] = useState<KeyPairRow[]>(
+    objectToKeyPairRow(initialData?.headers) || [],
   );
 
   // HTTP state
@@ -163,6 +167,7 @@ export default function AddMcpServerModal({
       setStdioCommand(initialData?.command || "");
       setStdioArgs(initialData?.args || [""]);
       setStdioEnv(objectToKeyPairRow(initialData?.env) || []);
+      setStdioHeaders(objectToKeyPairRow(initialData?.headers) || []);
       setHttpName(initialData?.name || "");
       setHttpUrl(initialData?.url || "");
       setHttpEnv(objectToKeyPairRow(initialData?.env) || []);
@@ -181,6 +186,10 @@ export default function AddMcpServerModal({
         setError(t("mcp.modal.errorDuplicateEnvKeys"));
         return;
       }
+      if (stdioHeaders.some((item) => item.error)) {
+        setError(t("mcp.modal.errorDuplicateHeaders"));
+        return;
+      }
       // The server name is the immutable identifier: it is the storage key and
       // the URL path PATCH targets. When editing, always reuse the original
       // name so the update hits the existing record. Re-deriving it from the
@@ -195,12 +204,17 @@ export default function AddMcpServerModal({
           ]).slice(0, MAX_MCP_SERVER_NAME_LENGTH);
       const argsPayload = buildArgsPayload(stdioArgs, initialData?.args);
       const envPayload = buildKeyPairPayload(stdioEnv, initialData?.env);
+      const headersPayload = buildKeyPairPayload(
+        stdioHeaders,
+        initialData?.headers,
+      );
       try {
         await modifyMCPServer({
           name,
           command: stdioCommand,
           ...(argsPayload !== undefined ? { args: argsPayload } : {}),
           ...(envPayload !== undefined ? { env: envPayload } : {}),
+          ...(headersPayload !== undefined ? { headers: headersPayload } : {}),
         });
         if (!initialData) {
           await queryClient.setQueryData(
@@ -219,6 +233,7 @@ export default function AddMcpServerModal({
         setStdioCommand("");
         setStdioArgs([""]);
         setStdioEnv([{ key: "", value: "", id: nanoid(), error: false }]);
+        setStdioHeaders([{ key: "", value: "", id: nanoid(), error: false }]);
         setError(null);
       } catch (err: unknown) {
         setError(
@@ -475,6 +490,20 @@ export default function AddMcpServerModal({
                       editNode={false}
                       id="stdio-args"
                       data-testid="stdio-args-input"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label className="!text-mmd">
+                      {t("mcp.modal.fieldHeaders")}
+                    </Label>
+                    <IOKeyPairInputWithVariables
+                      value={stdioHeaders}
+                      onChange={setStdioHeaders}
+                      duplicateKey={false}
+                      isList={true}
+                      isInputField={true}
+                      testId="stdio-headers"
+                      enableGlobalVariables={true}
                     />
                   </div>
                   <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

- preserve load-from-database variable references when the exact variable is supplied by the current public MCP request
- keep unmatched owner-only references and literal table values scrubbed
- add a global-variable-aware Headers editor to Stdio MCP server settings
- persist and clear Stdio headers without requiring generated project servers to be converted to Streamable HTTP

## Root cause

The public MCP execution sanitizer cleared secret-looking variable reference names before request-context resolution, preventing request-scoped global variables from reaching the target flow in release 1.11.5.

Langflow-generated project servers wrap the Streamable HTTP endpoint with Stdio `mcp-proxy`, but the settings modal exposed Headers only for direct HTTP servers even though the backend already resolves and injects headers for Stdio connections.

## Testing

- 28 public MCP request-variable tests passed
- 25 global-variable resolution and Stdio header-injection tests passed
- 6 focused MCP server modal tests passed
- Biome check passed for both changed frontend files
- pre-commit hooks passed, including Biome, secret detection, and staged no-any checks
- repository-wide TypeScript check remains blocked by 284 existing errors in 109 files; neither changed file is in the failure set
