### PR TITLE
fix(tests): match the publish PATCH by body before opening the shareable playground

### DIFF
--- a/src/frontend/tests/extended/regression/general-bugs-upload-during-cold-flow-list.spec.ts
+++ b/src/frontend/tests/extended/regression/general-bugs-upload-during-cold-flow-list.spec.ts
@@ -48,9 +48,13 @@ test(
       },
     );
 
+    // Armed before the full `/flows` navigation, so this budget also covers the
+    // page load. On Windows CI the Vite dev server spends ~20-35s serving the
+    // unbundled module graph before the app bootstraps and issues this request
+    // (nightly 33576072242, shard 69: it arrived ~32s after the goto).
     const firstPageRequest = page.waitForRequest(
       (request) => PROJECT_PAGE_PATTERN.test(request.url()),
-      { timeout: TIMEOUTS.standard },
+      { timeout: TIMEOUTS.long },
     );
 
     const dropTarget = await openFlowsList(page);

--- a/src/frontend/tests/utils/playground/publish-and-open-shareable.ts
+++ b/src/frontend/tests/utils/playground/publish-and-open-shareable.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Page } from "@playwright/test";
+import type { BrowserContext, Page, Request } from "@playwright/test";
 import { expect } from "@playwright/test";
 import { configureLoopbackOpenAI } from "../configure-loopback-openai";
 import { TID } from "../constants/testIds";
@@ -13,6 +13,16 @@ export type PublishedFlow = {
   /** The URL of the shareable playground (useful for reload-in-place tests). */
   url: string;
 };
