### PR TITLE
fix(composio): drop blank optional tool arguments before Composio execution

### DIFF
--- a/src/bundles/lfx-bundles/tests/test_composio_components.py
+++ b/src/bundles/lfx-bundles/tests/test_composio_components.py
@@ -1,6 +1,7 @@
 """Unit tests for Composio components cloud validation."""
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ import pytest
 pytest.importorskip("lfx_bundles")
 
 from lfx.base.composio.composio_base import ComposioBaseComponent
+from lfx.base.composio.safe_provider import SafeLangchainProvider, _drop_blank_optional_arguments, _is_blank_value
 from lfx.schema.data import Data
 from lfx.schema.message import Message
 from lfx_bundles.composio.composio_api import ComposioAPIComponent
@@ -145,3 +147,181 @@ class TestExecuteActionRichTypeCoercion:
         # body contains JSON-like text — should be passed as a string (schema type is str)
         args = self._run({"subject": "hi", "body": Message(text='{"key": "val"}')})
         assert args["body"] == '{"key": "val"}'
+
+
+@pytest.mark.unit
+class TestIsBlankValue:
+    """Unit coverage for the leaf-level blank check used to filter LLM-supplied tool arguments."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            [],
+            (),
+            set(),
+            {},
+            {"name": "", "data": ""},
+            {"nested": {"a": "", "b": None}},
+        ],
+    )
+    def test_blank_values(self, value):
+        assert _is_blank_value(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "test",
+            0,
+            False,
+            ["item"],
+            {"name": "file.txt", "data": ""},
+        ],
+    )
+    def test_non_blank_values(self, value):
+        assert _is_blank_value(value) is False
+
+
+@pytest.mark.unit
+class TestDropBlankOptionalArguments:
+    """Unit coverage for stripping blank optional arguments before they reach Composio."""
+
+    INPUT_PARAMETERS = {
+        "type": "object",
+        "properties": {
+            "recipient_email": {"type": "string"},
+            "subject": {"type": "string"},
+            "body": {"type": "string"},
+            "attachment": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}, "data": {"type": "string"}},
+            },
+        },
+        "required": ["recipient_email", "subject"],
+    }
+
+    def test_blank_optional_object_field_is_dropped(self):
+        arguments = {
+            "recipient_email": "me",
+            "subject": "test",
+            "attachment": {"name": "", "data": ""},
+        }
+        cleaned = _drop_blank_optional_arguments(arguments, self.INPUT_PARAMETERS)
+        assert "attachment" not in cleaned
+        assert cleaned == {"recipient_email": "me", "subject": "test"}
+
+    def test_blank_optional_string_field_is_dropped(self):
+        arguments = {"recipient_email": "me", "subject": "test", "body": ""}
+        cleaned = _drop_blank_optional_arguments(arguments, self.INPUT_PARAMETERS)
+        assert "body" not in cleaned
+
+    def test_non_blank_optional_field_is_kept(self):
+        arguments = {
+            "recipient_email": "me",
+            "subject": "test",
+            "attachment": {"name": "report.pdf", "data": "base64data"},
+        }
+        cleaned = _drop_blank_optional_arguments(arguments, self.INPUT_PARAMETERS)
+        assert cleaned["attachment"] == {"name": "report.pdf", "data": "base64data"}
+
+    def test_blank_required_field_is_never_dropped(self):
+        # Required fields are always forwarded so Composio's own validation still
+        # sees (and can report on) a genuinely missing required value.
+        arguments = {"recipient_email": "", "subject": "test"}
+        cleaned = _drop_blank_optional_arguments(arguments, self.INPUT_PARAMETERS)
+        assert cleaned == {"recipient_email": "", "subject": "test"}
+
+    def test_non_dict_arguments_are_returned_unchanged(self):
+        assert _drop_blank_optional_arguments("not-a-dict", self.INPUT_PARAMETERS) == "not-a-dict"
+
+    def test_non_dict_input_parameters_are_returned_unchanged(self):
+        arguments = {"subject": ""}
+        assert _drop_blank_optional_arguments(arguments, None) == arguments
+
+
+@pytest.mark.unit
+class TestSafeLangchainProviderDropsBlankOptionalArguments:
+    """Regression test for issue #14715.
+
+    When Gmail is used as a Tool by an agent, the underlying LLM would routinely
+    fill the optional consolidated "attachment" field with an empty placeholder
+    (``{"name": "", "data": ""}``) even when no attachment was requested. Composio
+    rejected that payload with "Tool input validation error". The direct
+    ``execute_action`` component path already dropped blank optional values, but
+    the agent Tool-calling path (``SafeLangchainProvider.wrap_tool``) forwarded the
+    LLM's raw arguments untouched. This exercises the real wrap_tool wiring, not
+    just the helper functions above.
+    """
+
+    def test_gmail_create_draft_tool_call_drops_blank_attachment_and_body(self):
+        tool = SimpleNamespace(
+            slug="GMAIL_CREATE_EMAIL_DRAFT",
+            description="Create a Gmail draft",
+            input_parameters={
+                "type": "object",
+                "title": "GmailCreateEmailDraftRequest",
+                "properties": {
+                    "user_id": {"type": "string"},
+                    "recipient_email": {"type": "string"},
+                    "subject": {"type": "string"},
+                    "body": {"type": "string"},
+                    "is_html": {"type": "boolean"},
+                    "attachment": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}, "data": {"type": "string"}},
+                    },
+                },
+                "required": ["user_id", "recipient_email", "subject"],
+            },
+        )
+
+        captured = {}
+
+        def fake_execute_tool(slug, arguments):
+            captured["slug"] = slug
+            captured["arguments"] = arguments
+            return {"successful": True, "data": {}, "error": None}
+
+        structured_tool = SafeLangchainProvider().wrap_tool(tool, fake_execute_tool)
+
+        # Exact payload the LLM produced in issue #14715.
+        structured_tool.func(
+            user_id="me",
+            recipient_email="me",
+            subject="test",
+            body="",
+            is_html=False,
+            attachment={"name": "", "data": ""},
+        )
+
+        assert captured["slug"] == "GMAIL_CREATE_EMAIL_DRAFT"
+        assert captured["arguments"] == {
+            "user_id": "me",
+            "recipient_email": "me",
+            "subject": "test",
+            "is_html": False,
+        }
+
+    def test_required_blank_field_still_reaches_execute_tool(self):
+        tool = SimpleNamespace(
+            slug="GMAIL_SEND_EMAIL",
+            description="Send a Gmail email",
+            input_parameters={
+                "type": "object",
+                "title": "GmailSendEmailRequest",
+                "properties": {"recipient_email": {"type": "string"}},
+                "required": ["recipient_email"],
+            },
+        )
+
+        captured = {}
+
+        def fake_execute_tool(slug, arguments):  # noqa: ARG001 - signature must match AgenticProviderExecuteFn
+            captured["arguments"] = arguments
+            return {"successful": False, "data": None, "error": "missing recipient"}
+
+        structured_tool = SafeLangchainProvider().wrap_tool(tool, fake_execute_tool)
+        structured_tool.func(recipient_email="")
+
+        assert captured["arguments"] == {"recipient_email": ""}

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -12,6 +12,17 @@ We sanitize ``tool.input_parameters`` in-place at wrap time, and also patch
 both the FileHelper file-substitution helpers and the pydantic schema builder
 so the agent path, the direct ``execute_action`` path, and the legacy
 ``tools.get`` path all see a schema with a ``"type"`` for every node.
+
+We also strip blank optional arguments before an agent's tool call reaches
+Composio (see ``_drop_blank_optional_arguments``). Tool-calling models
+routinely populate every property they see in a schema, including optional
+ones, with empty placeholders (e.g. Gmail's consolidated ``attachment`` field
+as ``{"name": "", "data": ""}`` when no attachment was requested). Composio's
+backend rejects that blank value with "Tool input validation error" (issue
+#14715). ``ComposioBaseComponent.execute_action`` already drops blank
+optional values for direct component runs; this mirrors that behavior for
+the agent ``configure_tools``/Tool-calling path, which otherwise forwards the
+model's raw arguments untouched.
 """
 
 from __future__ import annotations
