### PR TITLE
fix: report root error type on flow execution spans

### DIFF
--- a/src/backend/tests/unit/services/telemetry/test_flow_execution_span.py
+++ b/src/backend/tests/unit/services/telemetry/test_flow_execution_span.py
@@ -359,6 +359,7 @@ def test_failing_flow_marks_the_span_as_an_error_without_leaking_the_message():
     assert len(result["spans"]) == 1
     span = result["spans"][0]
     assert span["status"] == "ERROR"
+    assert span["description"] == "KeyError"
     assert span["attrs"]["status"] == "error"
     assert span["attrs"]["error.type"] == "KeyError"
     # The wrapped message embeds component output, which must not reach the operator's APM.

--- a/src/backend/tests/unit/services/telemetry/test_flow_execution_span.py
+++ b/src/backend/tests/unit/services/telemetry/test_flow_execution_span.py
@@ -93,7 +93,7 @@ class Boom(Component):
     outputs = [Output(name="message", display_name="Message", method="explode")]
 
     def explode(self) -> Message:
-        raise RuntimeError({SENTINEL!r})
+        raise KeyError({SENTINEL!r})
 
 async def main():
     chat_input = ChatInput(_id="chat-input")
@@ -352,13 +352,15 @@ def test_arun_emits_one_application_span():
 
 def test_failing_flow_marks_the_span_as_an_error_without_leaking_the_message():
     result = run_probe(FAILING_PROBE)
+    # Graph execution wraps the component failure for the API, but telemetry must classify the
+    # actionable root cause rather than the wrapper shared by unrelated failures.
     assert result["error"] == "ValueError"
 
     assert len(result["spans"]) == 1
     span = result["spans"][0]
     assert span["status"] == "ERROR"
     assert span["attrs"]["status"] == "error"
-    assert span["attrs"]["error.type"] == "ValueError"
+    assert span["attrs"]["error.type"] == "KeyError"
     # The wrapped message embeds component output, which must not reach the operator's APM.
     assert SENTINEL not in json.dumps(span)
 

--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -12372,7 +12372,9 @@
           "tool_mode": false
         },
         "CharacterTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -12416,8 +12418,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13580,7 +13585,9 @@
           "tool_mode": false
         },
         "LanguageRecursiveTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -13624,8 +13631,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13778,7 +13788,9 @@
           "tool_mode": false
         },
         "NaturalLanguageTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -13823,8 +13835,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13975,7 +13990,10 @@
           "tool_mode": false
         },
         "OpenAIToolsAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -14031,8 +14049,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -14042,8 +14063,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -14746,7 +14770,9 @@
           "tool_mode": false
         },
         "RecursiveCharacterTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -14790,8 +14816,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -16478,7 +16507,10 @@
           "tool_mode": false
         },
         "ToolCallingAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -16533,8 +16565,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -16544,8 +16579,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -17242,7 +17280,10 @@
           "tool_mode": false
         },
         "XMLAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": true,
           "conditional_paths": [],
           "custom_fields": {},
@@ -17298,8 +17339,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -17309,8 +17353,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -30987,6 +31034,6 @@
     "num_components": 127,
     "num_modules": 16
   },
