### PR TITLE
fix: detect watsonx models behind LiteLLM proxy

### DIFF
--- a/src/backend/tests/unit/components/models_and_agents/test_ibm_granite_handler.py
+++ b/src/backend/tests/unit/components/models_and_agents/test_ibm_granite_handler.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from langchain_core.messages import AIMessage
+from langchain_openai import ChatOpenAI
 from lfx.components.langchain_utilities.ibm_granite_handler import (
     PLACEHOLDER_PATTERN,
     create_granite_agent,
@@ -140,6 +141,15 @@ class TestIsWatsonxModel:
         mock_llm.model_id = "mistralai/mistral-large"
 
         result = is_watsonx_model(mock_llm)
+
+        assert result is True
+
+    @pytest.mark.parametrize("model_name", ["watsonx/granite-3-3-8b-instruct", "WATSONX/granite-3-3-8b-instruct"])
+    def test_detects_watsonx_prefix_on_openai_compatible_client(self, model_name):
+        """Test detection when LiteLLM routes WatsonX through ChatOpenAI."""
+        llm = ChatOpenAI(api_key="test", base_url="https://proxy.example/v1", model=model_name)
+
+        result = is_watsonx_model(llm)
 
         assert result is True
 

--- a/src/lfx/src/lfx/components/langchain_utilities/ibm_granite_handler.py
+++ b/src/lfx/src/lfx/components/langchain_utilities/ibm_granite_handler.py
@@ -31,11 +31,17 @@ def is_watsonx_model(llm) -> bool:
     """Check if the LLM is an IBM WatsonX model (any model, not just Granite).
 
     This detects the provider (WatsonX) rather than a specific model,
-    since tool calling issues affect all models on the WatsonX platform.
+    since tool calling issues affect all models on the WatsonX platform. OpenAI-compatible
+    proxies identify WatsonX routes with a ``watsonx/`` model-name prefix.
     """
     # Check class name for WatsonX (e.g., ChatWatsonx)
     class_name = type(llm).__name__.lower()
     if "watsonx" in class_name:
+        return True
+
+    # LiteLLM Proxy returns ChatOpenAI, so the model name is the only provider signal.
+    model_name = getattr(llm, "model_name", "")
+    if isinstance(model_name, str) and model_name.lower().startswith("watsonx/"):
         return True
 
     # Fallback: check module name (e.g., langchain_ibm)


### PR DESCRIPTION
## Summary

- detect watsonx/ model names on OpenAI-compatible clients returned by LiteLLM Proxy
- enable the existing WatsonX single-tool-call and placeholder-correction middleware for proxied models
- cover lowercase and uppercase prefixes with a real ChatOpenAI regression test

## Root cause

LiteLLM Proxy builds a ChatOpenAI client, while WatsonX detection only inspected the client class and module. The watsonx/ provider signal exists only in the model name, so proxied WatsonX models missed both protections and could loop until the Agent recursion limit.

## Verification

- Regression test failed for both prefix cases before the production change
- Ruff format/check: passed
- IBM Granite handler + LiteLLM Proxy suites: 122 passed, 4 skipped
- Standalone LFX Agent suite: 60 passed, 2 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WatsonX model recognition when using OpenAI-compatible clients.
  * WatsonX models are now detected from model names beginning with the `watsonx/` prefix, regardless of capitalization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->