@@ -99,6 +110,38 @@ def _sanitize_schema(schema: Any) -> None:
                 _sanitize_schema(sub)
 
 
+def _is_blank_value(value: Any) -> bool:
+    """Return True if ``value`` is empty/blank all the way down.
+
+    Covers ``None``, empty strings/collections, and objects whose every leaf
+    value is itself blank (e.g. ``{"name": "", "data": ""}``) — the shape an
+    LLM produces for an optional field it filled in without real content.
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value == ""
+    if isinstance(value, (list, tuple, set)):
+        return len(value) == 0
+    if isinstance(value, dict):
+        return len(value) == 0 or all(_is_blank_value(sub_value) for sub_value in value.values())
+    return False
+
+
+def _drop_blank_optional_arguments(arguments: Any, input_parameters: Any) -> Any:
+    """Strip blank optional arguments an LLM filled in just because the schema listed them.
+
+    Required fields are always forwarded untouched, even if blank, so this
+    never hides a genuinely missing required value from Composio's own
+    validation.
+    """
+    if not isinstance(arguments, dict) or not isinstance(input_parameters, dict):
+        return arguments
+
+    required = set(input_parameters.get("required") or [])
+    return {key: value for key, value in arguments.items() if key in required or not _is_blank_value(value)}
+
+
 if _COMPOSIO_AVAILABLE:
 
     class SafeLangchainProvider(LangchainProvider, name="langchain"):
@@ -106,7 +149,12 @@ if _COMPOSIO_AVAILABLE:
 
         def wrap_tool(self, tool: Tool, execute_tool: Callable[..., Any]) -> StructuredTool:
             _sanitize_schema(tool.input_parameters)
-            return super().wrap_tool(tool=tool, execute_tool=execute_tool)
+            input_parameters = tool.input_parameters
+
+            def execute_tool_without_blank_optionals(slug: str, arguments: dict) -> Any:
+                return execute_tool(slug, _drop_blank_optional_arguments(arguments, input_parameters))
+
+            return super().wrap_tool(tool=tool, execute_tool=execute_tool_without_blank_optionals)
 
 
 def _extract_schema_arg(args: tuple, kwargs: dict, positional_index: int, keyword: str) -> Any:


### PR DESCRIPTION
## Summary

Fixes #14715.

When a Composio action (e.g. Gmail) is used **as a Tool by an agent**, drafting/sending an email fails with `"Tool input validation error"` from Composio, even though the same action run **directly** from the component works fine.

### Root cause

- `ComposioBaseComponent.execute_action` (`src/lfx/src/lfx/base/composio/composio_base.py`), used when the component runs **directly**, already skips optional arguments that are `None`, empty strings/lists, or equal to the schema default before calling the Composio API.
- The **agent Tool-calling path** (`SafeLangchainProvider.wrap_tool` → `composio_langchain`'s `LangchainProvider.wrap_tool`) has no equivalent filtering: it forwards the LLM's raw tool-call arguments to Composio's `execute` API unchanged.

Tool-calling models routinely populate every property they see in a tool's JSON schema, including optional ones, with empty placeholders. For Gmail's consolidated `attachment` field this produces `{"name": "", "data": ""}` even when no attachment was requested. Composio's backend rejects that blank value with `"Tool input validation error"`, which matches the exact payload and error reported in the issue. This divergence between the two execution paths explains why the bug only reproduces "as a Tool."

### Fix

`SafeLangchainProvider.wrap_tool` (`src/lfx/src/lfx/base/composio/safe_provider.py`) now wraps `execute_tool` to strip blank optional arguments (recursively, so a nested object like `attachment` whose leaf values are all blank is dropped too) before delegating to Composio, mirroring `execute_action`'s existing behavior. Required fields are always forwarded untouched, so a genuinely missing required value still reaches Composio's own validation and error reporting.

This is a minimal, surgical change scoped to one file's tool-wrapping logic; no schema-building, UI, or direct-execution code paths were touched.

## Test plan

- [x] Added `TestIsBlankValue`, `TestDropBlankOptionalArguments`, and `TestSafeLangchainProviderDropsBlankOptionalArguments` (the latter reproduces the exact `GMAIL_CREATE_EMAIL_DRAFT` payload from the issue through the real `SafeLangchainProvider.wrap_tool` wiring) in `src/bundles/lfx-bundles/tests/test_composio_components.py`.
- [x] `uv run pytest src/bundles/lfx-bundles/tests/test_composio_components.py -q` → 30 passed.
- [x] `uv run pytest src/bundles/lfx-bundles/tests/ -q` (full bundle suite) → 192 passed, 29 skipped, no regressions.
- [x] `uv run ruff check` / `uv run pre-commit run --files ...` → clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool execution by removing empty placeholder values from optional arguments.
  * Preserved required fields and valid non-empty values when processing tool calls.
  * Improved consistency between direct component runs and wrapped tool execution.

* **Tests**
  * Added coverage for blank-value detection, optional-argument filtering, and end-to-end tool execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->