### PR TITLE
fix: propagate v2 stream run ID to telemetry

### DIFF
--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -378,15 +378,17 @@ def build_stream_response(
     before the response is constructed so a bad request fails before streaming.
     """
     parsed = _apply_execution_gates(parsed, flow, current_user)
+    run_id = str(uuid4())
     adapter = get_stream_adapter(
         stream_protocol,
         StreamAdapterContext(
-            run_id=str(uuid4()),
+            run_id=run_id,
             thread_id=parsed.session_id or str(flow.id),
         ),
     )
     return _execute_streaming_workflow(
         adapter=adapter,
+        run_id=run_id,
         parsed=parsed,
         flow=flow,
         current_user=current_user,

--- a/src/backend/base/langflow/api/v2/workflow_execution.py
+++ b/src/backend/base/langflow/api/v2/workflow_execution.py
@@ -295,10 +295,10 @@ async def _stream_event_frames(
                         files=parsed.files,
                         stop_component_id=parsed.stop_component_id,
                         start_component_id=parsed.start_component_id,
-                        # Persist vertex builds (keyed by ``run_id``) only for job-tracked
-                        # runs so a background job's status can be reconstructed later. Live
-                        # streams pass no ``run_id`` and keep the no-persist behavior.
-                        log_builds=run_id is not None,
+                        # Persist vertex builds only for durable/background jobs. Live streams
+                        # carry a ``run_id`` for job/trace/telemetry correlation, but keep the
+                        # existing no-build-persistence behavior because they pass no ``job_id``.
+                        log_builds=job_id is not None,
                         current_user=current_user,
                         flow_name=flow_name,
                         source_flow_id=source_flow_id,
@@ -474,6 +474,7 @@ async def _stream_event_frames(
 def _execute_streaming_workflow(
     *,
     adapter: StreamAdapter,
+    run_id: str,
     parsed: ParsedWorkflowRun,
     flow: FlowRead,
     current_user: UserRead,
@@ -497,6 +498,7 @@ def _execute_streaming_workflow(
             current_user=current_user,
             provider_policy_flow=flow,
             source_flow_owner_id=flow.user_id,
+            run_id=run_id,
             # The live v2 stream. Which client sent it is a separate attribute, read from the
             # X-Langflow-Client header, because the playground calls this same public endpoint.
             protocol="v2",

--- a/src/backend/base/langflow/api/v2/workflow_public.py
+++ b/src/backend/base/langflow/api/v2/workflow_public.py
@@ -226,11 +226,11 @@ async def execute_public_workflow(
             UnknownStreamProtocolError(request.stream_protocol, available_protocols())
         )
 
-    job_id = uuid4()
+    run_id = str(uuid4())
     adapter = get_stream_adapter(
         request.stream_protocol,
         StreamAdapterContext(
-            run_id=str(job_id),
+            run_id=run_id,
             thread_id=scoped_session or str(virtual_flow_id),
         ),
     )
@@ -263,6 +263,7 @@ async def execute_public_workflow(
             provider_policy_flow=flow,
             source_flow_id=real_flow_id,
             source_flow_owner_id=source_flow_owner_id,
+            run_id=run_id,
             # Anonymous shared-link traffic, kept apart from signed-in v2 runs the same way
             # playground.public is kept apart from playground.
             protocol="v2.public",

--- a/src/backend/tests/unit/api/v2/test_workflow_public.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_public.py
@@ -307,6 +307,7 @@ async def test_public_endpoint_namespaces_caller_session(client: AsyncClient, pu
     assert sent_inputs is not None
     assert sent_inputs.session == f"{expected_namespace}:{victim_session}"
     assert sent_inputs.session != victim_session
+    assert captured["run_id"] is not None
 
 
 @pytest.mark.benchmark

--- a/src/backend/tests/unit/api/v2/test_workflow_run_telemetry.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_run_telemetry.py
@@ -71,6 +71,44 @@ async def _execute_sync(wf_exec):
     )
 
 
+async def test_live_stream_uses_one_run_id_for_adapter_graph_and_telemetry(monkeypatch):
+    """A live stream's SSE run id must also identify its job row and RunPayload."""
+    from langflow.api.v2 import workflow as workflow_api
+    from langflow.api.v2 import workflow_execution as wf_exec
+    from langflow.services import deps
+
+    captured: dict[str, str | None] = {}
+    telemetry = SimpleNamespace(log_package_run=AsyncMock())
+    original_get_stream_adapter = workflow_api.get_stream_adapter
+
+    def capture_adapter(name, context):
+        captured["adapter_run_id"] = context.run_id
+        return original_get_stream_adapter(name, context)
+
+    async def fake_generate_flow_events(**kwargs):
+        captured["graph_run_id"] = kwargs["run_id"]
+        await kwargs["event_manager"].queue.put((None, None, time.time()))
+
+    monkeypatch.setattr(workflow_api, "_apply_execution_gates", lambda parsed, *_args: parsed)
+    monkeypatch.setattr(workflow_api, "get_stream_adapter", capture_adapter)
+    monkeypatch.setattr(wf_exec, "generate_flow_events", fake_generate_flow_events)
+    monkeypatch.setattr(deps, "get_telemetry_service", lambda: telemetry)
+
+    flow_id = uuid4()
+    response = workflow_api.build_stream_response(
+        ParsedWorkflowRun(flow_id=str(flow_id), input_value="", mode="stream"),
+        SimpleNamespace(id=flow_id, name="flow", user_id=uuid4()),
+        SimpleNamespace(id=uuid4()),
+        stream_protocol="langflow",
+        background_tasks=BackgroundTasks(),
+    )
+    async for _frame in response.body_iterator:
+        pass
+
+    payload = telemetry.log_package_run.await_args.args[0]
+    assert captured["adapter_run_id"] == captured["graph_run_id"] == payload.run_id
+
+
 async def test_stream_pause_does_not_emit_terminal_run_telemetry(monkeypatch):
     from langflow.api.v2 import workflow_execution as wf_exec
     from langflow.services import deps

--- a/src/backend/tests/unit/api/v2/test_workflow_run_telemetry.py
+++ b/src/backend/tests/unit/api/v2/test_workflow_run_telemetry.py
@@ -77,7 +77,7 @@ async def test_live_stream_uses_one_run_id_for_adapter_graph_and_telemetry(monke
     from langflow.api.v2 import workflow_execution as wf_exec
     from langflow.services import deps
 
-    captured: dict[str, str | None] = {}
+    captured: dict[str, object] = {}
     telemetry = SimpleNamespace(log_package_run=AsyncMock())
     original_get_stream_adapter = workflow_api.get_stream_adapter
 
@@ -87,6 +87,7 @@ async def test_live_stream_uses_one_run_id_for_adapter_graph_and_telemetry(monke
 
     async def fake_generate_flow_events(**kwargs):
         captured["graph_run_id"] = kwargs["run_id"]
+        captured["log_builds"] = kwargs["log_builds"]
         await kwargs["event_manager"].queue.put((None, None, time.time()))
 
     monkeypatch.setattr(workflow_api, "_apply_execution_gates", lambda parsed, *_args: parsed)
@@ -107,6 +108,7 @@ async def test_live_stream_uses_one_run_id_for_adapter_graph_and_telemetry(monke
 
     payload = telemetry.log_package_run.await_args.args[0]
     assert captured["adapter_run_id"] == captured["graph_run_id"] == payload.run_id
+    assert captured["log_builds"] is False
 
 
 async def test_stream_pause_does_not_emit_terminal_run_telemetry(monkeypatch):

--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -12372,7 +12372,9 @@
           "tool_mode": false
         },
         "CharacterTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -12416,8 +12418,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13580,7 +13585,9 @@
           "tool_mode": false
         },
         "LanguageRecursiveTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -13624,8 +13631,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13778,7 +13788,9 @@
           "tool_mode": false
         },
         "NaturalLanguageTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -13823,8 +13835,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13975,7 +13990,10 @@
           "tool_mode": false
         },
         "OpenAIToolsAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -14031,8 +14049,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -14042,8 +14063,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -14746,7 +14770,9 @@
           "tool_mode": false
         },
         "RecursiveCharacterTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -14790,8 +14816,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -16478,7 +16507,10 @@
           "tool_mode": false
         },
         "ToolCallingAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -16533,8 +16565,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -16544,8 +16579,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -17242,7 +17280,10 @@
           "tool_mode": false
         },
         "XMLAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": true,
           "conditional_paths": [],
           "custom_fields": {},
@@ -17298,8 +17339,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -17309,8 +17353,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -30987,6 +31034,6 @@
     "num_components": 127,
     "num_modules": 16
   },
-  "sha256": "7572f889a9012abfc0ecc2de7c45f5fcf7d5b85c24f7ec847afe5aa5f097754e",
+  "sha256": "b38dc88e6d01da028b3e0f4d2918c218e180e4c5b3d87d91cf00e18150bf8ee3",
   "version": "1.12.0"
 }


### PR DESCRIPTION
## Summary

- use one server-generated run ID for the live-stream adapter, graph/job row, and RunPayload
- cover authenticated and public v2 streaming paths
- keep vertex-build persistence limited to durable/background jobs

## Tests

- 136 passed: v2 run telemetry, public workflow, admin-only build, and AG-UI workflow suites
- Ruff checks and formatting checks passed for all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow stream tracking by consistently using one run identifier across streaming, graph events, and telemetry.
  - Ensured durable background jobs persist build information even when no run identifier is initially provided.
  - Public workflow streams now expose a reliable run identifier for correlation.

- **Tests**
  - Added regression coverage for consistent run tracking across live streams and telemetry.
  - Strengthened validation that public workflow executions receive a run identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->