### PR TITLE
fix(frontend): fetch a routed flow once per open, not once per render

### DIFF
--- a/src/frontend/src/pages/FlowPage/hooks/__tests__/use-load-flow-for-route.test.ts
+++ b/src/frontend/src/pages/FlowPage/hooks/__tests__/use-load-flow-for-route.test.ts
@@ -111,6 +111,103 @@ describe("useLoadFlowForRoute", () => {
     expect(applyFlowToCanvas).toHaveBeenCalledWith(FLOW);
   });
 
+  it("fires a single request when the navigate identity changes every render", async () => {
+    const pending = deferred<FlowType>();
+    const getFlow = jest.fn().mockReturnValue(pending.promise);
+    const applyFlowToCanvas = jest.fn();
+    const flows: FlowType[] = [];
+    const types = { flow: "Flow" };
+
+    const { rerender } = renderHook(() =>
+      useLoadFlowForRoute({
+        id: FLOW.id,
+        flows,
+        currentFlowId: "",
+        types,
+        getFlow,
+        applyFlowToCanvas,
+        // An unmemoized navigate is what turned this effect into a request
+        // storm: a new identity per render re-ran it while the first response
+        // was still in flight.
+        navigate: () => {},
+      }),
+    );
+
+    await waitFor(() => expect(getFlow).toHaveBeenCalledTimes(1));
+    Array.from({ length: 20 }).forEach(() => rerender());
+
+    expect(getFlow).toHaveBeenCalledTimes(1);
+    await act(async () => pending.resolve(FLOW));
+    expect(applyFlowToCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests the new id exactly once when the route changes flow", async () => {
+    const otherFlow: FlowType = { ...FLOW, id: "other-flow" };
+    const getFlow = jest
+      .fn()
+      .mockImplementation(({ id }: { id: string }) =>
+        Promise.resolve(id === FLOW.id ? FLOW : otherFlow),
+      );
+    const applyFlowToCanvas = jest.fn();
+    const flows: FlowType[] = [];
+    const types = { flow: "Flow" };
+
+    const { rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useLoadFlowForRoute({
+          id,
+          flows,
+          currentFlowId: "",
+          types,
+          getFlow,
+          applyFlowToCanvas,
+          navigate: () => {},
+        }),
+      { initialProps: { id: FLOW.id } },
+    );
+
+    await waitFor(() => expect(getFlow).toHaveBeenCalledWith({ id: FLOW.id }));
+
+    rerender({ id: otherFlow.id });
+
+    await waitFor(() =>
+      expect(getFlow).toHaveBeenCalledWith({ id: otherFlow.id }),
+    );
+    Array.from({ length: 10 }).forEach(() => rerender({ id: otherFlow.id }));
+
+    expect(getFlow).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows a retry after a failed confirmation", async () => {
+    const error = new Error("network unavailable");
+    const getFlow = jest
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue(FLOW);
+    const applyFlowToCanvas = jest.fn();
+    const flows: FlowType[] = [];
+    const types = { flow: "Flow" };
+
+    const { rerender } = renderHook(() =>
+      useLoadFlowForRoute({
+        id: FLOW.id,
+        flows,
+        currentFlowId: "",
+        types,
+        getFlow,
+        applyFlowToCanvas,
+        navigate: () => {},
+      }),
+    );
+
+    await waitFor(() => expect(getFlow).toHaveBeenCalledTimes(1));
+
+    rerender();
+
+    await waitFor(() => expect(applyFlowToCanvas).toHaveBeenCalledWith(FLOW));
+    expect(getFlow).toHaveBeenCalledTimes(2);
+  });
+
   it("logs and redirects when the server cannot confirm the flow", async () => {
     const error = new Error("network unavailable");
     const getFlow = jest.fn().mockRejectedValue(error);

--- a/src/frontend/src/pages/FlowPage/hooks/use-load-flow-for-route.ts
+++ b/src/frontend/src/pages/FlowPage/hooks/use-load-flow-for-route.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { FlowType } from "@/types/flow";
 
 type GetFlow = (payload: { id: string }) => Promise<FlowType>;
@@ -22,6 +22,19 @@ export default function useLoadFlowForRoute({
   applyFlowToCanvas,
   navigate,
 }: UseLoadFlowForRouteProps): void {
+  const requestedFlowIdRef = useRef<string | null>(null);
+  const mountedRef = useRef(true);
+
+  // Cancellation has to outlive the effect: React re-runs the cleanup on every
+  // dependency change, so a per-run flag would discard the in-flight response
+  // the guard below refuses to re-request, leaving the canvas empty forever.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   useEffect(() => {
     if (!flows || currentFlowId !== "" || Object.keys(types).length === 0) {
       return;
@@ -32,18 +45,41 @@ export default function useLoadFlowForRoute({
       return;
     }
 
-    let cancelled = false;
+    // `currentFlowId` only leaves "" once a response lands, so every render
+    // until then re-enters this effect. Without an in-flight guard each of
+    // those renders fires another request, and the pending mutation state
+    // renders again — a loop that saturates the browser socket pool and
+    // prevents the very response that would end it.
+    if (requestedFlowIdRef.current === id) {
+      return;
+    }
+    requestedFlowIdRef.current = id;
+
     const storedFlow = flows.find((flow) => flow.id === id);
+    const isStale = () =>
+      !mountedRef.current || requestedFlowIdRef.current !== id;
 
     const loadFlowToCanvas = async (flowId: string) => {
       const flow = await getFlow({ id: flowId });
-      if (!cancelled) {
+      if (!isStale()) {
         applyFlowToCanvas(flow);
       }
     };
 
+    const releaseForRetry = () => {
+      if (requestedFlowIdRef.current === id) {
+        requestedFlowIdRef.current = null;
+      }
+    };
+
     if (storedFlow) {
-      void loadFlowToCanvas(storedFlow.id);
+      void loadFlowToCanvas(storedFlow.id).catch((error) => {
+        const stale = isStale();
+        releaseForRetry();
+        if (!stale) {
+          console.error(`Failed to load flow ${id} into the canvas:`, error);
+        }
+      });
     } else {
       // The flows store is not authoritative here: right after
       // create-then-navigate (the "New Flow" button), an in-flight list
@@ -51,16 +87,14 @@ export default function useLoadFlowForRoute({
       // store without the new flow. Confirm with the server before giving up
       // on the route.
       void loadFlowToCanvas(id).catch((error) => {
-        if (cancelled) {
+        const stale = isStale();
+        releaseForRetry();
+        if (stale) {
           return;
         }
         console.error(`Failed to confirm flow ${id} from the server:`, error);
         navigate("/all");
       });
     }
-
-    return () => {
-      cancelled = true;
-    };
   }, [id, flows, currentFlowId, types, getFlow, applyFlowToCanvas, navigate]);
 }


### PR DESCRIPTION
Opening a flow issues one `GET /api/v1/flows/{id}` **per render** instead of one per open. On a fast local machine the loop closes after a handful of passes and nothing looks wrong; under real latency it runs long enough to exhaust the browser's socket pool and the canvas never renders at all.

## The loop

`useLoadFlowForRoute` guards its effect on `currentFlowId !== ""`, but `currentFlowId` is only populated once a response lands and `applyFlowToCanvas` runs. Until then every render re-enters the effect:

```
render -> a dependency has a new identity -> effect runs -> getFlow fires
       -> the mutation's pending state renders -> repeat
```

Each pass emits a request, and each response that does land triggers `refetchQueries` on the flow list in `useGetFlow`'s `onSettled`, which swaps the identity of the `flows` array — also a dependency — feeding the cycle again.

## Why it looked like a Windows/desktop bug

It is a latency race, not a platform bug. The loop exists everywhere; what differs is how many passes happen before the first response closes it.

- Locally the response returns in milliseconds, the loop turns 3–4 times, and the flow opens normally.
- Under real latency hundreds of passes fire first. Chromium's socket pool is exhausted, responses stop arriving, `net::ERR_INSUFFICIENT_RESOURCES` fills the console, and the loop becomes permanent: a blank canvas with the loading state spinning forever. The original report showed 11,039 requests / 245 MB transferred on a single flow open.

Because of this, "does the flow open?" is not a valid check — on a fast machine it opens with the bug fully present. **The observable is the request count.**

## Fix

**1. Make the effect idempotent per flow.** A `useRef` holds the id already requested; a re-run for the same id is a no-op no matter which dependency changed identity. This is the real defense — if some dependency becomes unstable again later, it cannot turn into a request storm.

**2. Scope cancellation to unmount and id changes, not to each effect run.** React re-runs the effect cleanup on *every* dependency change. A per-run `cancelled` flag combined with the guard above produces a second, quieter failure: the re-run sets `cancelled = true` on the in-flight request, the guard correctly refuses to re-request it, the response arrives and is discarded, and `currentFlowId` never leaves `""` — the same blank canvas, reached a different way. Cancellation now lives in a mount-scoped ref plus an id-ownership check, so a re-run for the same id leaves the in-flight request intact while a real id change still invalidates it.

`useCustomNavigate` — the unmemoized dependency that first set the loop off — is already memoized on `release-1.12.0`, so no change is needed here. That memoization also stabilizes four other effects that carry `navigate` in their dependency arrays (`homePage/index.tsx`, `use-test-deployment-modal.ts`, `use-start-new-flow.ts`, `use-navigate-to-test.ts`), harmless today because they only navigate.

## Tests

Three regression tests added to `use-load-flow-for-route.test.ts`:

| Test | Pins |
| --- | --- |
| single request when the navigate identity changes every render | the loop itself, and that the response still reaches the canvas |
| exactly one request for the new id when the route switches flows | the guard does not over-block a genuine flow change |
| retry allowed after a failed confirmation | a failure releases the guard |

Verified red before green against both prior states of the file:

- **`release-1.12.0` (no guard):** 2 failed, 7 passed
- **first cut of the fix (guard + per-run cancellation):** 1 failed, 8 passed — this is the discarded-response bug above
- **this PR:** 9 passed

Full `src/pages/FlowPage` suite: 79 suites, 1018 tests passing. `tsc --noEmit` clean, biome clean.

## Manual verification

DevTools → Network, filter `flows`, Preserve log on, clear the panel, open a flow.

- **Before:** several requests to the same id locally; hundreds or thousands under throttling, Pending / 0 B, followed by `ERR_INSUFFICIENT_RESOURCES`.
- **After:** exactly one `GET /api/v1/flows/{id}`, followed by the normal list refetch (`/api/v1/flows/?get_all=true&header_flows=true`).

Repeat with DevTools throttling at 400 ms+ RTT (or a custom Slow 4G profile) — the count must stay at one and the canvas must render.
