### PR TITLE
fix(logging): stop one ERROR line from OOM-killing the container with LANGFLOW_LOG_FILE set

### DIFF
--- a/src/backend/base/langflow/server.py
+++ b/src/backend/base/langflow/server.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from gunicorn import glogging
 from gunicorn.app.base import BaseApplication
-from lfx.log.logger import InterceptHandler
+from lfx.log.logger import InterceptHandler, get_file_handler, structlog_routes_to_stdlib
 from uvicorn.workers import UvicornWorker
 
 
@@ -59,9 +59,15 @@ class LangflowUvicornWorker(UvicornWorker):
 class Logger(glogging.Logger):
     """Implements and overrides the gunicorn logging interface.
 
-    This class inherits from the standard gunicorn logger and overrides it by
-    replacing the handlers with `InterceptHandler` in order to route the
-    gunicorn logs to loguru.
+    This class inherits from the standard gunicorn logger and overrides it so
+    gunicorn's records join Langflow's log output instead of gunicorn's own.
+
+    How they get there depends on which mode structlog is in, because
+    ``uvicorn.workers.UvicornWorker.__init__`` copies whatever handler list ends up
+    on ``gunicorn.error``/``gunicorn.access`` onto ``uvicorn.error``/``uvicorn.access``
+    and sets ``propagate = False``. Whatever is installed here is therefore also
+    what every uvicorn record in the worker gets, with no fallback to the root
+    logger. See ``_install_handlers``.
     """
 
     def __init__(self, cfg) -> None:
@@ -69,8 +75,42 @@ class Logger(glogging.Logger):
         logging.getLogger("gunicorn.error").setLevel(logging.WARNING)
         logging.getLogger("gunicorn.access").setLevel(logging.WARNING)
 
-        logging.getLogger("gunicorn.error").handlers = [InterceptHandler()]
-        logging.getLogger("gunicorn.access").handlers = [InterceptHandler()]
+        self._install_handlers("gunicorn.error")
+        self._install_handlers("gunicorn.access")
+
+    @staticmethod
+    def _install_handlers(name: str) -> None:
+        """Give ``name`` a handler that terminates, never one that cycles.
+
+        In stdout mode structlog renders directly, so an ``InterceptHandler`` is a
+        terminating sink and the behaviour is unchanged.
+
+        In log-file mode structlog is backed by the stdlib factory, so
+        ``InterceptHandler`` would hand the record to a structlog logger that
+        resolves right back to *this* logger -- a cycle that grows the payload
+        every lap until the process is OOM-killed. Attach the rotating file handler
+        directly instead. It has to be the handler itself rather than an empty list
+        plus ``propagate = True``: ``UvicornWorker`` copies this list and turns
+        propagation off, so an empty list would silently drop every uvicorn record.
+        """
+        stdlib_logger = logging.getLogger(name)
+
+        if not structlog_routes_to_stdlib():
+            stdlib_logger.handlers = [InterceptHandler()]
+            return
+
+        file_handler = get_file_handler()
+        if file_handler is None:
+            # File mode without a file handler should not happen, but falling back
+            # to propagation loses records rather than looping them.
+            stdlib_logger.handlers = []
+            stdlib_logger.propagate = True
+            return
+
+        stdlib_logger.handlers = [file_handler]
+        # The handler is attached directly, so propagating to root -- which owns
+        # that same handler -- would write every record twice.
+        stdlib_logger.propagate = False
 
     def error(self, msg, *args, **kwargs):
         """Override error method to filter out SIGSEGV messages."""

--- a/src/backend/tests/unit/test_logger.py
+++ b/src/backend/tests/unit/test_logger.py
@@ -32,6 +32,7 @@ from lfx.log.logger import (
     log_buffer,
     setup_gunicorn_logger,
     setup_uvicorn_logger,
+    structlog_routes_to_stdlib,
 )
 from loguru import logger as loguru_logger
 
@@ -479,6 +480,116 @@ class TestInterceptHandler:
 
         self.handler.emit(record)
         self.mock_logger.info.assert_called_once_with("Message with string and 42")