+
+/** `access_type` carried by a flow PATCH body, if any. */
+function patchAccessType(request: Request): string | undefined {
+  try {
+    const body = request.postDataJSON() as { access_type?: string } | null;
+    return body?.access_type;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * End-to-end: open Basic Prompting, configure the loopback model, build, publish, toggle
@@ -43,12 +53,18 @@ export async function publishBasicPromptingAndOpenShareablePlayground(
   if (!flowId) {
     throw new Error(`Expected a /flow/:id editor URL, got ${page.url()}`);
   }
+  // The switch flushes any pending canvas autosave before it changes access,
+  // and that flush is a PATCH to this same URL. Only the access-type PATCH
+  // publishes the flow, so match on its body rather than on the first response
+  // (nightly 33576072242: the autosave PATCH resolved first, the item was
+  // clicked while the flow was still private, and no tab ever opened).
   const publishResponsePromise = page.waitForResponse((response) => {
-    const url = new URL(response.url());
-    return (
-      response.request().method() === "PATCH" &&
-      url.pathname === `/api/v1/flows/${flowId}`
-    );
+    const request = response.request();
+    if (request.method() !== "PATCH") return false;
+    if (new URL(response.url()).pathname !== `/api/v1/flows/${flowId}`) {
+      return false;
+    }
+    return patchAccessType(request) === "PUBLIC";
   });
   await page.getByTestId(TID.publishSwitch).click();
   const publishResponse = await publishResponsePromise;
@@ -57,8 +73,15 @@ export async function publishBasicPromptingAndOpenShareablePlayground(
     `Publishing flow ${flowId} returned ${publishResponse.status()}`,
   ).toBeTruthy();
 
+  // The menu item only renders the playground link once the store reflects
+  // PUBLIC access, which lands after the response, so wait for the link itself
+  // rather than clicking the item as soon as the request has returned.
+  const shareableLink = page
+    .getByTestId(TID.shareablePlayground)
+    .getByRole("link");
+  await expect(shareableLink).toBeVisible({ timeout: TIMEOUTS.medium });
   const pagePromise = context.waitForEvent("page");
-  await page.getByTestId(TID.shareablePlayground).click();
+  await shareableLink.click();
   const playgroundPage = await pagePromise;
   await playgroundPage.waitForURL(new RegExp(`/playground/${flowId}/?$`), {
     timeout: TIMEOUTS.long,


### PR DESCRIPTION
## Summary

Nightly [33576072242](https://github.com/langflow-ai/langflow/actions/runs/33576072242) was the first nightly to resolve `release-1.13.0`. It failed Linux Playwright shards 40 and 41 on every `shareable-playground-*` spec (blocking) and Windows shard 69 on `general-bugs-upload-during-cold-flow-list.spec.ts` (non-blocking). The previous night ran the same shards on `release-1.12.0` and was green. Both fixes are test-side.

### Linux 40/41: the shareable-playground helper clicked before the flow was public

Since #14841 the publish switch flushes any pending canvas autosave before it changes the access type (`deploy-dropdown.tsx`: `await pendingAutoSave?.flush()` → `mutateAsync({access_type})`). That flush is a `PATCH /api/v1/flows/{id}`, the same URL as the access-type PATCH. On CI an autosave is still pending when the switch is clicked, so two PATCHes fire ~100ms apart.

`publishBasicPromptingAndOpenShareablePlayground` accepted any PATCH to that path, resolved on the autosave, and clicked `shareable-playground` while `access_type` was still `PRIVATE`. The item only renders its `target=_blank` link once the store reflects `PUBLIC`, so the click just closed the menu and `context.waitForEvent("page")` timed out after 20s.

Blob-report trace for the failing attempt (`shareable-playground-auth.spec.ts:7`, shard 40, attempt 2):

```
29.003s  Click publish-switch
29.049s  PATCH /api/v1/flows/{id}  (autosave flush)      start
29.075s  PATCH /api/v1/flows/{id}  (autosave flush)      200
29.175s  PATCH /api/v1/flows/{id}  (access_type PUBLIC)  start
29.186s  Click shareable-playground                       <-- still a <span>
29.214s  PATCH /api/v1/flows/{id}  (access_type PUBLIC)  200
49.188s  TimeoutError: browserContext.waitForEvent: Timeout 20000ms exceeded
```

Fix: match the publish response on an `access_type: "PUBLIC"` body (the autosave body carries no `access_type`), then wait for the rendered link inside the item and click the link. Same readiness idea as `shared-playground.a11y.spec.ts`, which waits for `toBeChecked()` after the switch.

### Windows 69: 30s budget armed before a full `/flows` navigation

The spec (added by #14876) arms `page.waitForRequest(/projects/{id}?…/)` with `TIMEOUTS.standard` *before* `openFlowsList` does `page.goto("/flows")`. The trace shows the Windows Vite dev reload alone took ~27s before the app bootstrapped, and the paginated request arrived at t+32s. Raised to `TIMEOUTS.long`, the budget the persistence barrier already uses for the same Windows reload cost.

## Test plan

- [x] Local Playwright run of `shareable-playground-auth.spec.ts` on unmodified `release-1.13.0` passes (the autosave had already landed locally, so the race did not trigger).
- [x] Throwaway repro that forces a pending autosave (hijacks `autoSaveFlow.flush` to PATCH the flow) and delays the access-type PATCH by 750ms: **fails with CI's exact error on the current helper, passes with this fix**. Repro trace before/after:

  ```
  before:  0.033s click shareable-playground   (access PATCH in flight until 0.810s) -> no page
  after:   0.812s access PATCH done -> 0.812s expect link visible -> 0.880s click link -> tab opens
  ```
- [x] `shareable-playground-auth`, `shareable-playground-token-display`, `shareable-playground-persistence` (helper's three users) and `general-bugs-upload-during-cold-flow-list` together: 5 passed, 4 conditionally skipped (same as CI).
- [x] `biome check` and `npm run test:e2e-utilities` (62/62) clean.
- [ ] Nightly on `release-1.13.0` green on Linux shards 40/41 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regression-test reliability by allowing additional time for project-list loading on slower environments.
  * Updated publishing validation to distinguish public-flow updates from autosave requests.
  * Improved shareable playground navigation by waiting for the link to become visible before opening it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->