### PR TITLE
fix(components): stop lazy loading from wiping the built-in registry

### DIFF
--- a/src/backend/tests/unit/custom/component/test_component_loading_fix.py
+++ b/src/backend/tests/unit/custom/component/test_component_loading_fix.py
@@ -164,7 +164,14 @@ class TestComponentLoadingFix:
 
     @pytest.mark.asyncio
     async def test_lazy_loading_mode_with_base_path_filtering(self, mock_settings_service, mock_langflow_components):
-        """Test that lazy loading mode uses aget_component_metadata with filtered paths."""
+        """Test that lazy loading mode uses aget_component_metadata with filtered paths.
+
+        Previously this asserted the FULL path list ("not filtered in lazy mode"), which is the
+        defect: built-ins are already loaded from the prebuilt index, so rescanning
+        BASE_COMPONENTS_PATH produced metadata-only stubs that replaced them. Every built-in then
+        read as an unregistered custom component and LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
+        rejected every flow. Both branches load custom paths only, as the test name always said.
+        """
         # Setup: Enable lazy loading and include BASE_COMPONENTS_PATH
         mock_settings_service.settings.lazy_load_components = True
         mock_settings_service.settings.components_path = [BASE_COMPONENTS_PATH, "/custom/path1"]
@@ -182,8 +189,8 @@ class TestComponentLoadingFix:
             # Execute the function
             result = await get_and_cache_all_types_dict(mock_settings_service)
 
-            # Verify that aget_component_metadata was called with the full path (not filtered in lazy mode)
-            mock_aget_metadata.assert_called_once_with([BASE_COMPONENTS_PATH, "/custom/path1"])
+            # Verify that aget_component_metadata was called with the base path filtered out
+            mock_aget_metadata.assert_called_once_with(["/custom/path1"])
 
             # Verify result contains both langflow and custom components
             assert "category1" in result
@@ -219,7 +226,15 @@ class TestComponentLoadingFix:
 
     @pytest.mark.asyncio
     async def test_component_merging_logic(self, mock_settings_service, mock_langflow_components):
-        """Test that langflow and custom components are properly merged."""
+        """Test that langflow and custom components are properly merged.
+
+        Merging is per COMPONENT, not per category. This previously asserted that a custom
+        category "should completely override" the built-in one of the same name, which meant a
+        custom directory containing a single component under a shared category name ("tools",
+        "embeddings", "utilities") silently deleted every built-in component in it. Those then
+        read as unregistered and were rejected under allow_custom_components=false. A same-named
+        *component* is still overridden, which is what the production comment always described.
+        """
         # Setup
         mock_settings_service.settings.components_path = ["/custom/path1"]
         mock_settings_service.settings.lazy_load_components = False
@@ -247,11 +262,13 @@ class TestComponentLoadingFix:
             assert "category2" in result  # From langflow
             assert "new_category" in result  # From custom
 
-            # Custom category should completely override langflow category
+            # A same-named component is still overridden by the custom one
             assert result["category1"]["Component1"]["display_name"] == "CustomComponent1"
 
