### PR TITLE
fix(logging): hide default service field in pretty console

### DIFF
--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -855,6 +855,29 @@ class TestProductionObservability:
         assert "version" not in rec
         assert "environment" not in rec
 
+    def test_pretty_console_hides_default_service_field(self, capsys, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_PRETTY_LOGS", "true")
+        configure(log_env="", log_level="DEBUG", cache=False)
+        log = structlog.get_logger("svc.pretty")
+
+        log.info("console hi")
+
+        out = capsys.readouterr().out
+        assert "console hi" in out
+        assert "service=langflow" not in out
+
+    def test_pretty_console_preserves_custom_service_field(self, capsys, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_PRETTY_LOGS", "true")
+        monkeypatch.setenv("LANGFLOW_SERVICE_NAME", "custom-service")
+        configure(log_env="", log_level="DEBUG", cache=False)
+        log = structlog.get_logger("svc.pretty")
+
+        log.info("console hi")
+
+        out = capsys.readouterr().out
+        assert "console hi" in out
+        assert "custom-service" in out
+
     def test_service_info_from_env_appears_in_records(self, capsys, monkeypatch):
         monkeypatch.setenv("LANGFLOW_SERVICE_NAME", "lfx-runner")
         monkeypatch.setenv("LANGFLOW_VERSION", "1.2.3")

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -209,6 +209,16 @@ def _get_service_info() -> dict[str, str]:
     return info
 
 
+def _hide_default_service_for_pretty_console(
+    _logger: Any,
+    _method_name: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    if event_dict.get("service") == "langflow":
+        event_dict.pop("service", None)
+    return event_dict
+
+
 # Default keys whose values are redacted before rendering. Production logs leak
 # auth tokens, cookies, and API keys with surprising regularity (third-party
 # clients log request bodies, dict reprs, kwargs, etc.); a cheap, default-on
@@ -1145,6 +1155,7 @@ def configure(
                 processors.append(structlog.processors.format_exc_info)
                 processors.append(structlog.processors.KeyValueRenderer())
             else:
+                processors.append(_hide_default_service_for_pretty_console)
                 processors.append(structlog.dev.ConsoleRenderer(colors=True))
         else:
             _append_json_tail()


### PR DESCRIPTION
The default `service=langflow` metadata adds noise to human-oriented pretty console logs. Hide only that implicit default in pretty output while preserving custom service names and structured log metadata.

Fixes #13615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pretty console logs no longer display the default `service=langflow` field, reducing unnecessary output.
  * Custom service names continue to appear in pretty console logs when configured.
* **Tests**
  * Added coverage to verify both default-field hiding and preservation of custom service names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->