### PR TITLE
fix(memory): support non-ASCII Memory Base names

### DIFF
--- a/src/backend/base/langflow/services/memory_base/kb_path_helpers.py
+++ b/src/backend/base/langflow/services/memory_base/kb_path_helpers.py
@@ -10,7 +10,9 @@ import hashlib
 import re
 from typing import TYPE_CHECKING
 
+import chromadb.errors
 from lfx.base.knowledge_bases.backends import create_backend, is_local_chroma
+from lfx.base.knowledge_bases.validation import MAX_LOCAL_COLLECTION_NAME_LENGTH
 from lfx.log.logger import logger
 from sqlmodel import select
 
@@ -24,12 +26,13 @@ if TYPE_CHECKING:
 
 
 class BackendProvisioningError(ValueError):
-    """Raised when a non-local vector-store backend fails its create-time check.
+    """Raised when a vector-store backend fails a non-retryable create-time check.
 
     A remote backend (OpenSearch / Chroma Cloud / Mongo / Astra / Postgres) with
     a bad URL or wrong credentials would otherwise be swallowed and produce a
     Memory Base that only errors later on every ingest and retrieval. Surfacing
-    it here lets the create path reject the misconfiguration up front.
+    it here lets the create path reject the misconfiguration up front. Local
+    Chroma validation failures are surfaced for the same reason.
     """
 
 
@@ -53,12 +56,16 @@ def hash_session_id(session_id: str) -> str:
     return hashlib.sha256(session_id.encode()).hexdigest()[:12]
 
 
+_KB_NAME_SUFFIX_LENGTH = 9  # underscore + 8 hex characters, added by MemoryBaseService
+_MAX_KB_NAME_PREFIX_LENGTH = MAX_LOCAL_COLLECTION_NAME_LENGTH - _KB_NAME_SUFFIX_LENGTH
+
+
 def sanitize_kb_name(name: str) -> str:
-    """Lowercase, replace spaces/hyphens with underscores, strip non-alphanum."""
+    """Return an ASCII-safe prefix for a generated Memory Base collection name."""
     sanitized = name.strip().lower()
     sanitized = re.sub(r"[\s\-]+", "_", sanitized)
-    sanitized = re.sub(r"[^\w]", "", sanitized)
-    return sanitized or "memory"
+    sanitized = re.sub(r"[^\w]", "", sanitized, flags=re.ASCII).lstrip("_")
+    return sanitized[:_MAX_KB_NAME_PREFIX_LENGTH] or "memory"
 
 
 async def resolve_kb_username(db: AsyncSession, user_id: uuid.UUID) -> str:
@@ -102,10 +109,10 @@ async def initialize_kb(
 
     Failure handling depends on the backend:
 
-    * **Local Chroma (default):** best-effort. The Chroma client creates its own
-      persistence directory and the collection is created lazily on first write,
-      so a provisioning hiccup here must not block Memory Base creation — it is
-      logged and swallowed.
+    * **Local Chroma (default):** transient provisioning failures remain
+      best-effort because the collection is created lazily on first write.
+      Deterministic Chroma validation failures are raised, since retrying can
+      never make the collection usable.
     * **Remote backends (OpenSearch / Chroma Cloud / Mongo / Astra / Postgres):**
       a bad URL or wrong credentials is a real misconfiguration that would make
       the Memory Base silently dead — every later ingest and retrieval would
@@ -146,7 +153,7 @@ async def initialize_kb(
         raise
     except Exception as exc:
         await logger.awarning("Initial %s setup for %s failed: %s", backend_type, kb_name, exc)
-        if not local:
+        if not local or isinstance(exc, chromadb.errors.InvalidArgumentError):
             msg = f"Could not initialize the '{backend_type}' vector store for this Memory Base: {exc}"
             raise BackendProvisioningError(msg) from exc
     finally:

--- a/src/backend/base/langflow/services/memory_base/service.py
+++ b/src/backend/base/langflow/services/memory_base/service.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
+from lfx.base.knowledge_bases.backends import is_local_chroma
 from lfx.base.knowledge_bases.backends.postgres import resolve_default_kb_backend
+from lfx.base.knowledge_bases.validation import validate_collection_name
 from lfx.base.models.provider_registry import is_api_key_optional
 from lfx.base.models.unified_models import get_api_key_for_provider
 from lfx.services.model_provider_policy import (
@@ -255,6 +257,11 @@ class MemoryBaseService(Service):
 
         # 3. Auto-generate kb_name: sanitized_name_<8hex>
         kb_name = f"{sanitize_kb_name(payload.name)}_{uuid.uuid4().hex[:8]}"
+        validate_collection_name(
+            kb_name,
+            resource="Memory Base",
+            local=is_local_chroma(backend_type, backend_config),
+        )
 
         # 4-5. Provision the backing KB (vector-store collection + ``knowledge_base``
         # row) then insert the memory_base row. These span independent sessions and

--- a/src/backend/tests/unit/test_memory_bases.py
+++ b/src/backend/tests/unit/test_memory_bases.py
@@ -3519,6 +3519,24 @@ class TestInitializeKbConnectivity:
 
         assert collection_names == [generated_name]
 
+    async def test_local_chroma_rejects_invalid_collection_name(self, tmp_path):
+        from langflow.services.memory_base.kb_path_helpers import BackendProvisioningError, initialize_kb
+
+        with (
+            patch(
+                "langflow.services.memory_base.kb_path_helpers.KBStorageHelper.get_root_path",
+                return_value=tmp_path,
+            ),
+            pytest.raises(BackendProvisioningError) as exc_info,
+        ):
+            await initialize_kb(
+                kb_name="catálogo_memória_deadbeef",
+                kb_username="testuser",
+                backend_type="chroma",
+            )
+
+        assert isinstance(exc_info.value.__cause__, chromadb.errors.InvalidArgumentError)
+
     @pytest.mark.asyncio
     async def test_unreachable_remote_backend_raises(self, tmp_path):
         from langflow.services.memory_base.kb_path_helpers import BackendProvisioningError, initialize_kb

--- a/src/backend/tests/unit/test_memory_bases.py
+++ b/src/backend/tests/unit/test_memory_bases.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import sqlite3
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import chromadb.errors
 import pytest
 from langflow.services.database.models.memory_base.model import (
     MemoryBase,
@@ -3469,6 +3471,54 @@ class TestMemoryBaseCreateAtomicity:
 class TestInitializeKbConnectivity:
     """initialize_kb surfaces remote-backend misconfig; local Chroma stays lazy."""
 
+    @pytest.mark.parametrize(
+        ("name", "expected_prefix"),
+        [
+            ("catálogo memória", "catlogo_memria"),
+            ("ação", "ao"),
+            ("José", "jos"),
+            ("日本語 base", "base"),
+            ("日本語", "memory"),
+            ("R&D docs", "rd_docs"),
+            ("___private", "private"),
+        ],
+    )
+    def test_memory_base_name_is_sanitized_to_chroma_safe_ascii(self, name, expected_prefix):
+        from langflow.services.memory_base.kb_path_helpers import sanitize_kb_name
+        from lfx.base.knowledge_bases.validation import validate_collection_name
+
+        prefix = sanitize_kb_name(name)
+
+        assert prefix == expected_prefix
+        validate_collection_name(f"{prefix}_deadbeef", local=True)
+
+    def test_memory_base_name_is_capped_for_local_chroma(self):
+        from langflow.services.memory_base.kb_path_helpers import sanitize_kb_name
+        from lfx.base.knowledge_bases.validation import MAX_LOCAL_COLLECTION_NAME_LENGTH, validate_collection_name
+
+        generated_name = f"{sanitize_kb_name('a' * 1000)}_deadbeef"
+
+        assert len(generated_name) == MAX_LOCAL_COLLECTION_NAME_LENGTH
+        validate_collection_name(generated_name, local=True)
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_memory_base_name_provisions_local_chroma(self, tmp_path):
+        from langflow.services.memory_base.kb_path_helpers import initialize_kb, sanitize_kb_name
+
+        generated_name = f"{sanitize_kb_name('catálogo memória')}_deadbeef"
+
+        with patch(
+            "langflow.services.memory_base.kb_path_helpers.KBStorageHelper.get_root_path",
+            return_value=tmp_path,
+        ):
+            await initialize_kb(kb_name=generated_name, kb_username="testuser", backend_type="chroma")
+
+        database_path = tmp_path / "testuser" / generated_name / "chroma.sqlite3"
+        with sqlite3.connect(database_path) as database:
+            collection_names = [row[0] for row in database.execute("SELECT name FROM collections")]
+
+        assert collection_names == [generated_name]
+
     @pytest.mark.asyncio
     async def test_unreachable_remote_backend_raises(self, tmp_path):
         from langflow.services.memory_base.kb_path_helpers import BackendProvisioningError, initialize_kb
@@ -3508,6 +3558,22 @@ class TestInitializeKbConnectivity:
         ):
             # Must NOT raise.
             await initialize_kb(kb_name="mb_kb", kb_username="testuser", backend_type="chroma", backend_config=None)
+        backend.teardown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_local_chroma_validation_failure_is_raised(self, tmp_path):
+        from langflow.services.memory_base.kb_path_helpers import BackendProvisioningError, initialize_kb
+
+        backend = AsyncMock()
+        backend.ensure_ready = AsyncMock(side_effect=chromadb.errors.InvalidArgumentError("invalid collection name"))
+        backend.teardown = AsyncMock()
+
+        with (
+            patch("langflow.services.memory_base.kb_path_helpers.KBStorageHelper.get_root_path", return_value=tmp_path),
+            patch("langflow.services.memory_base.kb_path_helpers.create_backend", MagicMock(return_value=backend)),
+            pytest.raises(BackendProvisioningError, match="invalid collection name"),
+        ):
+            await initialize_kb(kb_name="invalid", kb_username="testuser", backend_type="chroma")
         backend.teardown.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- generate ASCII-safe, length-bounded collection names for Memory Bases while preserving their display names
- surface deterministic local Chroma validation errors instead of creating unusable Memory Bases
- cover accented Latin, CJK, punctuation, length limits, and real local Chroma provisioning

## Testing

- `uv run pytest src/backend/tests/unit/test_memory_bases.py -q` (147 passed)
- `uv run ruff check src/backend/base/langflow/services/memory_base/kb_path_helpers.py src/backend/tests/unit/test_memory_bases.py`
- `uv run ruff format --check src/backend/base/langflow/services/memory_base/kb_path_helpers.py src/backend/tests/unit/test_memory_bases.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of memory base names containing non-ASCII characters.
  * Prevented generated collection names from exceeding supported length limits.
  * Local Chroma validation errors are now reported clearly instead of being silently ignored.
  * Preserved best-effort behavior for transient local provisioning failures.

* **Tests**
  * Added coverage for safe name generation, length limits, local provisioning, and validation error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->