-            # Only components from custom category should remain in category1
-            assert "Component2" not in result["category1"]  # Langflow component is replaced by custom category
+            # ...but its built-in siblings survive: the category is supplemented, not replaced
+            assert "Component2" in result["category1"], (
+                "a custom component in a shared category must not delete the built-ins beside it"
+            )
             assert "Component4" in result["category1"]  # New custom component
 
             # New custom component should be added

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -769,15 +769,19 @@ async def _determine_loading_strategy(settings_service: "SettingsService") -> di
         Dictionary containing loaded component types and templates
     """
     all_types_dict: dict[str, Any] = {}
+    # Both branches load *custom* components only. Built-ins are already loaded from the prebuilt
+    # index by import_langflow_components, and _initialize_component_cache merges this result over
+    # them -- so scanning BASE_COMPONENTS_PATH here does not add the built-ins, it REPLACES them
+    # with whatever this scan produces, under directory-derived keys.
+    custom_paths = [p for p in (settings_service.settings.components_path or []) if p != BASE_COMPONENTS_PATH]
     if settings_service.settings.lazy_load_components:
         # Partial loading mode - just load component metadata
         await logger.adebug("Using partial component loading")
-        all_types_dict = await aget_component_metadata(settings_service.settings.components_path)
-    elif settings_service.settings.components_path:
-        # Traditional full loading - filter out base components path to only load custom components
-        custom_paths = [p for p in settings_service.settings.components_path if p != BASE_COMPONENTS_PATH]
         if custom_paths:
-            all_types_dict = await aget_all_types_dict(custom_paths)
+            all_types_dict = await aget_component_metadata(custom_paths)
+    elif custom_paths:
+        # Traditional full loading - filter out base components path to only load custom components
+        all_types_dict = await aget_all_types_dict(custom_paths)
 
     # Log custom component loading stats
     components_dict = all_types_dict or {}
@@ -1427,6 +1431,35 @@ def _finish_component_initialization_task(
             initialization_future.set_exception(RuntimeError("Component cache initialization ended without a result"))
 
 
+def _merge_component_sources(
+    builtin: dict[str, Any],
+    *sources: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge component sources per COMPONENT, later sources winning on a name collision.
+
+    Categories are shared namespaces, not owned by one source: custom and extension loaders
+    routinely emit categories that also exist as built-ins ("tools", "embeddings",
+    "utilities"). Merging at the category level (``{**builtin, **custom}``) replaced the whole
+    built-in category with the other source's, deleting every built-in component in it. Those
+    components then had no registered hash, so ``allow_custom_components=false`` rejected every
+    flow that used one -- reporting first-party built-ins as custom components.
+
+    Extension components still win over a same-named *component*, which is what
+    "a manifest-shipping bundle supersedes any same-named legacy entry" was meant to say.
+
+    Empty categories are dropped: the lazy metadata scanner emits a fixed set of legacy category
+    names whether or not anything was found in them, and they would otherwise surface as empty
+    palette sections.
+    """
+    merged: dict[str, Any] = {category: dict(components) for category, components in builtin.items()}
+    for source in sources:
+        for category, components in source.items():
+            if not components:
+                continue
+            merged.setdefault(category, {}).update(components)
+    return merged
+
+
 async def _initialize_component_cache(
     cache: ComponentCache,
     settings_service: "SettingsService",
@@ -1451,13 +1484,7 @@ async def _initialize_component_cache(
         custom_flat = custom_components_dict.get("components", custom_components_dict) or {}
 
         # Merge built-in, custom, and extension components (no wrapper at cache level).
-        # Extension components win on collision so a manifest-shipping bundle
-        # supersedes any same-named legacy entry.
-        merged_types = {
-            **langflow_components["components"],
-            **custom_flat,
-            **extension_components,
-        }
+        merged_types = _merge_component_sources(langflow_components["components"], custom_flat, extension_components)
         component_count = sum(len(comps) for comps in merged_types.values())
         await logger.adebug(f"Loaded {component_count} components")
 
@@ -1697,17 +1724,17 @@ async def ensure_component_loaded(component_type: str, component_name: str, sett
     if component_key in component_cache.fully_loaded_components:
         return
 
-    # If we don't have a cache or the component doesn't exist in the cache, nothing to do
-    if (
-        not component_cache.all_types_dict
-        or "components" not in component_cache.all_types_dict
-        or component_type not in component_cache.all_types_dict["components"]
-        or component_name not in component_cache.all_types_dict["components"][component_type]
-    ):
+    # If we don't have a cache or the component doesn't exist in the cache, nothing to do.
+    # The cache stores categories at the top level: _initialize_component_cache publishes
+    # ``merged_types`` with no "components" wrapper (the wrapper is stripped from the custom
+    # dict before merging). Indexing through a "components" key here matched nothing, so this
+    # function returned early every time and lazy stubs were never hydrated.
+    registry = component_cache.all_types_dict
+    if not registry or component_type not in registry or component_name not in registry[component_type]:
         return
 
     # Check if component is marked for lazy loading
-    if component_cache.all_types_dict["components"][component_type][component_name].get("lazy_loaded", False):
+    if registry[component_type][component_name].get("lazy_loaded", False):
         await logger.adebug(f"Fully loading component {component_type}:{component_name}")
 
         # Load just this specific component
@@ -1717,10 +1744,10 @@ async def ensure_component_loaded(component_type: str, component_name: str, sett
 
         if full_component:
             # Replace the stub with the fully loaded component
-            component_cache.all_types_dict["components"][component_type][component_name] = full_component
+            registry[component_type][component_name] = full_component
             # Remove lazy_loaded flag if it exists
-            if "lazy_loaded" in component_cache.all_types_dict["components"][component_type][component_name]:
-                del component_cache.all_types_dict["components"][component_type][component_name]["lazy_loaded"]
+            if "lazy_loaded" in registry[component_type][component_name]:
+                del registry[component_type][component_name]["lazy_loaded"]
 
             # Mark as fully loaded
             component_cache.fully_loaded_components[component_key] = True

--- a/src/lfx/src/lfx/interface/components.py
+++ b/src/lfx/src/lfx/interface/components.py
@@ -759,6 +759,15 @@ def _process_single_module(modname: str) -> tuple[str, dict] | None:
     return (top_level, module_components)
 
 
+def _resolved_component_path(path: str | Path) -> Path:
+    """Resolve a component path for identity comparisons without requiring it to exist."""
+    candidate = Path(path)
+    try:
+        return candidate.resolve(strict=False)
+    except OSError:
+        return candidate
+
+
 async def _determine_loading_strategy(settings_service: "SettingsService") -> dict[str, Any]:
     """Determines and executes the appropriate component loading strategy.
 
@@ -773,7 +782,12 @@ async def _determine_loading_strategy(settings_service: "SettingsService") -> di
     # index by import_langflow_components, and _initialize_component_cache merges this result over
     # them -- so scanning BASE_COMPONENTS_PATH here does not add the built-ins, it REPLACES them
     # with whatever this scan produces, under directory-derived keys.
-    custom_paths = [p for p in (settings_service.settings.components_path or []) if p != BASE_COMPONENTS_PATH]
+    base_components_path = _resolved_component_path(BASE_COMPONENTS_PATH)
+    custom_paths = [
+        path
+        for path in (settings_service.settings.components_path or [])
+        if _resolved_component_path(path) != base_components_path
+    ]
     if settings_service.settings.lazy_load_components:
         # Partial loading mode - just load component metadata
         await logger.adebug("Using partial component loading")
@@ -869,17 +883,11 @@ def _components_path_extension_paths(settings_service: "SettingsService") -> lis
     components dir through as an inline-bundle root (which would produce
     duplicate / garbage palette entries from walking it as a bundle parent).
     """
-    try:
-        base_resolved = Path(BASE_COMPONENTS_PATH).resolve(strict=False)
-    except OSError:
-        base_resolved = Path(BASE_COMPONENTS_PATH)
+    base_resolved = _resolved_component_path(BASE_COMPONENTS_PATH)
     paths: list[Path] = []
     for raw in settings_service.settings.components_path or []:
         candidate = Path(raw)
-        try:
-            candidate_resolved = candidate.resolve(strict=False)
-        except OSError:
-            candidate_resolved = candidate
+        candidate_resolved = _resolved_component_path(candidate)
         if candidate_resolved == base_resolved:
             continue
         if candidate.is_dir():
@@ -1433,7 +1441,8 @@ def _finish_component_initialization_task(
 
 def _merge_component_sources(
     builtin: dict[str, Any],
-    *sources: dict[str, Any],
+    custom: dict[str, Any] | None = None,
+    extension: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Merge component sources per COMPONENT, later sources winning on a name collision.
 
@@ -1444,19 +1453,33 @@ def _merge_component_sources(
     components then had no registered hash, so ``allow_custom_components=false`` rejected every
     flow that used one -- reporting first-party built-ins as custom components.
 
-    Extension components still win over a same-named *component*, which is what
-    "a manifest-shipping bundle supersedes any same-named legacy entry" was meant to say.
+    Inline extension discovery is the canonical representation of components also found by the
+    legacy custom scanner. Its namespaced registry key differs from the legacy component name, so
+    replace that legacy copy by its ``name`` alias before publishing the extension. This prevents
+    one custom component from appearing twice while preserving unrelated built-in siblings.
 
     Empty categories are dropped: the lazy metadata scanner emits a fixed set of legacy category
     names whether or not anything was found in them, and they would otherwise surface as empty
     palette sections.
     """
+    custom = custom or {}
+    extension = extension or {}
     merged: dict[str, Any] = {category: dict(components) for category, components in builtin.items()}
-    for source in sources:
-        for category, components in source.items():
-            if not components:
-                continue
-            merged.setdefault(category, {}).update(components)
+    for category, components in custom.items():
+        if not components:
+            continue
+        merged.setdefault(category, {}).update(components)
+
+    for category, components in extension.items():
+        if not components:
+            continue
+        target = merged.setdefault(category, {})
+        custom_components = custom.get(category, {})
+        for component_id, component in components.items():
+            legacy_name = component.get("name") if isinstance(component, dict) else None
+            if isinstance(legacy_name, str) and legacy_name in custom_components:
+                target.pop(legacy_name, None)
+            target[component_id] = component
     return merged
 
 

--- a/src/lfx/tests/unit/interface/test_lazy_load_registry_parity.py
+++ b/src/lfx/tests/unit/interface/test_lazy_load_registry_parity.py
@@ -20,8 +20,11 @@ them. It only surfaced with the gate on, because that check returns early when c
 components are allowed.
 """
 
+from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 
+import lfx.interface.components as components_module
 from lfx.interface.components import (
     BASE_COMPONENTS_PATH,
     _determine_loading_strategy,
@@ -63,6 +66,26 @@ class TestLazyLoadingSkipsTheBuiltInPath:
 
         assert _flatten(await _determine_loading_strategy(service)) == {}
 
+    async def test_lazy_branch_skips_an_equivalent_built_in_path(self, monkeypatch):
+        """Path spelling must not turn the built-in directory into a custom source."""
+        metadata_loader = AsyncMock(return_value={})
+        monkeypatch.setattr(components_module, "aget_component_metadata", metadata_loader)
+        service = _SettingsService(_Settings(lazy=True, components_path=[f"{BASE_COMPONENTS_PATH}/./"]))
+
+        assert _flatten(await _determine_loading_strategy(service)) == {}
+        metadata_loader.assert_not_awaited()
+
+    async def test_lazy_branch_skips_a_symlink_to_the_built_in_path(self, monkeypatch, tmp_path: Path):
+        """A symlink alias of the built-in directory must be filtered as the same source."""
+        alias = tmp_path / "components-link"
+        alias.symlink_to(Path(BASE_COMPONENTS_PATH), target_is_directory=True)
+        metadata_loader = AsyncMock(return_value={})
+        monkeypatch.setattr(components_module, "aget_component_metadata", metadata_loader)
+        service = _SettingsService(_Settings(lazy=True, components_path=[str(alias)]))
+
+        assert _flatten(await _determine_loading_strategy(service)) == {}
+        metadata_loader.assert_not_awaited()
+
 
 class TestCategoryMergePreservesBuiltIns:
     """A custom or extension category must supplement a built-in one, never replace it."""
@@ -92,6 +115,27 @@ class TestCategoryMergePreservesBuiltIns:
         merged = _merge_component_sources(builtin, {}, extension)
 
         assert merged["tools"]["Calculator"]["id"] == "extension"
+
+    def test_namespaced_extension_replaces_its_legacy_custom_copy(self):
+        builtin = {"tools": {"Calculator": {"id": "builtin"}, "SearchAPI": {"id": "builtin"}}}
+        custom = {"tools": {"MyTool": {"id": "custom"}}}
+        extension_id = "ext:tools:MyTool@extra"
+        extension = {"tools": {extension_id: {"id": "extension", "name": "MyTool"}}}
+
+        merged = _merge_component_sources(builtin, custom, extension)
+
+        assert set(merged["tools"]) == {"Calculator", "SearchAPI", extension_id}
+
+    def test_namespaced_custom_override_hides_the_same_named_builtin(self):
+        builtin = {"tools": {"Calculator": {"id": "builtin"}, "SearchAPI": {"id": "builtin"}}}
+        custom = {"tools": {"Calculator": {"id": "custom"}}}
+        extension_id = "ext:tools:CalculatorComponent@extra"
+        extension = {"tools": {extension_id: {"id": "extension", "name": "Calculator"}}}
+
+        merged = _merge_component_sources(builtin, custom, extension)
+
+        assert set(merged["tools"]) == {"SearchAPI", extension_id}
+        assert merged["tools"][extension_id]["id"] == "extension"
 
     def test_the_built_in_source_is_not_mutated(self):
         """The registry is a process-wide cache; merging must not write through to it."""

--- a/src/lfx/tests/unit/interface/test_lazy_load_registry_parity.py
+++ b/src/lfx/tests/unit/interface/test_lazy_load_registry_parity.py
@@ -1,0 +1,127 @@
+"""Lazy component loading must not damage the built-in registry.
+
+``LANGFLOW_LAZY_LOAD_COMPONENTS=true`` combined with
+``LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false`` blocked every flow in the product, reporting
+first-party built-ins as custom components::
+
+    Flow build blocked: custom components are not allowed: Chat Input (ChatInput-b6UCc), ...
+
+Two defects combined:
+
+1. ``_determine_loading_strategy`` filtered ``BASE_COMPONENTS_PATH`` out of the full-loading
+   branch but not the lazy branch, so lazy mode rescanned the *built-in* component directory
+   and produced metadata-only stubs keyed by directory and file name.
+2. The cache initializer merged those results per CATEGORY (``{**builtin, **custom}``), so a
+   category present in both -- "tools", "embeddings", "utilities" -- had its entire built-in
+   contents replaced rather than supplemented.
+
+The built-in components then had no registered hash, so ``check_flow_and_raise`` rejected
+them. It only surfaced with the gate on, because that check returns early when custom
+components are allowed.
+"""
+
+from typing import Any
+
+from lfx.interface.components import (
+    BASE_COMPONENTS_PATH,
+    _determine_loading_strategy,
+    _merge_component_sources,
+)
+
+
+class _Settings:
+    def __init__(self, *, lazy: bool, components_path: list[str]):
+        self.lazy_load_components = lazy
+        self.components_path = components_path
+
+
+class _SettingsService:
+    def __init__(self, settings: _Settings):
+        self.settings = settings
+
+
+def _flatten(result: dict[str, Any]) -> dict[str, Any]:
+    return result.get("components", result) or {}
+
+
+class TestLazyLoadingSkipsTheBuiltInPath:
+    """Both branches load *custom* components; built-ins come from the prebuilt index."""
+
+    async def test_lazy_branch_does_not_rescan_the_built_in_directory(self):
+        service = _SettingsService(_Settings(lazy=True, components_path=[BASE_COMPONENTS_PATH]))
+
+        result = _flatten(await _determine_loading_strategy(service))
+
+        assert result == {}, (
+            "lazy loading rescanned BASE_COMPONENTS_PATH; its metadata-only stubs overwrite the "
+            f"built-ins loaded from the index (got {len(result)} categories)"
+        )
+
+    async def test_full_branch_does_not_rescan_the_built_in_directory(self):
+        """The behaviour the lazy branch was missing -- pinned so the pair cannot drift apart."""
+        service = _SettingsService(_Settings(lazy=False, components_path=[BASE_COMPONENTS_PATH]))
+
+        assert _flatten(await _determine_loading_strategy(service)) == {}
+
+
+class TestCategoryMergePreservesBuiltIns:
+    """A custom or extension category must supplement a built-in one, never replace it."""
+
+    def test_a_colliding_category_does_not_delete_built_in_components(self):
+        builtin = {"tools": {"Calculator": {"id": "builtin"}, "SearchAPI": {"id": "builtin"}}}
+        custom = {"tools": {"MyTool": {"id": "custom"}}}
+
+        merged = _merge_component_sources(builtin, custom)
+
+        assert set(merged["tools"]) == {"Calculator", "SearchAPI", "MyTool"}
+
+    def test_an_empty_scanned_category_does_not_erase_a_built_in_one(self):
+        """The metadata scanner emits legacy category names whether or not they hold anything."""
+        builtin = {"embeddings": {"OpenAIEmbeddings": {"id": "builtin"}}}
+        custom = {"embeddings": {}, "llms": {}, "prompts": {}}
+
+        merged = _merge_component_sources(builtin, custom)
+
+        assert set(merged["embeddings"]) == {"OpenAIEmbeddings"}
+        assert "llms" not in merged, "empty scanned categories should not surface as empty palette sections"
+
+    def test_extension_still_wins_on_a_same_named_component(self):
+        builtin = {"tools": {"Calculator": {"id": "builtin"}}}
+        extension = {"tools": {"Calculator": {"id": "extension"}}}
+
+        merged = _merge_component_sources(builtin, {}, extension)
+
+        assert merged["tools"]["Calculator"]["id"] == "extension"
+
+    def test_the_built_in_source_is_not_mutated(self):
+        """The registry is a process-wide cache; merging must not write through to it."""
+        builtin = {"tools": {"Calculator": {"id": "builtin"}}}
+
+        _merge_component_sources(builtin, {"tools": {"MyTool": {"id": "custom"}}})
+
+        assert set(builtin["tools"]) == {"Calculator"}
+
+
+class TestRegistryParityAcrossModes:
+    """The end-to-end invariant: lazy mode must not shrink what the server knows."""
+
+    async def test_lazy_and_full_registries_agree_on_built_ins(self):
+        from lfx.interface.components import import_langflow_components
+
+        builtin = (await import_langflow_components(None, None))["components"]
+
+        async def registry(*, lazy: bool) -> dict[str, Any]:
+            service = _SettingsService(_Settings(lazy=lazy, components_path=[BASE_COMPONENTS_PATH]))
+            custom = _flatten(await _determine_loading_strategy(service))
+            return _merge_component_sources(builtin, custom)
+
+        lazy_registry = await registry(lazy=True)
+        full_registry = await registry(lazy=False)
+
+        def counts(reg: dict[str, Any]) -> tuple[int, int]:
+            return len(reg), sum(len(c) for c in reg.values())
+
+        assert counts(lazy_registry) == counts(full_registry)
+        assert any("ChatInput" in comps for comps in lazy_registry.values()), (
+            "ChatInput missing from the lazy registry; built-in components would read as custom"
+        )


### PR DESCRIPTION
### Problem

`LANGFLOW_LAZY_LOAD_COMPONENTS=true` combined with
`LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` blocked every flow in the product, reporting first-party built-ins as custom components:

    Flow build blocked: custom components are not allowed:
    Chat Input (ChatInput-b6UCc), Prompt (Prompt-rQ5Up), ...

Verified against the starter projects through Graph.from_payload: 0/8 built with lazy loading on, 8/8 with it off.

Two causes:

* _determine_loading_strategy filtered BASE_COMPONENTS_PATH out of the full-loading branch but not the lazy branch. Built-ins already come from the prebuilt index, so rescanning that directory did not add them, it produced metadata-only stubs keyed by directory and file name.

* The cache initializer merged sources per category ({**builtin, **custom}), so a category present in both -- "tools", "embeddings", "utilities" -- had its built-in contents replaced rather than supplemented. The lazy metadata scanner emits those legacy category names whether or not it found anything in them, so merely configuring a custom components path deleted 15 built-in components.

The built-ins then had no registered hash, so check_flow_and_raise rejected them. It only surfaced with the gate on, because that check returns early when custom components are allowed, which is why it went unnoticed.

-----

### Fix
 1. Lazy component loading no longer corrupts the component registry. Previously LANGFLOW_LAZY_LOAD_COMPONENTS=true wiped the built-ins, which made every first-party component look custom — so with allow_custom_components=false every flow was rejected.
2. A custom component in a category that already exists (tools, embeddings, utilities) is now added to that category instead of replacing its contents. A component with the same name still takes precedence, as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected component loading so custom paths are handled consistently in lazy and full loading modes.
  - Preserved built-in components when custom components share a category, while allowing same-named custom components to override them.
  - Fixed lazy-loaded components so they are properly hydrated and available when needed.
  - Removed empty component categories from the resulting registry.
- **Tests**
  - Added coverage confirming equivalent results between lazy and full loading modes.
  - Added tests for path filtering, component merging, and registry integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->