### PR TITLE
fix(frontend): render no icon for plain select trigger

### DIFF
--- a/src/frontend/src/components/ui/__tests__/select-trigger-variants.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/select-trigger-variants.test.tsx
@@ -1,5 +1,35 @@
 import { render, screen } from "@testing-library/react";
+import type * as ReactTypes from "react";
 import { Select, SelectTrigger, SelectValue } from "../select";
+
+// Exercise the Slot 1.3+ `asChild` contract without updating the full Radix
+// dependency graph locked for the release branch.
+jest.mock("@radix-ui/react-select", () => {
+  const actual = jest.requireActual<typeof import("@radix-ui/react-select")>(
+    "@radix-ui/react-select",
+  );
+  const React = jest.requireActual<typeof import("react")>("react");
+
+  const StrictIcon = React.forwardRef<
+    ReactTypes.ElementRef<typeof actual.Icon>,
+    ReactTypes.ComponentPropsWithoutRef<typeof actual.Icon>
+  >(({ asChild, children, ...props }, ref) => {
+    if (asChild && !React.isValidElement(children)) {
+      throw new Error(
+        "Primitive.span failed to slot onto its children. Expected a single React element child or `Slottable`.",
+      );
+    }
+
+    return (
+      <actual.Icon {...props} asChild={asChild} ref={ref}>
+        {children}
+      </actual.Icon>
+    );
+  });
+  StrictIcon.displayName = "StrictSelectIcon";
+
+  return { ...actual, Icon: StrictIcon };
+});
 
 const renderTrigger = (triggerProps: Record<string, unknown> = {}) =>
   render(

--- a/src/frontend/src/components/ui/__tests__/select-trigger-variants.test.tsx
+++ b/src/frontend/src/components/ui/__tests__/select-trigger-variants.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { Select, SelectTrigger, SelectValue } from "../select";
+
+const renderTrigger = (triggerProps: Record<string, unknown> = {}) =>
+  render(
+    <Select>
+      <SelectTrigger data-testid="trigger" {...triggerProps}>
+        <SelectValue placeholder="Pick a model" />
+      </SelectTrigger>
+    </Select>,
+  );
+
+describe("SelectTrigger variants", () => {
+  // Radix's `asChild` swaps the primitive for its single element child, so the
+  // plain variant must omit the icon entirely. Rendering `<Select.Icon asChild>`
+  // with no children throws "Primitive.span failed to slot onto its children"
+  // on @radix-ui/react-slot >= 1.3, taking the whole tree down.
+  it("should_render_no_icon_for_plain_variant", () => {
+    expect(() => renderTrigger({ variant: "plain" })).not.toThrow();
+
+    expect(screen.getByTestId("trigger").querySelector("svg")).toBeNull();
+  });
+
+  it("should_render_chevron_for_default_variant", () => {
+    renderTrigger();
+
+    expect(screen.getByTestId("trigger").querySelector("svg")).not.toBeNull();
+  });
+});

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -36,9 +36,7 @@ const SelectTrigger = React.forwardRef<
       {...props}
     >
       {children}
-      {variant === "plain" ? (
-        <SelectPrimitive.Icon asChild></SelectPrimitive.Icon>
-      ) : (
+      {variant === "plain" ? null : (
         <SelectPrimitive.Icon asChild>
           {direction === "up" ? (
             <ChevronUp className="h-4 w-4" />


### PR DESCRIPTION
## Problem

`SelectTrigger variant="plain"` renders `<SelectPrimitive.Icon asChild>` with **no children**:

```tsx
{variant === "plain" ? (
  <SelectPrimitive.Icon asChild></SelectPrimitive.Icon>
) : ( ... )}
```

Radix's `asChild` replaces the primitive with its single element child, so an empty one has nothing to slot onto.

`@radix-ui/react-slot` tolerated this until 1.3, where the guard became `Children.count(children) === 1 && isValidElement(children)`. It now throws:

```
Primitive.span failed to slot onto its children.
Expected a single React element child or `Slottable`.
```

The throw happens during render, so the whole React tree unmounts into the error boundary. Every screen that mounts a plain trigger is affected — flow sidebar (`sidebarDraggableComponent`), node toolbar (`ToolbarMoreMenu`), note toolbar, and the session menus.

## Why CI is green today

The committed lockfile resolves `@radix-ui/react-slot` to 1.2.4, whose guard only rejects **more than one** child — zero passes silently. `package.json` declares `^1.2.4`, so any install that resolves >= 1.3 within that range crashes. We hit this in a downstream build whose lockfile resolved 1.3.3.

## Fix

Omit the icon entirely for the plain variant instead of rendering an empty slot. This is correct on every `react-slot` version and does not change rendered output on 1.2.x.

## Tests

Adds `select-trigger-variants.test.tsx`: the plain variant renders without throwing and emits no icon; the default variant still renders the chevron. Existing `select.a11y.test.tsx` passes unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the plain select trigger variant so it no longer displays an empty icon.
  * Preserved the chevron icon for the default select trigger variant.

* **Tests**
  * Added coverage to verify icon behavior across select trigger variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->