-  "sha256": "7572f889a9012abfc0ecc2de7c45f5fcf7d5b85c24f7ec847afe5aa5f097754e",
+  "sha256": "b38dc88e6d01da028b3e0f4d2918c218e180e4c5b3d87d91cf00e18150bf8ee3",
   "version": "1.12.0"
 }

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -41,6 +41,7 @@ from lfx.graph.vertex.vertex_types import ComponentVertex, InterfaceVertex, Stat
 from lfx.log.logger import LogConfig, configure, logger
 from lfx.observability import (
     APPLICATION_TRACER_NAME,
+    _root_error_type,
     get_execution_client,
     get_execution_protocol,
     get_queued_trace_link,
@@ -1052,8 +1053,9 @@ class Graph:
             raise
         except Exception as exc:
             status = "error"
-            span.set_status(otel_trace.Status(otel_trace.StatusCode.ERROR, type(exc).__name__))
-            span.set_attribute("error.type", type(exc).__name__)
+            error_type = _root_error_type(exc)
+            span.set_status(otel_trace.Status(otel_trace.StatusCode.ERROR, error_type))
+            span.set_attribute("error.type", error_type)
             raise
         finally:
             if self.flow_id:

--- a/src/lfx/tests/unit/graph/test_async_start_flow_span.py
+++ b/src/lfx/tests/unit/graph/test_async_start_flow_span.py
@@ -250,13 +250,13 @@ def test_the_sync_start_runs_under_the_caller_span():
 
 
 @pytest.mark.parametrize(
-    ("mode", "expected_error"),
+    ("mode", "expected_raised", "expected_error_type"),
     [
-        ("sync_start_value_error", "ValueError"),
-        ("sync_start_other_error", "ComponentBuildError"),
+        ("sync_start_value_error", "ValueError", "ValueError"),
+        ("sync_start_other_error", "ComponentBuildError", "TypeError"),
     ],
 )
-def test_a_failing_sync_run_reaches_the_caller_and_the_span(mode: str, expected_error: str):
+def test_a_failing_sync_run_reaches_the_caller_and_the_span(mode: str, expected_raised: str, expected_error_type: str):
     """A failure has to leave the span scope, then be caught at the worker boundary.
 
     Caught inside the scope, the context manager exits cleanly and the run's telemetry is wrong.
@@ -271,9 +271,9 @@ def test_a_failing_sync_run_reaches_the_caller_and_the_span(mode: str, expected_
     """
     result = run_probe(mode)
 
-    assert result["raised"] == expected_error, result
+    assert result["raised"] == expected_raised, result
 
     flow_spans = [s for s in result["spans"] if s["name"] == "flow.execute"]
     assert len(flow_spans) == 1, result["spans"]
     assert flow_spans[0]["status"] == "error", flow_spans[0]
-    assert flow_spans[0]["error_type"] == expected_error, flow_spans[0]
+    assert flow_spans[0]["error_type"] == expected_error_type, flow_spans[0]

--- a/src/lfx/tests/unit/graph/test_flow_span_events_boundary.py
+++ b/src/lfx/tests/unit/graph/test_flow_span_events_boundary.py
@@ -173,10 +173,10 @@ def test_a_failing_component_puts_its_message_in_no_event():
     assert len(flow_spans) == 1, spans
     assert flow_spans[0]["attributes"].get("status") == "error", flow_spans[0]["attributes"]
     # The type is the whole point: it is what an operator gets instead of the message. arun wraps
-    # the component failure as ValueError("Error running graph: Error building Component
-    # Passthrough: <the component's message>"), so the message carries component output and only
-    # the type may cross.
-    assert flow_spans[0]["attributes"].get("error.type") == "ValueError"
+    # the RuntimeError as ValueError("Error running graph: Error building Component Passthrough:
+    # <the component's message>"), so telemetry must follow the exception cause without exporting
+    # either message.
+    assert flow_spans[0]["attributes"].get("error.type") == "RuntimeError"
 
     assert flow_spans[0]["events"] == [], flow_spans[0]["events"]
     assert EXC_MESSAGE not in json.dumps(spans)


### PR DESCRIPTION
## Summary
- classify `flow.execute` failures by the leak-safe root exception type instead of a shared graph wrapper
- preserve `record_exception=False` so exception messages are still withheld
- cover a `KeyError` wrapped as `ValueError` and existing sync/component wrapper paths

## Verification
- `test_flow_execution_span.py`: 13 passed
- isolated lfx observability and graph span tests: 41 passed
- post-format graph span tests: 10 passed
- pre-commit hooks: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved telemetry accuracy for failed flow executions by recording the underlying root error type.
  - Preserved the appropriate exception presented to callers while reporting the originating cause in flow span telemetry.
  - Prevented sensitive error messages from being exposed through telemetry descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->