### PR TITLE
fix(workflows): reject unsupported inline run cancellation

### DIFF
--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -111,6 +111,23 @@ from langflow.services.warm_registry.resolver import resolve_warm_flow_for_execu
 # with its own idempotent early return).
 _TERMINAL_JOB_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.TIMED_OUT})
 
+
+def _workflow_job_mode(job: Job) -> str | None:
+    """Return the persisted execution mode for a workflow job, if recognized.
+
+    Durable background submissions store their sanitized request under
+    ``job_metadata["request"]``. Sync and live-stream rows do not have that
+    durable execution handle, so missing or malformed metadata intentionally
+    resolves to ``None`` and is treated as non-cancellable.
+    """
+    metadata = job.job_metadata if isinstance(job.job_metadata, dict) else {}
+    request = metadata.get("request")
+    if not isinstance(request, dict):
+        return None
+    mode = request.get("mode")
+    return mode if mode in {"background", "stream", "sync"} else None
+
+
 # The langflow durable background routes (GET status, POST /stop, GET /pending,
 # POST /{job_id}/resume, GET /{job_id}/events). The POST run path is contributed
 # by the shared lfx router (``lfx.workflow.router.create_workflow_router``)
@@ -955,16 +972,18 @@ async def get_workflow_status(
 @router.post(
     "/stop",
     summary="Stop Workflow",
-    description="Stop a running workflow execution",
+    description="Stop a running background workflow execution",
 )
 async def stop_workflow(
     request: WorkflowStopRequest,
     http_request: Request,
     current_user: Annotated[UserRead, Depends(get_current_user_for_workflow)],
 ) -> WorkflowStopResponse:
-    """Stop a running workflow execution by job_id.
+    """Stop a running background workflow execution by job_id.
 
-    This endpoint allows clients to gracefully or forcefully stop a running workflow.
+    Sync and live-stream runs execute inside their caller's request and cannot be
+    interrupted by the durable background executor. Those modes are rejected
+    instead of reporting a cancellation that did not happen.
 
     Args:
         request: Stop request containing job_id and optional force flag
@@ -978,6 +997,7 @@ async def stop_workflow(
         HTTPException:
             - 403: Developer API disabled or unauthorized
             - 404: Job ID not found
+            - 409: Job is not a cancellable background run
             - 500: Internal server error
     """
     job_id = request.job_id
@@ -1034,13 +1054,28 @@ async def stop_workflow(
             },
         )
 
-    if job.status == JobStatus.CANCELLED:
+    job_mode = _workflow_job_mode(job)
+    if job.status == JobStatus.CANCELLED and job_mode not in {"sync", "stream"}:
         return WorkflowStopResponse(job_id=str(job_id), message=f"Job {job_id} is already cancelled.")
     # A late stop on a job that already finished must not rewrite its terminal
     # status: flipping a COMPLETED/FAILED/TIMED_OUT row to CANCELLED would strand
     # the result/error blob the run already wrote. Report the existing state.
     if job.status in _TERMINAL_JOB_STATUSES:
         return WorkflowStopResponse(job_id=str(job_id), message=f"Job {job_id} already finished ({job.status.value}).")
+
+    if job_mode != "background":
+        display_mode = job_mode or "unknown"
+        await logger.ainfo("Rejected stop for workflow job %s in non-cancellable mode %s", job_id, display_mode)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "Job cannot be stopped",
+                "code": "JOB_NOT_CANCELLABLE",
+                "message": "Only background workflow jobs can be stopped.",
+                "job_id": str(job_id),
+                "mode": display_mode,
+            },
+        )
 
     try:
         revoked = await task_service.revoke_task(job_id)

--- a/src/backend/base/langflow/api/v2/workflow.py
+++ b/src/backend/base/langflow/api/v2/workflow.py
@@ -1055,14 +1055,6 @@ async def stop_workflow(
         )
 
     job_mode = _workflow_job_mode(job)
-    if job.status == JobStatus.CANCELLED and job_mode not in {"sync", "stream"}:
-        return WorkflowStopResponse(job_id=str(job_id), message=f"Job {job_id} is already cancelled.")
-    # A late stop on a job that already finished must not rewrite its terminal
-    # status: flipping a COMPLETED/FAILED/TIMED_OUT row to CANCELLED would strand
-    # the result/error blob the run already wrote. Report the existing state.
-    if job.status in _TERMINAL_JOB_STATUSES:
-        return WorkflowStopResponse(job_id=str(job_id), message=f"Job {job_id} already finished ({job.status.value}).")
-
     if job_mode != "background":
         display_mode = job_mode or "unknown"
         await logger.ainfo("Rejected stop for workflow job %s in non-cancellable mode %s", job_id, display_mode)
@@ -1076,6 +1068,14 @@ async def stop_workflow(
                 "mode": display_mode,
             },
         )
+
+    if job.status == JobStatus.CANCELLED:
+        return WorkflowStopResponse(job_id=str(job_id), message=f"Job {job_id} is already cancelled.")
+    # A late stop on a job that already finished must not rewrite its terminal
+    # status: flipping a COMPLETED/FAILED/TIMED_OUT row to CANCELLED would strand
+    # the result/error blob the run already wrote. Report the existing state.
+    if job.status in _TERMINAL_JOB_STATUSES:
+        return WorkflowStopResponse(job_id=str(job_id), message=f"Job {job_id} already finished ({job.status.value}).")
 
     try:
         revoked = await task_service.revoke_task(job_id)

--- a/src/backend/tests/unit/api/v2/test_workflow.py
+++ b/src/backend/tests/unit/api/v2/test_workflow.py
@@ -357,6 +357,7 @@ class TestWorkflowStop:
         mock_job.status = JobStatus.IN_PROGRESS
         mock_job.type = JobType.WORKFLOW
         mock_job.user_id = None
+        mock_job.job_metadata = {"request": {"mode": "background"}}
 
         with (
             patch("langflow.api.v2.workflow.get_job_service") as mock_get_job_service,
@@ -386,6 +387,65 @@ class TestWorkflowStop:
             mock_task_service.revoke_task.assert_awaited_once_with(UUID(job_id))
             mock_bg_service.stop_job.assert_awaited_once()
             mock_job_service.update_job_status.assert_awaited_once_with(UUID(job_id), JobStatus.CANCELLED)
+
+    @pytest.mark.parametrize(
+        ("job_metadata", "expected_mode"),
+        [
+            ({"request": {"mode": "sync"}}, "sync"),
+            ({"request": {"mode": "stream"}}, "stream"),
+            (None, "unknown"),
+        ],
+    )
+    async def test_stop_workflow_rejects_non_background_jobs(
+        self,
+        client: AsyncClient,
+        created_api_key,
+        job_metadata,
+        expected_mode,
+    ):
+        """Active jobs not owned by the background executor must not report cancellation."""
+        job_id = uuid4()
+        mock_job = MagicMock(
+            job_id=job_id,
+            status=JobStatus.IN_PROGRESS,
+            type=JobType.WORKFLOW,
+            user_id=None,
+            job_metadata=job_metadata,
+        )
+
+        with (
+            patch("langflow.api.v2.workflow.get_job_service") as mock_get_job_service,
+            patch("langflow.api.v2.workflow.get_task_service") as mock_get_task_service,
+            patch("langflow.api.v2.workflow.get_background_execution_service") as mock_get_bg_service,
+        ):
+            mock_job_service = MagicMock()
+            mock_job_service.get_job_by_job_id = AsyncMock(return_value=mock_job)
+            mock_job_service.update_job_status = AsyncMock()
+            mock_get_job_service.return_value = mock_job_service
+            mock_task_service = MagicMock()
+            mock_task_service.revoke_task = AsyncMock()
+            mock_get_task_service.return_value = mock_task_service
+            mock_bg_service = MagicMock()
+            mock_bg_service.stop_job = AsyncMock()
+            mock_get_bg_service.return_value = mock_bg_service
+
+            response = await client.post(
+                "api/v2/workflows/stop",
+                json={"job_id": str(job_id)},
+                headers={"x-api-key": created_api_key.api_key},
+            )
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == {
+            "error": "Job cannot be stopped",
+            "code": "JOB_NOT_CANCELLABLE",
+            "message": "Only background workflow jobs can be stopped.",
+            "job_id": str(job_id),
+            "mode": expected_mode,
+        }
+        mock_task_service.revoke_task.assert_not_awaited()
+        mock_bg_service.stop_job.assert_not_awaited()
+        mock_job_service.update_job_status.assert_not_awaited()
 
     async def test_stop_workflow_not_found(
         self,

--- a/src/backend/tests/unit/api/v2/test_workflow.py
+++ b/src/backend/tests/unit/api/v2/test_workflow.py
@@ -713,6 +713,7 @@ class TestWorkflowIDORProtection:
                 status=JobStatus.IN_PROGRESS,
                 type=JobType.WORKFLOW,
                 user_id=None,
+                job_metadata={"request": {"mode": "background"}},
             )
             session.add(job)
             await session.flush()

--- a/src/backend/tests/unit/api/v2/test_workflow.py
+++ b/src/backend/tests/unit/api/v2/test_workflow.py
@@ -389,11 +389,15 @@ class TestWorkflowStop:
             mock_job_service.update_job_status.assert_awaited_once_with(UUID(job_id), JobStatus.CANCELLED)
 
     @pytest.mark.parametrize(
-        ("job_metadata", "expected_mode"),
+        ("job_metadata", "job_status", "expected_mode"),
         [
-            ({"request": {"mode": "sync"}}, "sync"),
-            ({"request": {"mode": "stream"}}, "stream"),
-            (None, "unknown"),
+            ({"request": {"mode": "sync"}}, JobStatus.IN_PROGRESS, "sync"),
+            ({"request": {"mode": "stream"}}, JobStatus.IN_PROGRESS, "stream"),
+            (None, JobStatus.IN_PROGRESS, "unknown"),
+            (None, JobStatus.CANCELLED, "unknown"),
+            ({"request": {"mode": "sync"}}, JobStatus.COMPLETED, "sync"),
+            ({"request": {"mode": "stream"}}, JobStatus.FAILED, "stream"),
+            ({"request": {"mode": "sync"}}, JobStatus.TIMED_OUT, "sync"),
         ],
     )
     async def test_stop_workflow_rejects_non_background_jobs(
@@ -401,13 +405,14 @@ class TestWorkflowStop:
         client: AsyncClient,
         created_api_key,
         job_metadata,
+        job_status,
         expected_mode,
     ):
-        """Active jobs not owned by the background executor must not report cancellation."""
+        """Jobs not owned by the background executor must not report cancellation."""
         job_id = uuid4()
         mock_job = MagicMock(
             job_id=job_id,
-            status=JobStatus.IN_PROGRESS,
+            status=job_status,
             type=JobType.WORKFLOW,
             user_id=None,
             job_metadata=job_metadata,

--- a/src/backend/tests/unit/api/v2/test_workflow.py
+++ b/src/backend/tests/unit/api/v2/test_workflow.py
@@ -485,6 +485,7 @@ class TestWorkflowStop:
         mock_job.status = JobStatus.CANCELLED
         mock_job.type = JobType.WORKFLOW
         mock_job.user_id = None
+        mock_job.job_metadata = {"request": {"mode": "background"}}
 
         with patch("langflow.api.v2.workflow.get_job_service") as mock_get_job_service:
             mock_service = MagicMock()
@@ -643,6 +644,7 @@ class TestWorkflowIDORProtection:
                 status=JobStatus.CANCELLED,
                 type=JobType.WORKFLOW,
                 user_id=owner_user_id,
+                job_metadata={"request": {"mode": "background"}},
             )
             session.add(job)
             await session.flush()

--- a/src/lfx/src/lfx/_assets/component_index.json
+++ b/src/lfx/src/lfx/_assets/component_index.json
@@ -12372,7 +12372,9 @@
           "tool_mode": false
         },
         "CharacterTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -12416,8 +12418,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13580,7 +13585,9 @@
           "tool_mode": false
         },
         "LanguageRecursiveTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -13624,8 +13631,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13778,7 +13788,9 @@
           "tool_mode": false
         },
         "NaturalLanguageTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -13823,8 +13835,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -13975,7 +13990,10 @@
           "tool_mode": false
         },
         "OpenAIToolsAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -14031,8 +14049,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -14042,8 +14063,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -14746,7 +14770,9 @@
           "tool_mode": false
         },
         "RecursiveCharacterTextSplitter": {
-          "base_classes": [],
+          "base_classes": [
+            "JSON"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -14790,8 +14816,11 @@
               "group_outputs": false,
               "method": "transform_data",
               "name": "data",
+              "selected": "JSON",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "JSON"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -16478,7 +16507,10 @@
           "tool_mode": false
         },
         "ToolCallingAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": false,
           "conditional_paths": [],
           "custom_fields": {},
@@ -16533,8 +16565,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -16544,8 +16579,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -17242,7 +17280,10 @@
           "tool_mode": false
         },
         "XMLAgent": {
-          "base_classes": [],
+          "base_classes": [
+            "AgentExecutor",
+            "Message"
+          ],
           "beta": true,
           "conditional_paths": [],
           "custom_fields": {},
@@ -17298,8 +17339,11 @@
               "group_outputs": false,
               "method": "message_response",
               "name": "response",
+              "selected": "Message",
               "tool_mode": true,
-              "types": [],
+              "types": [
+                "Message"
+              ],
               "value": "__UNDEFINED__"
             },
             {
@@ -17309,8 +17353,11 @@
               "group_outputs": false,
               "method": "build_agent",
               "name": "agent",
+              "selected": "AgentExecutor",
               "tool_mode": false,
-              "types": [],
+              "types": [
+                "AgentExecutor"
+              ],
               "value": "__UNDEFINED__"
             }
           ],
@@ -30987,6 +31034,6 @@
     "num_components": 127,
     "num_modules": 16
   },
-  "sha256": "7572f889a9012abfc0ecc2de7c45f5fcf7d5b85c24f7ec847afe5aa5f097754e",
+  "sha256": "b38dc88e6d01da028b3e0f4d2918c218e180e4c5b3d87d91cf00e18150bf8ee3",
   "version": "1.12.0"
 }


### PR DESCRIPTION
## Summary
- restrict `POST /api/v2/workflows/stop` to jobs positively identified as durable background runs
- return `409 JOB_NOT_CANCELLABLE` for active sync, stream, or unclassified inline jobs without revoking tasks or changing job status
- preserve existing background cancellation and terminal-state handling

## Root cause
Sync runs execute inline in the caller request, and live streams are driven by a request-local asyncio task. Neither is owned by `BackgroundExecutionService`, but the stop endpoint previously ran the background cancellation path for every workflow job and wrote `CANCELLED` anyway. The inline runner then continued and truthfully overwrote that transient status on completion.

## Verification
- RED: focused regression failed 3 cases on the release base because `/stop` returned 200
- `uv run pytest src/backend/tests/unit/api/v2/test_workflow.py -q` — 32 passed
- `uv run pytest src/backend/tests/unit/api/v2/test_workflow.py -k test_stop_workflow -q` — 13 passed
- `uv run pytest src/backend/tests/unit/api/v2/test_workflow_agui.py::TestBackgroundFinalizationGuards::test_finalize_does_not_overwrite_cancelled_status -q` — 1 passed
- targeted Ruff format/check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted workflow cancellation to background runs.
  - Added a clear conflict response when attempting to stop synchronous, streaming, or unsupported workflow runs.
  - Prevented cancellation services from being triggered for non-cancellable jobs.

- **Tests**
  - Added coverage confirming cancellation behavior across supported and unsupported workflow modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->