### PR TITLE
fix(release): unblock the 1.11.6 bundle publish (bump release-1.11.x to 1.11.6 + un-pin the smoke test's lfx)

### DIFF
--- a/.github/workflows/release_bundles.yml
+++ b/.github/workflows/release_bundles.yml
@@ -65,12 +65,21 @@ jobs:
           done
           echo "bundles-found=1" >> $GITHUB_OUTPUT
           ls -la bundles-dist/
-      # Bundles floor lfx at >=0.5.0 (no upper bound). The smoke test below
-      # installs the bundles in a fresh venv, so it needs an lfx wheel that
-      # satisfies the floor available locally — PyPI may not yet have a
-      # matching lfx published when bundles are released ahead of a main
-      # release. We build the lfx wheel from the current ref so the smoke
-      # test resolves against it; this artifact is not published.
+      # Bundles floor lfx at the release line they were cut from (e.g.
+      # ">=1.11.6,<1.12"). The smoke test below installs the bundles into a
+      # fresh venv, so it needs an lfx satisfying that floor to be resolvable
+      # — PyPI may not yet have a matching lfx published when bundles are
+      # released ahead of a main release. We build an lfx wheel from the
+      # current ref and hand it to the smoke test via --find-links so it can
+      # serve as a *fallback* source; this artifact is not published.
+      #
+      # Do not pass this wheel as an explicit path argument: a wheel path is a
+      # direct-file requirement, which pins lfx to exactly that file's version
+      # and removes the registry as a source for it. If the ref's lfx version
+      # lags the bundles' floor (the source tree says 1.11.5 while the bundles
+      # require >=1.11.6), the resolve fails even when a satisfying lfx is
+      # published. --find-links keeps the local wheel as a candidate without
+      # excluding PyPI.
       - name: Build langflow-sdk wheel for smoke test
         if: steps.build.outputs.bundles-found == '1'
         run: |
@@ -173,7 +182,7 @@ jobs:
             exit 1
           fi
           printf 'Installing: %s\n' "${SDK_WHEELS[@]}" "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
-          uv pip install --prerelease=if-necessary-or-explicit --python ./test-env/bin/python "${SDK_WHEELS[@]}" "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=if-necessary-or-explicit --python ./test-env/bin/python --find-links ./lfx-dist "${SDK_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
         shell: bash
       - name: Install lfx + bundle wheels (Windows)
         if: matrix.os == 'windows'
@@ -195,7 +204,7 @@ jobs:
             exit 1
           fi
           printf 'Installing: %s\n' "${SDK_WHEELS[@]}" "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
-          uv pip install --prerelease=if-necessary-or-explicit --python ./test-env/Scripts/python.exe "${SDK_WHEELS[@]}" "${LFX_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
+          uv pip install --prerelease=if-necessary-or-explicit --python ./test-env/Scripts/python.exe --find-links ./lfx-dist "${SDK_WHEELS[@]}" "${BUNDLE_WHEELS[@]}"
         shell: bash
 
   publish-bundles:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow"
-version = "1.11.5"
+version = "1.11.6"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 # Define your main dependencies here
 dependencies = [
-    "langflow-base[complete]>=0.11.5",
+    "langflow-base[complete]>=0.11.6",
     # langflow-extensions:bundle-deps-start
     # Release coordination: langflow declares BOUNDED ranges (>=A,<B) for every
     # curated lfx-* package, never exact pins -- exact pins in reusable library

--- a/src/backend/base/pyproject.toml
+++ b/src/backend/base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langflow-base"
-version = "0.11.5"
+version = "0.11.6"
 description = "A Python package with a built-in web application"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
@@ -17,7 +17,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "lfx~=1.11.5",
+    "lfx~=1.11.6",
     "fastapi>=0.139.0,<1.0.0",
     "slowapi>=0.1.9,<1.0.0",
     "httpx[http2]>=0.27,<1.0.0",
@@ -200,7 +200,7 @@ local = [
 
 # Individual database providers
 couchbase = ["couchbase>=4.2.1"]
-cassandra = ["lfx[cassandra]~=1.11.4"]  # cassio relocated to lfx (lfx-core Cassandra components)
+cassandra = ["lfx[cassandra]~=1.11.6"]  # cassio relocated to lfx (lfx-core Cassandra components)
 clickhouse = ["clickhouse-connect==0.7.19"]
 
 
@@ -279,7 +279,7 @@ opendsstar = [
 ]
 
 # Individual tools
-beautifulsoup = ["lfx~=1.11.5"]  # beautifulsoup4 is now a hard lfx dependency
+beautifulsoup = ["lfx~=1.11.6"]  # beautifulsoup4 is now a hard lfx dependency
 serpapi = ["google-search-results>=2.4.1,<3.0.0"]
 google-api = ["google-api-python-client~=2.161"]
 wikipedia = ["wikipedia==1.4.0"]
@@ -357,7 +357,7 @@ spider = ["spider-client>=0.0.27,<1.0.0"]
 altk = ["agent-lifecycle-toolkit>=0.10.1,<1.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
 
 # Toolguard Integration
-toolguard = ["lfx[toolguard]~=1.11.4"]  # toolguard relocated to lfx
+toolguard = ["lfx[toolguard]~=1.11.6"]  # toolguard relocated to lfx
 
 # Additional LangChain integrations
 # Excluded on macOS x86_64: transitive torch dependency (via sentence-transformers) has no Intel Mac wheels

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langflow",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langflow",
-      "version": "1.11.5",
+      "version": "1.11.6",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
         "@chakra-ui/number-input": "^2.1.2",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langflow",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "private": true,
   "engines": {
     "node": ">=20.19.0"

--- a/src/lfx/pyproject.toml
+++ b/src/lfx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx"
-version = "1.11.5"
+version = "1.11.6"
 description = "Langflow Executor - A lightweight CLI tool for executing and serving Langflow AI flows"
 readme = "README.md"
 authors = [

--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -32612,6 +32612,6 @@
     "num_components": 131,
     "num_modules": 17
   },
-  "sha256": "8ba59d38e65e98cac3c9044dbf935ddb40690eac9502d1795456f6d98c6d9af0",
-  "version": "1.11.5"
+  "sha256": "f1f4a444bbeed1833c88040c6714e01b54008ce341d48d79b223475254d45439",
+  "version": "1.11.6"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -7674,7 +7674,7 @@ wheels = [
 
 [[package]]
 name = "langflow"
-version = "1.11.5"
+version = "1.11.6"
 source = { editable = "." }
 dependencies = [
     { name = "langflow-base", extra = ["complete"] },
@@ -7858,7 +7858,7 @@ dev = [
 
 [[package]]
 name = "langflow-base"
-version = "0.11.5"
+version = "0.11.6"
 source = { editable = "src/backend/base" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -8918,7 +8918,7 @@ wheels = [
 
 [[package]]
 name = "lfx"
-version = "1.11.5"
+version = "1.11.6"
 source = { editable = "src/lfx" }
 dependencies = [
     { name = "a2wsgi", marker = "sys_platform != 'win32'" },


### PR DESCRIPTION
Unblocks [Release Bundles run 33465556270](https://github.com/langflow-ai/langflow/actions/runs/33465556270), whose four `Install Smoke Test` jobs all failed, so the `Publish Bundles to PyPI` job was skipped.

## Why `pip install langflow==1.11.6` is broken today

Reproduced against live PyPI:

```
$ uv pip install --dry-run "langflow==1.11.6"
  × No solution found when resolving dependencies:
  ╰─▶ Because only langflow-base[complete]<=0.11.6 is available and
      langflow-base==0.11.6 depends on lfx>=1.11.6,<1.12.dev0, we can conclude
      that langflow-base[complete]>=0.11.6 depends on lfx>=1.11.6,<1.12.dev0.
      And because lfx-amazon>=0.1.2 depends on lfx>=1.12.0.dev0,<2.0.0, we
      can conclude that lfx-amazon>=0.1.2 and langflow-base[complete]>=0.11.6
      are incompatible.
```

Every `lfx-*` version currently on PyPI was published from the 1.12 dev line and requires `lfx>=1.12.0.dev0`, which cannot coexist with `langflow-base==0.11.6`'s `lfx~=1.11.6`. `aae8b15a6` cut new bundle versions with a tightened `lfx>=1.11.6,<1.12` pin to fix exactly this — they just have not been publishable.

## Why the publish is blocked

`release-1.11.6` and `release-1.11.x` diverged by exactly one commit each:

| branch | carries | lfx version in tree | bundle floor |
| --- | --- | --- | --- |
| `release-1.11.6` | `d2eb519fd` version bump | 1.11.6 | `>=1.11.0,<2.0.0` (old) |
| `release-1.11.x` | `aae8b15a6` bundle pins | **1.11.5** | `>=1.11.6,<1.12` (new) |

The version bump never reached the maintenance branch, so **neither branch can produce a green `Release Bundles` run**. `Release Bundles` builds an lfx wheel from the ref it is dispatched on; on `release-1.11.x` that wheel is `lfx-1.11.5-py3-none-any.whl`, which cannot satisfy the bundles' own `>=1.11.6` floor:

```
Because only the following versions of lfx are available:
    lfx<1.11.6
    lfx>=1.12
and lfx-amazon==0.1.5 depends on lfx>=1.11.6,<1.12, we can conclude that
lfx-amazon==0.1.5 cannot be used.
```

That message reads like PyPI is missing lfx 1.11.6. It is not — 1.11.6 was uploaded at `2026-09-01T02:20Z`, an hour before the run, `requires-python >=3.10,<3.15`, not yanked. The smoke test passes the locally built wheel as an **explicit path**, which makes it a direct-file requirement: uv pins lfx to exactly that file's version and drops the registry as a source. PubGrub then renders the *forbidden* range rather than the available one.

## Changes

**1. `chore:` bump `release-1.11.x` to 1.11.6** — cherry-picks `d2eb519fd` so the maintenance branch carries the version it shipped: langflow 1.11.6, langflow-base 0.11.6, lfx 1.11.6 across the pyprojects, frontend `package.json`, both lock files, and the `component_index.json` restamp. Additionally raises the extras-qualified `lfx[cassandra]` / `lfx[toolguard]` pins from 1.11.4 to 1.11.6 — the Makefile's `"lfx(?:~=|>=)[^"]*"` regex cannot match across the bracket, so the 1.11.5 and 1.11.6 bumps both missed them (same manual fixup as `58f29f293`). No-op for resolution; the unqualified `lfx~=1.11.6` already intersects them.

**2. `fix(ci):` pass the smoke test's lfx wheel via `--find-links ./lfx-dist`** instead of as an explicit path. This preserves the original intent — a local fallback for when PyPI has no matching lfx yet — without excluding the registry, so the job cannot deadlock this way again on a future line. The `LFX_WHEELS` guard is kept so a missing lfx build still fails loudly, and the stale `Bundles floor lfx at >=0.5.0 (no upper bound)` comment is corrected.

Either change alone unblocks the run; both are correct independently.

## Test plan

All 19 bundle wheels + lfx + sdk built from this branch exactly as CI does, then:

- [x] **New workflow form** (`--find-links`): `Resolved 222 packages`, `+ lfx==1.11.6`
- [x] **Old workflow form** (explicit path): now passes too — `+ lfx @ .../lfx-1.11.6-py3-none-any.whl`. Confirms the version bump alone is sufficient.
- [x] **Pre-fix control**: reproduced the exact CI failure byte-for-byte on a machine whose index *does* have lfx 1.11.6, and confirmed dropping the explicit path resolves to `lfx==1.11.6`.
- [x] **The actual goal** — `langflow==1.11.6` against live PyPI with the new bundles available:
  ```
  Resolved 561 packages
   + langflow==1.11.6      + langflow-base==0.11.6   + lfx==1.11.6
   + lfx-amazon==0.1.5     + lfx-anthropic==0.1.6    + lfx-bundles==1.1.19
   + lfx-datastax==0.1.7   + lfx-ibm==0.2.2          + lfx-openai==0.1.3   (…19 total)
  ```
- [x] `uv lock --check` clean
- [x] All 19 target bundle versions confirmed absent from PyPI, so the publish job's preflight will not skip them

## After merge

Dispatch `Release Bundles` on `release-1.11.x`. The `fix(ci):` commit should also be forward-ported to `main` and `release-1.12.0`, which carry the same explicit-path smoke test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and packages to version 1.11.6.
  * Updated component metadata to reference the 1.11.6 asset bundle.
  * Aligned package compatibility requirements with the 1.11.6 release line.

* **Chores**
  * Improved release smoke-test installation to use the locally built package as a fallback source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->