+
+
+class TestInterceptHandlerReentrancy:
+    """Regression cover for the LE-2454 / #14776 logging cycle.
+
+    When structlog is backed by the stdlib factory, the structlog call inside
+    ``emit`` resolves to the same stdlib logger the handler is attached to, so the
+    record comes straight back in -- carrying the previous lap's rendered payload.
+    ``emit`` drops a record that arrives while the thread is already inside it.
+    """
+
+    # A regression here recurses until memory runs out. Cap the laps so the test
+    # fails an assert in milliseconds instead of taking CI down with it.
+    LAP_CAP = 10
+
+    def _record(self, message="boom"):
+        return logging.LogRecord(
+            name="gunicorn.error",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg=message,
+            args=(),
+            exc_info=None,
+        )
+
+    def test_reentrant_record_is_dropped(self):
+        """The record that re-enters emit() is dropped rather than forwarded again."""
+        handler = InterceptHandler()
+        forwarded = []
+
+        class CyclingLogger:
+            """Stands in for the stdlib-backed structlog logger that feeds emit()."""
+
+            def error(inner_self, message, **_kwargs):  # noqa: N805
+                forwarded.append(message)
+                if len(forwarded) > TestInterceptHandlerReentrancy.LAP_CAP:
+                    msg = "emit() cycled past the lap cap -- the re-entrancy guard is gone"
+                    raise AssertionError(msg)
+                # Exactly what the stdlib logger does in file mode: hand the
+                # rendered payload straight back to the handler that emitted it.
+                handler.emit(self._record(f"rendered({message})"))
+
+        with patch("structlog.get_logger", return_value=CyclingLogger()):
+            handler.emit(self._record())
+
+        assert forwarded == ["boom"]
+
+    def test_guard_is_released_after_a_successful_emit(self):
+        """A completed emit must not leave the thread's logging wedged shut."""
+        handler = InterceptHandler()
+        mock_logger = Mock()
+
+        with patch("structlog.get_logger", return_value=mock_logger):
+            handler.emit(self._record("first"))
+            handler.emit(self._record("second"))
+
+        assert [call.args[0] for call in mock_logger.error.call_args_list] == ["first", "second"]
+
+    def test_guard_is_released_after_handle_error(self):
+        """One malformed record must not silence every record after it."""
+        handler = InterceptHandler()
+        mock_logger = Mock()
+
+        with (
+            patch("structlog.get_logger", side_effect=RuntimeError("broken")),
+            patch.object(handler, "handleError") as mock_handle_error,
+        ):
+            handler.emit(self._record("explodes"))
+        assert mock_handle_error.called
+
+        with patch("structlog.get_logger", return_value=mock_logger):
+            handler.emit(self._record("still works"))
+        mock_logger.error.assert_called_once_with("still works")
+
+
+class TestStructlogRoutesToStdlib:
+    """``structlog_routes_to_stdlib()`` is what callers check before intercepting."""
+
+    def test_false_without_a_log_file(self):
+        """Stdout mode renders directly, so an intercept terminates safely."""
+        configure(log_level="ERROR")
+
+        assert structlog_routes_to_stdlib() is False
+
+    def test_true_with_a_log_file(self, tmp_path):
+        """File mode routes structlog back through stdlib -- intercepting would cycle."""
+        configure(log_level="ERROR", log_file=tmp_path / "langflow.log")
+
+        assert structlog_routes_to_stdlib() is True
+
+
+class TestRootInterceptAcrossModes:
+    """The root intercept must not survive the switch into log-file mode.
+
+    ``--log-file`` carries no ``envvar``, so a JSON-mode process can install the
+    root intercept at import time (``json_mode and not log_file``) and only learn
+    about the log file on the next ``configure()``. Left in place, that handler is
+    the root-logger form of the LE-2454 cycle.
+    """
+
+    def test_root_intercept_is_dropped_when_a_log_file_arrives(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_LOG_ENV", "container")
+
+        configure(log_level="ERROR", log_env="container")
+        assert any(isinstance(h, InterceptHandler) for h in logging.root.handlers)
+
+        configure(log_level="ERROR", log_env="container", log_file=tmp_path / "langflow.log")
+
+        assert not any(isinstance(h, InterceptHandler) for h in logging.root.handlers)
 
 
 class TestSetupFunctions:

--- a/src/backend/tests/unit/test_server_logger.py
+++ b/src/backend/tests/unit/test_server_logger.py
@@ -1,0 +1,234 @@
+"""Tests for ``langflow.server.Logger``'s stdlib logging wiring.
+
+Regression cover for LE-2454 / #14776: with ``LANGFLOW_LOG_FILE`` set, the
+gunicorn loggers used to be given an ``InterceptHandler`` unconditionally. In that
+mode ``structlog.get_logger(name)`` resolves back to the stdlib logger of the same
+name, so the handler fed the logger it was attached to and the record cycled,
+growing every lap until the process was OOM-killed.
+
+Three things have to hold, and each is easy to break independently:
+
+* stdout mode keeps the intercept (unchanged behaviour);
+* file mode attaches the rotating file handler *itself*, not an empty list --
+  ``UvicornWorker`` copies this list onto the uvicorn loggers and sets
+  ``propagate = False``, so an empty list silently drops every uvicorn record;
+* it must hold when ``configure()`` already ran before the ``Logger`` is built,
+  because the repeat call early-returns on an unchanged fingerprint and never
+  re-runs ``setup_gunicorn_logger()``.
+"""
+
+import contextlib
+import importlib
+import logging
+from pathlib import Path
+
+import pytest
+import structlog
+from gunicorn.config import Config
+from langflow.server import Logger
+from lfx.log.logger import InterceptHandler, configure, get_file_handler
+
+# A cycle regression would recurse until the machine gives out. Cap the number of
+# times ``InterceptHandler.emit`` may run per test so a regression fails an assert
+# in milliseconds instead of exhausting CI memory.
+EMIT_CAP = 20
+
+GUNICORN_LOGGERS = ("gunicorn.error", "gunicorn.access")
+UVICORN_LOGGERS = ("uvicorn.error", "uvicorn.access")
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_state():
+    """Snapshot and restore every process-global this module rewires.
+
+    ``configure(log_file=...)`` sets ``logging.root``'s level, installs a
+    ``RotatingFileHandler`` on the root logger and stores it in the
+    ``lfx.log.logger._file_handler`` module global. ``Logger.__init__`` then edits
+    the gunicorn loggers, and the uvicorn tests edit theirs. None of that is
+    undone automatically, and leaking a handler pointed at a deleted tmp_path into
+    a later test is how this module would poison an xdist worker.
+    """
+    lfx_log = importlib.import_module("lfx.log.logger")
+
+    orig_structlog_config = dict(structlog.get_config())
+    orig_root_handlers = logging.root.handlers[:]
+    orig_root_level = logging.root.level
+    orig_file_handler = lfx_log._file_handler
+    orig_named = {
+        name: (lg.handlers[:], lg.level, lg.propagate)
+        for name in (*GUNICORN_LOGGERS, *UVICORN_LOGGERS)
+        if (lg := logging.getLogger(name))
+    }
+
+    yield
+
+    # Close any file handler this test opened before putting the old one back,
+    # otherwise the fd leaks and the tmp_path cannot be cleaned up on Windows.
+    for handler in logging.root.handlers[:]:
+        if handler not in orig_root_handlers:
+            logging.root.removeHandler(handler)
+            with contextlib.suppress(OSError, ValueError):
+                handler.close()
+
+    # If configure() replaced the lfx-managed file handler it also *closed* the
+    # original, so reinstalling that one would put a handler pointed at a
+    # torn-down tmp_path back on the root logger -- where the next record silently
+    # re-creates the file or fails into handleError. Drop it instead, exactly as
+    # the module fixture in test_logger.py does.
+    restored_handlers = orig_root_handlers
+    if lfx_log._file_handler is not orig_file_handler:
+        restored_handlers = [h for h in orig_root_handlers if h is not orig_file_handler]
+        lfx_log._file_handler = None
+    else:
+        lfx_log._file_handler = orig_file_handler
+
+    logging.root.handlers[:] = restored_handlers
+    logging.root.setLevel(orig_root_level)
+    for name, (handlers, level, propagate) in orig_named.items():
+        lg = logging.getLogger(name)
+        lg.handlers[:] = handlers
+        lg.setLevel(level)
+        lg.propagate = propagate
+
+    structlog.configure(**orig_structlog_config)
+
+
+@pytest.fixture
+def capped_emit(monkeypatch):
+    """Count ``InterceptHandler.emit`` calls and abort past ``EMIT_CAP``."""
+    calls = []
+    original = InterceptHandler.emit
+
+    def counting_emit(self, record):
+        calls.append(record)
+        if len(calls) > EMIT_CAP:
+            msg = f"InterceptHandler.emit re-entered more than {EMIT_CAP} times -- the LE-2454 cycle is back"
+            raise AssertionError(msg)
+        return original(self, record)
+
+    monkeypatch.setattr(InterceptHandler, "emit", counting_emit)
+    return calls
+
+
+def _gunicorn_config() -> Config:
+    cfg = Config()
+    cfg.set("loglevel", "info")
+    return cfg
+
+
+def _read_log(log_file: Path) -> list[str]:
+    handler = get_file_handler()
+    if handler is not None:
+        handler.flush()
+    if not log_file.exists():
+        return []
+    return [line for line in log_file.read_text().splitlines() if line]
+
+
+class TestHandlerWiring:
+    """Which handler each mode installs on the gunicorn loggers."""
+
+    def test_stdout_mode_keeps_the_intercept_handler(self):
+        """With no log file structlog renders directly, so the intercept terminates."""
+        configure(log_level="ERROR")
+
+        Logger(_gunicorn_config())
+
+        for name in GUNICORN_LOGGERS:
+            handlers = logging.getLogger(name).handlers
+            assert len(handlers) == 1
+            assert isinstance(handlers[0], InterceptHandler)
+
+    def test_file_mode_attaches_the_file_handler_instead(self, tmp_path):
+        """In file mode an intercept would cycle, so the file handler is attached directly."""
+        configure(log_level="ERROR", log_file=tmp_path / "langflow.log")
+
+        Logger(_gunicorn_config())
+
+        for name in GUNICORN_LOGGERS:
+            lg = logging.getLogger(name)
+            assert not any(isinstance(h, InterceptHandler) for h in lg.handlers)
+            assert lg.handlers == [get_file_handler()]
+            # The handler is attached directly; propagating to root -- which owns
+            # that same handler -- would write every record twice.
+            assert lg.propagate is False
+
+
+class TestRecordsReachTheFile:
+    """One record in, one line out, in the modes that used to lose or loop it."""
+
+    def test_gunicorn_error_is_written_exactly_once(self, tmp_path, capped_emit):
+        log_file = tmp_path / "langflow.log"
+        configure(log_level="ERROR", log_file=log_file)
+        Logger(_gunicorn_config())
+
+        logging.getLogger("gunicorn.error").error("boom")
+
+        assert _read_log(log_file) == ["boom"]
+        assert capped_emit == []
+
+    def test_uvicorn_logger_inherits_a_terminating_handler(self, tmp_path, capped_emit):
+        """Replicates ``UvicornWorker.__init__``'s handler copy.
+
+        uvicorn assigns gunicorn's handler *list* to the uvicorn loggers and turns
+        propagation off, so whatever ``Logger`` installed is the only thing standing
+        between a uvicorn record and the void.
+        """
+        log_file = tmp_path / "langflow.log"
+        configure(log_level="ERROR", log_file=log_file)
+        Logger(_gunicorn_config())
+
+        for gunicorn_name, uvicorn_name in zip(GUNICORN_LOGGERS, UVICORN_LOGGERS, strict=True):
+            uvicorn_logger = logging.getLogger(uvicorn_name)
+            uvicorn_logger.handlers = logging.getLogger(gunicorn_name).handlers
+            uvicorn_logger.setLevel(logging.WARNING)
+            uvicorn_logger.propagate = False
+
+        logging.getLogger("uvicorn.error").error("boom")
+
+        assert _read_log(log_file) == ["boom"]
+        assert capped_emit == []
+
+    def test_holds_when_configure_early_returns(self, tmp_path, capped_emit):
+        """LE-2454's deciding variable: ``configure()`` ran before the ``Logger``.
+
+        This is the real boot order -- ``langflow/__main__.py`` configures logging
+        long before ``LangflowApplication`` is constructed. The app's later
+        ``configure()`` call carries identical arguments, so it early-returns on the
+        unchanged fingerprint and never reaches ``setup_gunicorn_logger()``. Nothing
+        cleans up after ``Logger.__init__``, which is why the fix cannot rely on it.
+        """
+        log_file = tmp_path / "langflow.log"
+        configure(log_level="ERROR", log_file=log_file)
+        Logger(_gunicorn_config())
+
+        # Same arguments -> unchanged fingerprint -> early return.
+        configure(log_level="ERROR", log_file=log_file)
+
+        assert not any(isinstance(h, InterceptHandler) for h in logging.getLogger("gunicorn.error").handlers)
+
+        logging.getLogger("gunicorn.error").error("boom")
+
+        assert _read_log(log_file) == ["boom"]
+        assert capped_emit == []
+
+    def test_large_record_is_not_amplified(self, tmp_path, capped_emit):
+        """Pretty mode's failure was a threshold, not an absence.
+
+        Each lap of the cycle carried a copy of the previous message, so peak memory
+        and bytes-on-disk scaled with the size of the originating record: a 4-byte
+        message survived while a 10 MB one OOM-killed the process. A short-message
+        test therefore passes against the unfixed code -- this one has to be big.
+        """
+        log_file = tmp_path / "langflow.log"
+        configure(log_level="ERROR", log_file=log_file)
+        Logger(_gunicorn_config())
+
+        payload = "x" * 1_000_000
+        logging.getLogger("gunicorn.error").error(payload)
+
+        lines = _read_log(log_file)
+        assert lines == [payload]
+        # Written once, not once per lap.
+        assert log_file.stat().st_size < 2 * len(payload)
+        assert capped_emit == []

--- a/src/lfx/src/lfx/log/logger.py
+++ b/src/lfx/src/lfx/log/logger.py
@@ -11,7 +11,7 @@ from collections import deque
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from threading import Lock, Semaphore
+from threading import Lock, Semaphore, local
 from typing import Any, TypedDict
 
 import orjson
@@ -957,6 +957,33 @@ def setup_log_file(log_file: Path, *, max_bytes: int, formatter: logging.Formatt
     logging.root.addHandler(_file_handler)
 
 
+def get_file_handler() -> logging.handlers.RotatingFileHandler | None:
+    """Return the rotating file handler ``setup_log_file`` installed, if any.
+
+    Callers that need to hand a stdlib logger a terminating handler -- rather than
+    relying on propagation to the root logger -- reach for this. See
+    ``langflow.server.Logger``, which has to do exactly that because
+    ``uvicorn.workers.UvicornWorker`` copies the gunicorn handler list onto the
+    uvicorn loggers and sets ``propagate = False``.
+    """
+    return _file_handler
+
+
+def structlog_routes_to_stdlib() -> bool:
+    """Report whether structlog writes back out through the stdlib logging tree.
+
+    ``configure()`` selects ``structlog.stdlib.LoggerFactory`` whenever a log file
+    is configured, which makes ``structlog.get_logger(name)`` resolve to *the stdlib
+    logger of that same name*. Installing an ``InterceptHandler`` on a stdlib logger
+    in that mode builds a cycle: the handler feeds structlog, which writes straight
+    back out to the logger the handler is attached to. Anything that installs an
+    intercept must check this first.
+    """
+    if not structlog.is_configured():
+        return False
+    return isinstance(structlog.get_config().get("logger_factory"), structlog.stdlib.LoggerFactory)
+
+
 class LogConfig(TypedDict):
     """Configuration for logging."""
 
@@ -1220,6 +1247,14 @@ def configure(
     )
     if json_mode and not log_file:
         _install_stdlib_intercept(numeric_level)
+    elif log_file:
+        # From here structlog resolves back into the stdlib tree, so a root
+        # intercept left over from an earlier stdout-mode configure() would feed
+        # every record back into the logger it just came from. The guard in
+        # ``InterceptHandler.emit`` keeps that from looping, but the record would
+        # still be written twice -- once by the intercept's structlog call and
+        # once by the original record reaching the file handler.
+        _remove_stdlib_intercept()
 
     # Apply per-logger level overrides last so user env beats library defaults.
     _apply_logger_level_overrides()
@@ -1307,6 +1342,14 @@ def add_stdlib_log_level_from_record(_logger: Any, method_name: str, event_dict:
 _RESERVED_LOGRECORD_ATTRS = frozenset(logging.makeLogRecord({}).__dict__) | {"message", "asctime"}
 
 
+# Set while a thread is inside ``InterceptHandler.emit``. Guards against the
+# handler being re-entered by the very structlog call it just made -- see
+# ``InterceptHandler.emit``. Thread-local because the cycle is synchronous and
+# within one thread; a global flag would make concurrent threads drop each
+# other's records.
+_emit_state = local()
+
+
 class InterceptHandler(logging.Handler):
     """Route stdlib logging records into structlog.
 
@@ -1317,6 +1360,17 @@ class InterceptHandler(logging.Handler):
     """
 
     def emit(self, record: logging.LogRecord) -> None:
+        # Re-entrancy guard. When structlog is backed by the stdlib factory
+        # (see ``structlog_routes_to_stdlib``), the structlog call below resolves
+        # to the same stdlib logger this handler is attached to, so the record
+        # comes straight back here -- carrying the previous lap's rendered payload
+        # as its message. Left alone that cycles until the process dies. Dropping
+        # the re-entrant record is the only safe answer: a logging handler must
+        # never take down the process it instruments, and the record is already
+        # being handled by the lap that caused the re-entry.
+        if getattr(_emit_state, "active", False):
+            return
+        _emit_state.active = True
         # Mirrors the stdlib Handler.emit safety net: a malformed third-party
         # log call (e.g. mismatched %-format args) must not propagate up and
         # crash the request path. Anything that raises here is routed to
@@ -1338,6 +1392,10 @@ class InterceptHandler(logging.Handler):
             getattr(structlog_logger, method_name)(record.getMessage(), **kwargs)
         except Exception:  # noqa: BLE001 - logging must never break the caller
             self.handleError(record)
+        finally:
+            # Released even when handleError ran, otherwise one malformed record
+            # would wedge the guard on and silence the thread's logging for good.
+            _emit_state.active = False
 
 
 def _install_stdlib_intercept(numeric_level: int) -> None:
@@ -1355,6 +1413,19 @@ def _install_stdlib_intercept(numeric_level: int) -> None:
         root.addHandler(handler)
     handler.setLevel(numeric_level)
     root.setLevel(numeric_level)
+
+
+def _remove_stdlib_intercept() -> None:
+    """Drop any ``InterceptHandler`` from the stdlib root logger.
+
+    The counterpart to ``_install_stdlib_intercept``, for the switch into log-file
+    mode. Leaving one installed once structlog routes back through stdlib is the
+    root-logger form of the cycle ``structlog_routes_to_stdlib`` exists to warn
+    about.
+    """
+    root = logging.root
+    for handler in [h for h in root.handlers if isinstance(h, InterceptHandler)]:
+        root.removeHandler(handler)
 
 
 # Initialize logger - will be reconfigured when configure() is called


### PR DESCRIPTION
Set `LANGFLOW_LOG_FILE`, log one ERROR line, and the process dies. In a container it's an OOM kill from a single log record — and the line never reaches the log file it was meant to go to.

The cycle is between two halves that are individually reasonable. `configure()` selects `structlog.stdlib.LoggerFactory` whenever a log file is configured, which makes `structlog.get_logger(name)` resolve to *the stdlib logger of that same name*. `Logger.__init__` then installed an `InterceptHandler` on `gunicorn.error`/`gunicorn.access` unconditionally. So a record goes: handler → structlog → the same stdlib logger → the same handler, carrying the previous lap's already-rendered payload as the next message. `configure()` already declines to install the root intercept in this mode (`if json_mode and not log_file`), but the gunicorn path bypassed that check.

It reaches further than gunicorn. `UvicornWorker.__init__` aliases gunicorn's handler *list object* onto `uvicorn.error`/`uvicorn.access` and sets `propagate = False`, so the looping handler lands on the uvicorn loggers in every worker and ordinary in-request code triggers it.

## Fix

- `InterceptHandler.emit` gets a thread-local re-entrancy guard, released in a `finally`. A handler must never take down the process it instruments.
- `Logger` stops intercepting when structlog routes back through stdlib, attaching the rotating file handler itself. It has to be the handler rather than an empty list plus propagation — `UvicornWorker` turns propagation off, so an empty list would silently drop every uvicorn record instead of looping it.
- `configure()` also drops a root intercept left over from an earlier stdout-mode call when a log file arrives. `--log-file` carries no `envvar`, so a JSON-mode process really can install one at import time and only learn about the log file on the next call.

With no log file configured, stdout behaviour is unchanged.

## Two things worth knowing

**It is order-dependent, which makes it easy to "fail to reproduce".** `configure()` early-returns on an unchanged config fingerprint *before* reaching `setup_gunicorn_logger()`/`setup_uvicorn_logger()` — the functions that clear those handlers and are therefore the accidental cleanup. Configure *after* the `Logger` is built and there's no cycle; configure *before*, which is what `langflow run` does, and the worker's repeat call early-returns and the handler survives. The fix decides at install time rather than relying on a later `configure()`, and there's a test pinning exactly that.

**Pretty mode is not the benign mode.** JSON/container mode doubles the payload per lap and dies in ~30 laps. Default pretty mode grows linearly and aborts at ~110 laps on a `RecursionError` that `handleError` swallows — but every lap copies the previous message, so peak RSS scales at roughly 165× the originating record. Measured before the fix: a 4-byte message costs 27 MB and survives; 1 MB costs 167 MB; 10 MB costs 1.65 GB and is killed. A short-message test therefore passes against the unfixed code, so the regression test uses a 1 MB record and asserts peak output stays flat in the message size.

## Verification

Same stock image, same `-m 2g`, same `LANGFLOW_LOG_ENV=container`, both runs mounting this branch's source so the *only* variable is the two changed files:

| | result |
| --- | --- |
| without the fix | `OOMKilled=true ExitCode=137` |
| with the fix | `survived`, `OOMKilled=false ExitCode=0` |

End-to-end through the real gunicorn + `LangflowUvicornWorker` stack at the real boot order, driving `logging.getLogger("uvicorn.error").error(...)` from inside a request: the request used to hang indefinitely with an empty log file and 65 KB of nested `RecursionError` output. It now returns `200` in 0.0 s and writes exactly one line.

Every new test was checked against the unpatched code first: reverting the `server.py` change fails 5 of the 6 new wiring tests (the survivor is the stdout-mode test, which is meant to be unchanged), reverting only the guard fails the re-entrancy test, and removing only the root-intercept hunk fails its own test. The recursion tests carry an emit-depth cap so a future regression fails an assert instead of exhausting CI memory.

## Not fixed here

`add_serialized`/`buffer_writer` aren't in the `ProcessorFormatter` `foreign_pre_chain`, so no foreign stdlib record reaches the log-retrieval buffer in file mode, and pretty file mode gives foreign records a bare `%(message)s` formatter. Both predate this change and apply to every foreign logger, not just gunicorn's; closing that gap would change behaviour across the board and belongs in its own PR.

## Prior art

@shahulmubeen-a reported this in #14776 and proposed a fix in #14777 against `release-1.12.0`, reaching the same three-part shape. This PR is written against `release-1.12.1` and adds coverage for the ordering dependency and the message-size threshold. Happy to close this in favour of theirs if maintainers prefer.

Fixes #14776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging reliability when writing to files, preventing duplicate records, recursive logging, and potential memory issues.
  * Ensured application and server logs are routed correctly in both console and file-output modes.
  * Prevented repeated log entries when logging configuration is refreshed without changes.

* **Tests**
  * Added coverage for logging behavior across console and file configurations, including large and repeated log records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->