### PR TITLE
bug: Memory bases cleanup post flow deletion

### DIFF
--- a/src/backend/base/langflow/api/utils/flow_utils.py
+++ b/src/backend/base/langflow/api/utils/flow_utils.py
@@ -33,6 +33,7 @@ from langflow.services.database.models.vertex_builds.model import VertexBuildTab
 
 if TYPE_CHECKING:
     from langflow.services.chat.service import ChatService
+    from langflow.services.memory_base.flow_cleanup import FlowMemoryBaseCleanup
 
 
 async def _get_flow_name(flow_id: uuid.UUID) -> str:
@@ -100,9 +101,28 @@ async def build_and_cache_graph_from_data(
     return graph
 
 
-async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None:
+async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> list[FlowMemoryBaseCleanup]:
+    """Delete a flow and everything owned by it, atomically on ``session``.
+
+    Returns the external-resource handles for the flow's Memory Bases (remote
+    vector-store collections + local KB directories). Those live outside the
+    database, so they cannot be torn down inside this transaction: the caller
+    must pass the returned list to
+    :func:`~langflow.services.memory_base.flow_cleanup.finalize_flow_memory_base_cleanup`
+    once the transaction has committed. Callers that don't manage Memory Bases
+    can ignore the return value.
+    """
+    # Imported lazily so this module (loaded early, via ``api.utils``) stays free
+    # of the memory-base service import chain.
+    from langflow.services.memory_base.flow_cleanup import purge_flow_memory_bases
+
     try:
         await check_flow_has_deployed_versions(session, flow_id=flow_id)
+        # Reclaim the flow's Memory Bases first: this drops the message_ingestion_record
+        # rows that reference this flow's messages, so the MessageTable delete below
+        # cannot trip an FK constraint. Returns handles for the post-commit external
+        # teardown of remote collections + local KB directories.
+        memory_base_cleanups = await purge_flow_memory_bases(session, flow_id)
         # TODO: Verify if deleting messages is safe in terms of session id relevance
         # If we delete messages directly, rather than setting flow_id to null,
         # it might cause unexpected behaviors because the session id could still be
@@ -137,6 +157,7 @@ async def cascade_delete_flow(session: AsyncSession, flow_id: uuid.UUID) -> None
         )
         msg = f"Unable to cascade delete flow: {flow_id}"
         raise RuntimeError(msg, e) from e
+    return memory_base_cleanups
 
 
 # Public flow file paths must be ``{source_flow_id}/{safe_basename}`` — uploads

--- a/src/backend/base/langflow/api/v1/flows.py
+++ b/src/backend/base/langflow/api/v1/flows.py
@@ -927,13 +927,17 @@ async def delete_flow(
     current_user: CurrentActiveUser,
 ):
     """Delete a flow."""
+    from langflow.services.memory_base.flow_cleanup import FlowMemoryBaseCleanup, finalize_flow_memory_base_cleanup
+
     actor = UserRead.model_validate(current_user, from_attributes=True)
     target_flow_id = flow_id
     flow_owner_ids: dict[UUID, UUID] = {target_flow_id: flow.user_id}
+    memory_base_cleanups: list[FlowMemoryBaseCleanup] = []
 
     async def _delete_attempt(_attempt: int) -> None:
         async def _delete_operation() -> None:
             flow_owner_ids.clear()
+            memory_base_cleanups.clear()
             retry_target = await _read_flow(session, target_flow_id, actor.id)
             if retry_target is None:
                 return
@@ -946,7 +950,7 @@ async def delete_flow(
                 folder_id=retry_target.folder_id,
             )
             flow_owner_ids[retry_target.id] = retry_target.user_id
-            await cascade_delete_flow(session, target_flow_id)
+            memory_base_cleanups.extend(await cascade_delete_flow(session, target_flow_id))
 
         await retry_flow_operation_on_deployment_guard(
             db=session,
@@ -956,6 +960,10 @@ async def delete_flow(
 
     try:
         await run_with_lock_retry(_delete_attempt, session=session, description=f"delete_flow {target_flow_id}")
+        # Commit the deletion before the best-effort external teardown so a
+        # remote collection is dropped only for a flow that is actually gone.
+        await session.commit()
+        await finalize_flow_memory_base_cleanup(memory_base_cleanups)
     except HTTPException:
         raise
     except Exception as exc:
@@ -1220,12 +1228,16 @@ async def delete_multiple_flows(
     db: DbSession,
 ):
     """Delete multiple flows by their IDs."""
+    from langflow.services.memory_base.flow_cleanup import FlowMemoryBaseCleanup, finalize_flow_memory_base_cleanup
+
     actor = UserRead.model_validate(user, from_attributes=True)
     try:
         authorized_flow_owner_ids: dict[UUID, UUID] = {}
+        memory_base_cleanups: list[FlowMemoryBaseCleanup] = []
 
         async def _delete_operation() -> int:
             authorized_flow_owner_ids.clear()
+            memory_base_cleanups.clear()
             if not flow_ids:
                 return 0
             # Widen fetch when cross-user DELETE is supported; else owner-scoped.
@@ -1250,7 +1262,7 @@ async def delete_multiple_flows(
                 )
             authorized_flow_owner_ids.update((flow.id, flow.user_id) for flow in flows_to_delete)
             for flow in flows_to_delete:
-                await cascade_delete_flow(db, flow.id)
+                memory_base_cleanups.extend(await cascade_delete_flow(db, flow.id))
             await db.flush()
             return len(flows_to_delete)
 
@@ -1266,6 +1278,10 @@ async def delete_multiple_flows(
             session=db,
             description=f"delete_multiple_flows count={len(flow_ids)}",
         )
+        # Commit the deletions before the best-effort external teardown so a
+        # remote collection is dropped only for flows that are actually gone.
+        await db.commit()
+        await finalize_flow_memory_base_cleanup(memory_base_cleanups)
     except HTTPException:
         raise
     except Exception as exc:

--- a/src/backend/base/langflow/api/v1/projects.py
+++ b/src/backend/base/langflow/api/v1/projects.py
@@ -1012,14 +1012,19 @@ async def delete_project(
     # only their own (which is the empty set for a non-owner).
     project_owner_id = project.user_id
 
+    from langflow.services.memory_base.flow_cleanup import FlowMemoryBaseCleanup, finalize_flow_memory_base_cleanup
+
+    memory_base_cleanups: list[FlowMemoryBaseCleanup] = []
+
     def _make_delete_operation(target: Folder):
         async def _delete_project_operation() -> None:
+            memory_base_cleanups.clear()
             flows = (
                 await session.exec(select(Flow).where(Flow.folder_id == project_id, Flow.user_id == project_owner_id))
             ).all()
             if len(flows) > 0:
                 for flow in flows:
-                    await cascade_delete_flow(session, flow.id)
+                    memory_base_cleanups.extend(await cascade_delete_flow(session, flow.id))
 
             await check_project_has_deployments(session, project_id=project_id)
             await session.delete(target)
@@ -1033,6 +1038,13 @@ async def delete_project(
     # therefore re-read with awaits — a plain attribute read on expired state
     # would lazy-load outside the greenlet context and raise MissingGreenlet.
     async def _delete_attempt(attempt: int) -> None:
+        # LE-2020 follow-up: a prior attempt may have populated memory_base_cleanups
+        # before hitting a lock error. If this attempt short-circuits below (target
+        # is None — the project was already deleted by a concurrent request), the
+        # clear() inside _delete_project_operation never runs, and the stale handles
+        # from the earlier attempt would flow into finalize_flow_memory_base_cleanup
+        # for a flow that only moved, not deleted. Clear unconditionally, first.
+        memory_base_cleanups.clear()
         if attempt == 0:
             target = project
         else:
@@ -1050,6 +1062,10 @@ async def delete_project(
 
     try:
         await run_with_lock_retry(_delete_attempt, session=session, description=f"delete_project {project_id}")
+        # Commit the deletions before the best-effort external teardown so a
+        # Memory Base's remote collection is dropped only for flows that are gone.
+        await session.commit()
+        await finalize_flow_memory_base_cleanup(memory_base_cleanups)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except Exception as e:
         await araise_if_deployment_guard_error_or_skip(

--- a/src/backend/base/langflow/services/flow/flow_runner.py
+++ b/src/backend/base/langflow/services/flow/flow_runner.py
@@ -217,6 +217,8 @@ class LangflowRunnerExperimental:
 
     @staticmethod
     async def clear_flow_state(flow_dict: dict):
+        from langflow.services.memory_base.flow_cleanup import finalize_flow_memory_base_cleanup
+
         cache_service = get_cache_service()
         if isinstance(cache_service, AsyncBaseCacheService):
             await cache_service.clear()
@@ -225,17 +227,27 @@ class LangflowRunnerExperimental:
         async with session_scope() as session:
             flow_id = flow_dict["id"]
             uuid_obj = flow_id if isinstance(flow_id, UUID) else UUID(str(flow_id))
-            await cascade_delete_flow(session, uuid_obj)
+            memory_base_cleanups = await cascade_delete_flow(session, uuid_obj)
+        # session_scope committed on exit; drop the external resources now.
+        await finalize_flow_memory_base_cleanup(memory_base_cleanups)
 
     @staticmethod
     async def clear_user_state(user_id: str):
+        from langflow.services.memory_base.flow_cleanup import (
+            FlowMemoryBaseCleanup,
+            finalize_flow_memory_base_cleanup,
+        )
+
+        memory_base_cleanups: list[FlowMemoryBaseCleanup] = []
         async with session_scope() as session:
             flows = await session.exec(select(Flow.id).where(Flow.user_id == user_id))
             flow_ids: list[UUID] = [fid for fid in flows.scalars().all() if fid is not None]
             for flow_id in flow_ids:
-                await cascade_delete_flow(session, flow_id)
+                memory_base_cleanups.extend(await cascade_delete_flow(session, flow_id))
             await session.exec(delete(Variable).where(Variable.user_id == user_id))
             await session.exec(delete(User).where(User.id == user_id))
+        # session_scope committed on exit; drop the external resources now.
+        await finalize_flow_memory_base_cleanup(memory_base_cleanups)
 
     async def init_db_if_needed(self):
         if not await self.database_exists_check() and self.should_initialize_db:

--- a/src/backend/base/langflow/services/memory_base/flow_cleanup.py
+++ b/src/backend/base/langflow/services/memory_base/flow_cleanup.py
@@ -1,0 +1,254 @@
+"""Reclaim a flow's Memory Bases when the flow itself is deleted.
+
+A Memory Base is owned by exactly one flow (``memory_base.flow_id``), and is
+meant to die with it. There is no DB-level foreign key from ``memory_base`` to
+``flow`` — the vector-store collection that backs each Memory Base lives outside
+the database and can only be torn down with an explicit call — so the cascade is
+coordinated here in code rather than by the schema. This module is the single
+entry point invoked from ``cascade_delete_flow`` so *every* flow-deletion path
+(single delete, bulk delete, project delete, and the flow runner's state resets)
+reclaims the Memory Bases and their remote collections.
+
+The work is split into two deliberately-separated phases:
+
+* :func:`purge_flow_memory_bases` runs **inside** the flow-deletion transaction,
+  on the caller's session. It removes every ``memory_base`` row (and its
+  children) plus the backing ``knowledge_base`` row, so the database cleanup is
+  atomic with the flow deletion — if the flow deletion rolls back, so does this.
+  It captures the handles needed to reach each remote collection *before*
+  dropping the ``knowledge_base`` rows that carry the backend routing config,
+  and returns them for the second phase.
+* :func:`finalize_flow_memory_base_cleanup` runs the best-effort **external**
+  teardown (remote vector-store collection, then the local Chroma directory).
+  It must run only after the flow-deletion transaction has committed — deleting
+  a remote collection for a flow that then survives a rolled-back transaction
+  would be worse than leaving the collection in place. It never raises: a broken
+  connection to the remote store is logged (the collection is left for manual
+  cleanup) exactly as standalone Memory Base deletion behaves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from lfx.base.knowledge_bases.backends import create_backend, is_local_chroma
+from lfx.log.logger import logger
+from sqlalchemy import delete
+from sqlmodel import col, select
+
+from langflow.api.utils.kb_helpers import _coerce_backend_config_value
+from langflow.services.database.models.knowledge_base.model import KnowledgeBaseRecord
+from langflow.services.database.models.memory_base.model import (
+    MemoryBase,
+    MemoryBasePreprocessingOutput,
+    MemoryBaseSession,
+    MemoryBaseWorkflowRun,
+    MessageIngestionRecord,
+)
+from langflow.services.database.models.user.model import User
+from langflow.services.memory_base.ingestion import cancel_active_jobs
+from langflow.services.memory_base.kb_path_helpers import delete_kb
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@dataclass(frozen=True)
+class FlowMemoryBaseCleanup:
+    """External resources of one deleted Memory Base, captured before its rows go.
+
+    The ``knowledge_base`` row carries the backend routing (``backend_type`` /
+    ``backend_config``) needed to reach a remote collection, and the row is
+    dropped inside the flow-deletion transaction — so everything the external
+    teardown needs is snapshotted here first.
+    """
+
+    kb_name: str
+    user_id: UUID
+    # ``None`` when the owning user could not be resolved (e.g. the user is being
+    # deleted in the same transaction); the on-disk path cannot be built without
+    # it, so local-Chroma disk cleanup is skipped in that case.
+    kb_username: str | None
+    backend_type: str
+    backend_config: dict = field(default_factory=dict)
+
+
+async def purge_flow_memory_bases(session: AsyncSession, flow_id: UUID) -> list[FlowMemoryBaseCleanup]:
+    """Delete the DB rows for every Memory Base owned by ``flow_id``.
+
+    Runs on the caller's session so the deletions commit (or roll back) together
+    with the flow deletion. Removes the ``memory_base`` rows, their child rows
+    (sessions, workflow runs, ingestion records, preprocessing outputs) and the
+    backing ``knowledge_base`` rows. The child deletes are explicit because
+    SQLite does not honor ``ON DELETE CASCADE`` unless ``PRAGMA foreign_keys`` is
+    on — matching the surrounding ``cascade_delete_flow`` convention.
+
+    Returns one :class:`FlowMemoryBaseCleanup` per Memory Base so the caller can
+    run :func:`finalize_flow_memory_base_cleanup` after the transaction commits.
+    No external I/O happens here.
+    """
+    memory_bases = list((await session.exec(select(MemoryBase).where(MemoryBase.flow_id == flow_id))).all())
+    if not memory_bases:
+        return []
+
+    # Resolve each owner's username once (KB directories are laid out under it).
+    username_cache: dict[UUID, str | None] = {}
+
+    async def _resolve_username(user_id: UUID) -> str | None:
+        if user_id not in username_cache:
+            username_cache[user_id] = (await session.exec(select(User.username).where(User.id == user_id))).first()
+        return username_cache[user_id]
+
+    handles: list[FlowMemoryBaseCleanup] = []
+    kb_record_ids: list[UUID] = []
+    for mb in memory_bases:
+        # Cancel in-flight ingestion so a running job cannot write to a
+        # collection we are about to drop. Best-effort — never let job teardown
+        # block the flow deletion.
+        try:
+            await cancel_active_jobs(memory_base_id=mb.id, db=session)
+        except Exception as exc:  # noqa: BLE001 — job teardown is best-effort
+            await logger.awarning(
+                "Could not cancel ingestion jobs for Memory Base %s during flow deletion: %s", mb.id, exc
+            )
+
+        # Snapshot backend routing from the knowledge_base row BEFORE it is
+        # deleted below — the remote teardown in phase two needs it.
+        kb_record = (
+            await session.exec(
+                select(KnowledgeBaseRecord)
+                .where(KnowledgeBaseRecord.user_id == mb.user_id)
+                .where(KnowledgeBaseRecord.name == mb.kb_name)
+            )
+        ).first()
+        if kb_record is not None:
+            backend_type = kb_record.backend_type or "chroma"
+            backend_config = _coerce_backend_config_value(kb_record.backend_config)
+            kb_record_ids.append(kb_record.id)
+        else:
+            # No row to resolve a remote backend from; treat as local so the
+            # only cleanup attempted is the on-disk directory (a no-op if absent).
+            backend_type = "chroma"
+            backend_config = {}
+
+        handles.append(
+            FlowMemoryBaseCleanup(
+                kb_name=mb.kb_name,
+                user_id=mb.user_id,
+                kb_username=await _resolve_username(mb.user_id),
+                backend_type=backend_type,
+                backend_config=backend_config,
+            )
+        )
+
+    memory_base_ids = [mb.id for mb in memory_bases]
+
+    # Children first (explicit — SQLite does not enforce FK cascades), then the
+    # memory_base rows, then the backing knowledge_base rows.
+    await session.exec(
+        delete(MessageIngestionRecord).where(col(MessageIngestionRecord.memory_base_id).in_(memory_base_ids))
+    )
+    await session.exec(
+        delete(MemoryBaseWorkflowRun).where(col(MemoryBaseWorkflowRun.memory_base_id).in_(memory_base_ids))
+    )
+    await session.exec(
+        delete(MemoryBasePreprocessingOutput).where(
+            col(MemoryBasePreprocessingOutput.memory_base_id).in_(memory_base_ids)
+        )
+    )
+    await session.exec(delete(MemoryBaseSession).where(col(MemoryBaseSession.memory_base_id).in_(memory_base_ids)))
+    await session.exec(delete(MemoryBase).where(col(MemoryBase.id).in_(memory_base_ids)))
+    if kb_record_ids:
+        await session.exec(delete(KnowledgeBaseRecord).where(col(KnowledgeBaseRecord.id).in_(kb_record_ids)))
+
+    return handles
+
+
+async def finalize_flow_memory_base_cleanup(handles: list[FlowMemoryBaseCleanup]) -> None:
+    """Drop the external resources captured by :func:`purge_flow_memory_bases`.
+
+    Call this only after the flow-deletion transaction has committed. For each
+    Memory Base it drops the remote vector-store collection (skipped for local
+    Chroma, whose vectors live on disk) and then removes the local KB directory.
+    Best-effort throughout: a single Memory Base's failure never aborts the rest,
+    and nothing here raises.
+    """
+    for handle in handles:
+        try:
+            await _drop_remote_collection(handle)
+            # Local Chroma vectors and any residual on-disk state live in the KB
+            # directory; ``delete_kb`` is a no-op for a remote-backed Memory Base
+            # (no directory) and when no local storage is configured.
+            if handle.kb_username is not None:
+                await delete_kb(kb_name=handle.kb_name, kb_username=handle.kb_username)
+        except Exception:  # noqa: BLE001 — one handle's failure must never orphan the rest of the batch
+            await logger.aexception(
+                "Memory Base cleanup failed for kb_name=%s; it may need manual cleanup.", handle.kb_name
+            )
+
+
+async def _drop_remote_collection(handle: FlowMemoryBaseCleanup) -> None:
+    """Delete one Memory Base's remote vector-store collection, best-effort.
+
+    Local Chroma is skipped — its vectors are removed with the KB directory by
+    :func:`delete_kb`. For every remote backend the collection lives off-box and
+    needs an explicit ``delete_collection`` call. If the store cannot be reached,
+    log that the connection is broken and that the remote collection could not be
+    deleted (it must then be cleaned up manually), and swallow the error so flow
+    deletion is never blocked by an unreachable cluster.
+    """
+    if is_local_chroma(handle.backend_type, handle.backend_config):
+        return
+
+    try:
+        backend = create_backend(
+            handle.backend_type,
+            kb_name=handle.kb_name,
+            backend_config=handle.backend_config,
+            user_id=handle.user_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — an unregistered/misconfigured backend must not abort the batch
+        # Construction failure (e.g. a backend_type no longer registered in this
+        # deployment) has no backend object to retry or tear down — distinct from
+        # the ensure_ready/delete_collection failures below, which do.
+        await logger.awarning(
+            "Could not construct the '%s' vector-store backend for the deleted flow's Memory Base "
+            "(kb_name=%s); the remote collection may need manual cleanup: %s",
+            handle.backend_type,
+            handle.kb_name,
+            exc,
+        )
+        return
+
+    try:
+        await backend.ensure_ready()
+        await backend.delete_collection()
+    except Exception as exc:  # noqa: BLE001 — best-effort remote cleanup
+        # Distinguish a broken connection (the case the requirement calls out)
+        # from other delete failures so the log is actionable.
+        connection_broken = True
+        try:
+            connection_broken = not (await backend.test_connection()).ok
+        except Exception:  # noqa: BLE001 — probing the connection is itself best-effort
+            connection_broken = True
+        if connection_broken:
+            await logger.awarning(
+                "Connection to the '%s' vector store is broken: the remote collection for the deleted flow's "
+                "Memory Base (kb_name=%s) could not be deleted and may need manual cleanup: %s",
+                handle.backend_type,
+                handle.kb_name,
+                exc,
+            )
+        else:
+            await logger.awarning(
+                "Could not delete the remote '%s' collection for the deleted flow's Memory Base (kb_name=%s); "
+                "it may need manual cleanup: %s",
+                handle.backend_type,
+                handle.kb_name,
+                exc,
+            )
+    finally:
+        await backend.teardown()

--- a/src/backend/base/langflow/services/memory_base/ingestion.py
+++ b/src/backend/base/langflow/services/memory_base/ingestion.py
@@ -18,6 +18,7 @@ from langflow.api.utils.kb_helpers import (
     resolve_embedding_selection,
     resolve_local_store_path,
 )
+from langflow.services.database.models.jobs.crud import update_job_status as crud_update_job_status
 from langflow.services.database.models.jobs.model import Job, JobStatus, JobType
 from langflow.services.database.models.memory_base.model import (
     MemoryBase,
@@ -564,11 +565,15 @@ async def cancel_active_jobs(*, memory_base_id: uuid.UUID, db: AsyncSession) -> 
     active_jobs = list(result.all())
 
     task_service = get_task_service()
-    job_service = get_job_service()
     for job in active_jobs:
         try:
             await task_service.revoke_task(job.job_id)
-            await job_service.update_job_status(job.job_id, JobStatus.CANCELLED)
+            # Reuse the caller's session instead of JobService.update_job_status,
+            # which opens its own session_scope(). A second writer session here
+            # would contend with this transaction's own write lock under SQLite
+            # (the caller is mid flow-deletion transaction), timing out and
+            # aborting this loop before later jobs are cancelled.
+            await crud_update_job_status(db, job.job_id, JobStatus.CANCELLED)
             await logger.ainfo("Cancelled job %s for memory_base %s", job.job_id, memory_base_id)
         except (RuntimeError, ValueError, OSError):
             await logger.awarning(

--- a/src/backend/base/langflow/tests/api/v1/test_deployment_guard_delete_endpoints.py
+++ b/src/backend/base/langflow/tests/api/v1/test_deployment_guard_delete_endpoints.py
@@ -166,18 +166,20 @@ async def test_cascade_delete_flow_prunes_orphan_attachments_before_delete_state
         side_effect=[
             _ExecResult(None, rowcount=1),  # prune orphan attachments
             _ExecResult(None),  # live deployment attachment lookup
+            _ExecResult([]),  # memory base lookup (no memory bases -> early return)
             _ExecResult(None),  # message delete
             _ExecResult(None),  # transaction delete
             _ExecResult(None),  # vertex_build delete
             _ExecResult(None),  # flow_version delete
             _ExecResult([]),  # trace id lookup
+            _ExecResult(None),  # authz_share delete
             _ExecResult(None),  # flow delete
         ]
     )
 
     await cascade_delete_flow(session, flow_id)
 
-    assert session.exec.await_count == 8
+    assert session.exec.await_count == 10
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/api/v1/test_projects.py
+++ b/src/backend/tests/unit/api/v1/test_projects.py
@@ -22,6 +22,7 @@ from langflow.services.database.models.flow_version_deployment_attachment.model 
 from langflow.services.database.models.folder.model import Folder
 from langflow.services.deps import session_scope
 from lfx.services.adapters.deployment.schema import DeploymentType
+from sqlmodel import select
 
 CYRILLIC_NAME = "Новый проект"
 CYRILLIC_DESC = "Описание проекта с кириллицей"  # noqa: RUF001
@@ -427,6 +428,144 @@ async def test_delete_project_recovers_from_concurrent_write_lock(
 
     get_resp = await client.get(f"api/v1/projects/{project_id}", headers=logged_in_headers)
     assert get_resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_delete_project_retry_does_not_leak_stale_memory_base_handle(
+    client: AsyncClient, active_user, logged_in_headers, basic_case, monkeypatch
+):
+    """A retry that finds the project already gone must not carry a stale cleanup handle.
+
+    Regression for: attempt 0 populates ``memory_base_cleanups`` with a handle for
+    flow F1's Memory Base, then hits lock contention and its DB transaction rolls
+    back — but the in-memory ``memory_base_cleanups`` list is a plain Python list
+    the rollback never touches. Before the retry, a concurrent request moves F1
+    out of the project and deletes the (now-empty) project. The retry's
+    ``_load_project()`` returns None so ``_delete_attempt`` returns early, BEFORE
+    the ``.clear()`` inside ``_delete_project_operation`` (which never runs on
+    this attempt) would have reset the list. Without the fix,
+    ``finalize_flow_memory_base_cleanup`` is then called with F1's now-stale
+    handle even though F1 survived — only moved — dropping its live collection.
+
+    Uses the REAL ``run_with_lock_retry``. On the first attempt a competing
+    connection commits the flow move + project delete, then the attempt raises a
+    genuine SQLite "database is locked" error (the same wrapped-``OperationalError``
+    shape ``test_delete_project_does_not_leak_sql_on_database_error`` uses) so the
+    real retry logic rolls back and re-runs — deterministically, without relying
+    on SQLite snapshot-conflict timing. Only ``cascade_delete_flow`` is stubbed,
+    to record the handle into the list without taking the writer lock.
+    """
+    import sqlite3
+
+    from langflow.api.v1 import projects as projects_module
+    from langflow.services.database.models.flow.model import Flow as FlowModel
+    from langflow.services.database.models.memory_base.model import MemoryBase
+    from langflow.services.memory_base import flow_cleanup as flow_cleanup_module
+    from langflow.services.memory_base.flow_cleanup import FlowMemoryBaseCleanup
+    from sqlalchemy.exc import OperationalError
+
+    create_resp = await client.post("api/v1/projects/", json=basic_case, headers=logged_in_headers)
+    assert create_resp.status_code == status.HTTP_201_CREATED
+    project_id = UUID(create_resp.json()["id"])
+    owner_id = active_user.id
+
+    flow_payload = FlowCreate(name=f"MB Flow {uuid4()}", description="d", data={}, folder_id=project_id)
+    flow_resp = await client.post("api/v1/flows/", json=flow_payload.model_dump(mode="json"), headers=logged_in_headers)
+    assert flow_resp.status_code == status.HTTP_201_CREATED
+    flow_id = UUID(flow_resp.json()["id"])
+
+    kb_name = f"kb_{uuid4().hex[:8]}"
+    async with session_scope() as db:
+        db.add(MemoryBase(name=f"mb-{uuid4().hex[:6]}", flow_id=flow_id, user_id=owner_id, kb_name=kb_name))
+
+    async with session_scope() as db:
+        other_project = Folder(name=f"other-project-{uuid4()}", user_id=owner_id)
+        db.add(other_project)
+        await db.flush()
+        other_project_id = other_project.id
+
+    recorded_handles: list[list] = []
+
+    async def _record_finalize(handles):
+        recorded_handles.append(list(handles))
+
+    monkeypatch.setattr(flow_cleanup_module, "finalize_flow_memory_base_cleanup", _record_finalize)
+
+    # Stub cascade_delete_flow to populate the cleanup list WITHOUT taking the
+    # writer lock, so the competing commit below is free to land. The handle it
+    # records is the one that must NOT survive into the retry.
+    async def _fake_cascade_delete_flow(session, target_flow_id):  # noqa: ARG001
+        return [
+            FlowMemoryBaseCleanup(
+                kb_name=kb_name,
+                user_id=owner_id,
+                kb_username="activeuser",
+                backend_type="chroma",
+                backend_config={},
+            )
+        ]
+
+    monkeypatch.setattr(projects_module, "cascade_delete_flow", _fake_cascade_delete_flow)
+
+    # Wrap the REAL run_with_lock_retry so we can prove a second attempt ran.
+    # (attempts on the check hook alone can't prove it: the retry returns early
+    # at `target is None` before check_project_has_deployments is reached.)
+    real_run_with_lock_retry = projects_module.run_with_lock_retry
+    op_attempts = {"max": 0}
+
+    async def counting_run_with_lock_retry(operation, **kwargs):
+        async def counting_operation(attempt):
+            op_attempts["max"] = max(op_attempts["max"], attempt + 1)
+            return await operation(attempt)
+
+        return await real_run_with_lock_retry(counting_operation, **kwargs)
+
+    monkeypatch.setattr(projects_module, "run_with_lock_retry", counting_run_with_lock_retry)
+
+    original_check = projects_module.check_project_has_deployments
+    attempts = {"count": 0}
+
+    async def check_with_flow_moved_and_project_deleted(session, *, project_id):
+        # First attempt only: a genuinely separate request moves F1 to another
+        # project and deletes the (now-empty) original project, committed on its
+        # own connection. Then raise a real SQLite lock error so the REAL
+        # run_with_lock_retry rolls back attempt 0's transaction and retries —
+        # while memory_base_cleanups (a plain Python list) keeps F1's handle.
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            async with session_scope() as competing_session:
+                flow_row = await competing_session.get(FlowModel, flow_id)
+                flow_row.folder_id = other_project_id
+                competing_session.add(flow_row)
+                folder_row = await competing_session.get(Folder, project_id)
+                await competing_session.delete(folder_row)
+            lock_statement = "UPDATE ..."
+            raise OperationalError(lock_statement, {}, sqlite3.OperationalError("database is locked"))
+        return await original_check(session, project_id=project_id)
+
+    monkeypatch.setattr(projects_module, "check_project_has_deployments", check_with_flow_moved_and_project_deleted)
+
+    delete_resp = await client.delete(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+
+    assert delete_resp.status_code == status.HTTP_204_NO_CONTENT, delete_resp.text
+    assert op_attempts["max"] >= 2, "a retry attempt never ran — the test no longer exercises the bug path"
+    assert attempts["count"] == 1, "the lock error was injected on exactly the first attempt"
+
+    # The finalizer must have been called, but with NO handle for the surviving
+    # flow's Memory Base — the fix clears the list at the top of the retry.
+    assert recorded_handles, "finalize_flow_memory_base_cleanup was never called"
+    leaked_kb_names = {h.kb_name for handles in recorded_handles for h in handles}
+    assert kb_name not in leaked_kb_names, (
+        f"stale handle for surviving flow's Memory Base ({kb_name}) leaked into finalize: {recorded_handles}"
+    )
+
+    # F1 itself survived (moved, not deleted) and its Memory Base row is intact.
+    async with session_scope() as db:
+        surviving_flow = await db.get(FlowModel, flow_id)
+        surviving_mb = (await db.exec(select(MemoryBase).where(MemoryBase.flow_id == flow_id))).first()
+    assert surviving_flow is not None
+    assert surviving_flow.folder_id == other_project_id
+    assert surviving_mb is not None
+    assert surviving_mb.kb_name == kb_name
 
 
 async def test_delete_project_does_not_leak_sql_on_database_error(

--- a/src/backend/tests/unit/test_memory_base_flow_cleanup.py
+++ b/src/backend/tests/unit/test_memory_base_flow_cleanup.py
@@ -1,0 +1,431 @@
+"""Tests for Memory Base cleanup on flow deletion.
+
+When a flow is deleted, the Memory Bases it owns must be reclaimed:
+
+* every ``memory_base`` row (and its child rows) plus the backing
+  ``knowledge_base`` row are removed atomically with the flow deletion, and
+* the corresponding vector-store collection is dropped — best-effort, so a
+  broken connection to the remote store is logged and swallowed rather than
+  blocking the deletion.
+
+The DB side is exercised end-to-end through the DELETE flow endpoint; the
+external side (remote collection teardown, broken-connection logging) is
+exercised directly against ``finalize_flow_memory_base_cleanup``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import orjson
+import pytest
+from langflow.services.database.models.flow import FlowCreate
+from langflow.services.database.models.folder.model import FolderCreate
+from langflow.services.database.models.jobs.model import Job, JobStatus, JobType
+from langflow.services.database.models.knowledge_base.model import KnowledgeBaseRecord
+from langflow.services.database.models.memory_base.model import (
+    MemoryBase,
+    MemoryBasePreprocessingOutput,
+    MemoryBaseSession,
+    MemoryBaseWorkflowRun,
+    MessageIngestionRecord,
+)
+from langflow.services.database.models.message.model import MessageTable
+from langflow.services.deps import session_scope
+from langflow.services.memory_base.flow_cleanup import (
+    FlowMemoryBaseCleanup,
+    finalize_flow_memory_base_cleanup,
+    purge_flow_memory_bases,
+)
+from langflow.services.memory_base.ingestion import cancel_active_jobs
+from lfx.base.knowledge_bases.backends.base import TestConnectionResult
+from sqlmodel import col, select
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+# ------------------------------------------------------------------ #
+#  Helpers                                                             #
+# ------------------------------------------------------------------ #
+
+
+async def _create_flow(client: AsyncClient, json_flow: str, logged_in_headers) -> tuple[uuid.UUID, uuid.UUID]:
+    """Create a flow via the API and return ``(flow_id, owner_user_id)``."""
+    data = orjson.loads(json_flow)["data"]
+    payload = FlowCreate(name=f"MB Flow {uuid.uuid4()}", description="d", data=data)
+    response = await client.post("api/v1/flows/", json=payload.model_dump(), headers=logged_in_headers)
+    assert response.status_code == 201, response.content
+    body = response.json()
+    return uuid.UUID(body["id"]), uuid.UUID(body["user_id"])
+
+
+async def _seed_memory_base(flow_id: uuid.UUID, user_id: uuid.UUID, *, kb_name: str) -> uuid.UUID:
+    """Insert a Memory Base (with children + backing KB row) tied to ``flow_id``.
+
+    Uses a local-Chroma KB row so the external teardown is a no-op (no remote
+    collection, and the on-disk directory simply does not exist).
+    """
+    now = datetime.now(timezone.utc)
+    mb_id = uuid.uuid4()
+    async with session_scope() as db:
+        db.add(
+            MemoryBase(id=mb_id, name=f"mb-{uuid.uuid4().hex[:6]}", flow_id=flow_id, user_id=user_id, kb_name=kb_name)
+        )
+        db.add(
+            KnowledgeBaseRecord(
+                name=kb_name,
+                user_id=user_id,
+                backend_type="chroma",
+                backend_config={"mode": "local"},
+                source_types=["memory"],
+            )
+        )
+        # A message ingested into the MB — MessageIngestionRecord references it.
+        msg = MessageTable(
+            id=uuid.uuid4(),
+            sender="AI",
+            sender_name="Bot",
+            session_id="sess-1",
+            text="hi",
+            flow_id=flow_id,
+            is_output=True,
+        )
+        db.add(msg)
+        db.add(MemoryBaseSession(memory_base_id=mb_id, session_id="sess-1"))
+        db.add(MemoryBaseWorkflowRun(memory_base_id=mb_id, session_id="sess-1", recorded_at=now))
+        db.add(
+            MemoryBasePreprocessingOutput(
+                memory_base_id=mb_id,
+                session_id="sess-1",
+                status="ingested",
+                output_text="distilled",
+                source_message_ids=[str(msg.id)],
+                model_used="gpt-x",
+            )
+        )
+        db.add(MessageIngestionRecord(message_id=msg.id, memory_base_id=mb_id, session_id="sess-1", ingested_at=now))
+    return mb_id
+
+
+async def _count_rows(model, **filters) -> int:
+    async with session_scope() as db:
+        stmt = select(model)
+        for field, value in filters.items():
+            stmt = stmt.where(getattr(model, field) == value)
+        return len(list((await db.exec(stmt)).all()))
+
+
+# ------------------------------------------------------------------ #
+#  Integration: DELETE flow reclaims its Memory Bases                  #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_delete_flow_deletes_memory_bases_and_children(client: AsyncClient, json_flow: str, logged_in_headers):
+    flow_id, user_id = await _create_flow(client, json_flow, logged_in_headers)
+    kb_name = f"kb_{uuid.uuid4().hex[:8]}"
+    mb_id = await _seed_memory_base(flow_id, user_id, kb_name=kb_name)
+
+    # Sanity: rows exist before deletion.
+    assert await _count_rows(MemoryBase, id=mb_id) == 1
+    assert await _count_rows(KnowledgeBaseRecord, name=kb_name, user_id=user_id) == 1
+
+    response = await client.delete(f"api/v1/flows/{flow_id}", headers=logged_in_headers)
+    assert response.status_code == 200, response.content
+
+    # Memory base, its children, and the backing knowledge_base row are gone.
+    assert await _count_rows(MemoryBase, id=mb_id) == 0
+    assert await _count_rows(MemoryBaseSession, memory_base_id=mb_id) == 0
+    assert await _count_rows(MemoryBaseWorkflowRun, memory_base_id=mb_id) == 0
+    assert await _count_rows(MemoryBasePreprocessingOutput, memory_base_id=mb_id) == 0
+    assert await _count_rows(MessageIngestionRecord, memory_base_id=mb_id) == 0
+    assert await _count_rows(KnowledgeBaseRecord, name=kb_name, user_id=user_id) == 0
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_delete_flow_leaves_other_flows_memory_bases_untouched(
+    client: AsyncClient, json_flow: str, logged_in_headers
+):
+    flow_a, user_id = await _create_flow(client, json_flow, logged_in_headers)
+    flow_b, _ = await _create_flow(client, json_flow, logged_in_headers)
+    kb_a = f"kb_{uuid.uuid4().hex[:8]}"
+    kb_b = f"kb_{uuid.uuid4().hex[:8]}"
+    mb_a = await _seed_memory_base(flow_a, user_id, kb_name=kb_a)
+    mb_b = await _seed_memory_base(flow_b, user_id, kb_name=kb_b)
+
+    response = await client.delete(f"api/v1/flows/{flow_a}", headers=logged_in_headers)
+    assert response.status_code == 200, response.content
+
+    assert await _count_rows(MemoryBase, id=mb_a) == 0
+    # Deleting flow A must not touch flow B's Memory Base.
+    assert await _count_rows(MemoryBase, id=mb_b) == 1
+    assert await _count_rows(KnowledgeBaseRecord, name=kb_b, user_id=user_id) == 1
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_delete_project_deletes_member_flows_memory_bases(client: AsyncClient, json_flow: str, logged_in_headers):
+    # A project deletion cascades through its flows; each flow's Memory Bases
+    # must be reclaimed too.
+    project = FolderCreate(name=f"Proj {uuid.uuid4()}", description="d", components_list=[], flows_list=[])
+    resp = await client.post("api/v1/projects/", json=project.model_dump(), headers=logged_in_headers)
+    assert resp.status_code == 201, resp.content
+    project_id = resp.json()["id"]
+
+    data = orjson.loads(json_flow)["data"]
+    flow_payload = FlowCreate(name=f"MB Flow {uuid.uuid4()}", description="d", data=data, folder_id=project_id)
+    fresp = await client.post("api/v1/flows/", json=flow_payload.model_dump(mode="json"), headers=logged_in_headers)
+    assert fresp.status_code == 201, fresp.content
+    flow_id = uuid.UUID(fresp.json()["id"])
+    user_id = uuid.UUID(fresp.json()["user_id"])
+
+    kb_name = f"kb_{uuid.uuid4().hex[:8]}"
+    mb_id = await _seed_memory_base(flow_id, user_id, kb_name=kb_name)
+
+    dresp = await client.delete(f"api/v1/projects/{project_id}", headers=logged_in_headers)
+    assert dresp.status_code == 204, dresp.content
+
+    assert await _count_rows(MemoryBase, id=mb_id) == 0
+    assert await _count_rows(KnowledgeBaseRecord, name=kb_name, user_id=user_id) == 0
+
+
+# ------------------------------------------------------------------ #
+#  purge_flow_memory_bases returns handles + is a no-op when empty     #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.usefixtures("active_user")
+async def test_purge_returns_handles_with_backend_config(client: AsyncClient, json_flow: str, logged_in_headers):
+    flow_id, user_id = await _create_flow(client, json_flow, logged_in_headers)
+    kb_name = f"kb_{uuid.uuid4().hex[:8]}"
+    await _seed_memory_base(flow_id, user_id, kb_name=kb_name)
+
+    async with session_scope() as db:
+        handles = await purge_flow_memory_bases(db, flow_id)
+
+    assert len(handles) == 1
+    handle = handles[0]
+    assert handle.kb_name == kb_name
+    assert handle.user_id == user_id
+    assert handle.backend_type == "chroma"
+    assert handle.backend_config == {"mode": "local"}
+
+
+async def test_purge_no_memory_bases_returns_empty():
+    async with session_scope() as db:
+        handles = await purge_flow_memory_bases(db, uuid.uuid4())
+    assert handles == []
+
+
+# ------------------------------------------------------------------ #
+#  cancel_active_jobs — reuses the caller's session                   #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.usefixtures("client")
+async def test_cancel_active_jobs_cancels_every_active_job():
+    """Every IN_PROGRESS/QUEUED job for the Memory Base is cancelled, not just the first.
+
+    Regression for a bug where the per-job status update went through
+    ``JobService.update_job_status``, which opens its own ``session_scope()`` —
+    a second writer session distinct from the caller's (here, the flow-deletion
+    transaction's) session. Under SQLite's single-writer model that second
+    writer contends with the still-open outer transaction; the resulting lock
+    error was not caught by the loop's narrow exception filter, so it aborted
+    the loop and left later jobs uncancelled. The fix updates status through
+    the caller's own session, so no second writer is ever opened.
+    """
+    mb_id = uuid.uuid4()
+    flow_id = uuid.uuid4()
+    job_ids = [uuid.uuid4(), uuid.uuid4()]
+
+    async with session_scope() as db:
+        for job_id in job_ids:
+            db.add(
+                Job(
+                    job_id=job_id,
+                    flow_id=flow_id,
+                    status=JobStatus.IN_PROGRESS,
+                    type=JobType.INGESTION,
+                    asset_id=mb_id,
+                    asset_type="memory_base",
+                )
+            )
+
+    async with session_scope() as db:
+        # Exercised on the SAME open session a flow-deletion transaction would
+        # already be using — the exact scenario the bug reproduced under.
+        await cancel_active_jobs(memory_base_id=mb_id, db=db)
+
+    async with session_scope() as db:
+        rows = (await db.exec(select(Job).where(col(Job.job_id).in_(job_ids)))).all()
+
+    assert len(rows) == len(job_ids)
+    assert {row.status for row in rows} == {JobStatus.CANCELLED}
+
+
+@pytest.mark.usefixtures("client")
+async def test_cancel_active_jobs_does_not_open_a_second_session(monkeypatch):
+    """cancel_active_jobs must not go through JobService's own session_scope().
+
+    Direct regression for the root cause: asserts get_job_service (the old
+    path to the second-writer update_job_status) is never touched.
+    """
+    from langflow.services.memory_base import ingestion as ingestion_module
+
+    def _fail_if_called():
+        msg = "cancel_active_jobs must not open a second session via get_job_service()"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(ingestion_module, "get_job_service", _fail_if_called)
+
+    mb_id = uuid.uuid4()
+    flow_id = uuid.uuid4()
+    job_id = uuid.uuid4()
+
+    async with session_scope() as db:
+        db.add(
+            Job(
+                job_id=job_id,
+                flow_id=flow_id,
+                status=JobStatus.QUEUED,
+                type=JobType.INGESTION,
+                asset_id=mb_id,
+                asset_type="memory_base",
+            )
+        )
+
+    async with session_scope() as db:
+        await cancel_active_jobs(memory_base_id=mb_id, db=db)  # must not raise via the patched get_job_service
+
+    async with session_scope() as db:
+        row = (await db.exec(select(Job).where(Job.job_id == job_id))).first()
+    assert row.status == JobStatus.CANCELLED
+
+
+# ------------------------------------------------------------------ #
+#  finalize_flow_memory_base_cleanup — external teardown              #
+# ------------------------------------------------------------------ #
+
+
+def _fake_backend(*, delete_error: Exception | None = None, connection_ok: bool = True) -> MagicMock:
+    backend = MagicMock()
+    backend.ensure_ready = AsyncMock()
+    backend.delete_collection = AsyncMock(side_effect=delete_error)
+    backend.test_connection = AsyncMock(return_value=TestConnectionResult(ok=connection_ok, message="probe"))
+    backend.teardown = AsyncMock()
+    return backend
+
+
+async def test_finalize_drops_remote_collection(monkeypatch):
+    backend = _fake_backend()
+    monkeypatch.setattr("langflow.services.memory_base.flow_cleanup.create_backend", lambda *_a, **_k: backend)
+
+    handle = FlowMemoryBaseCleanup(
+        kb_name="kb1",
+        user_id=uuid.uuid4(),
+        kb_username=None,  # skip disk cleanup — irrelevant to remote drop
+        backend_type="opensearch",
+        backend_config={"url": "https://os.example"},
+    )
+    await finalize_flow_memory_base_cleanup([handle])
+
+    backend.delete_collection.assert_awaited_once()
+    backend.teardown.assert_awaited_once()
+
+
+async def test_finalize_logs_broken_connection_and_swallows(monkeypatch):
+    # delete_collection fails AND the connection probe reports the store is down.
+    backend = _fake_backend(delete_error=ConnectionError("no route to host"), connection_ok=False)
+    monkeypatch.setattr("langflow.services.memory_base.flow_cleanup.create_backend", lambda *_a, **_k: backend)
+
+    warnings: list[str] = []
+
+    async def _capture_warning(msg, *args, **_kwargs):
+        warnings.append(msg % args if args else msg)
+
+    monkeypatch.setattr("langflow.services.memory_base.flow_cleanup.logger.awarning", _capture_warning)
+
+    handle = FlowMemoryBaseCleanup(
+        kb_name="kb1",
+        user_id=uuid.uuid4(),
+        kb_username=None,
+        backend_type="opensearch",
+        backend_config={"url": "https://os.example"},
+    )
+    # Must not raise even though the remote delete failed.
+    await finalize_flow_memory_base_cleanup([handle])
+
+    backend.test_connection.assert_awaited_once()
+    backend.teardown.assert_awaited_once()
+    assert any("connection" in w.lower() and "broken" in w.lower() for w in warnings), warnings
+    assert any("kb1" in w for w in warnings)
+
+
+async def test_finalize_survives_backend_construction_failure_for_one_handle(monkeypatch):
+    """A construction failure for one handle must not orphan the rest of the batch.
+
+    Regression for create_backend() raising (e.g. an unregistered backend_type,
+    such as an Astra-backed record when the Astra provider is not installed)
+    outside any try/except. Before the fix this propagated out of
+    finalize_flow_memory_base_cleanup entirely, aborting the loop before later
+    handles — otherwise perfectly healthy — were cleaned up.
+    """
+    healthy_backend = _fake_backend()
+
+    def _create_backend(backend_type, **_kwargs):
+        if backend_type == "astra":
+            msg = "Vector-store backend 'astra' is not registered."
+            raise ValueError(msg)
+        return healthy_backend
+
+    monkeypatch.setattr("langflow.services.memory_base.flow_cleanup.create_backend", _create_backend)
+    delete_kb = AsyncMock()
+    monkeypatch.setattr("langflow.services.memory_base.flow_cleanup.delete_kb", delete_kb)
+
+    failing_handle = FlowMemoryBaseCleanup(
+        kb_name="kb_astra",
+        user_id=uuid.uuid4(),
+        kb_username=None,
+        backend_type="astra",
+        backend_config={},
+    )
+    healthy_handle = FlowMemoryBaseCleanup(
+        kb_name="kb_healthy",
+        user_id=uuid.uuid4(),
+        kb_username="alice",
+        backend_type="opensearch",
+        backend_config={"url": "https://os.example"},
+    )
+
+    # Must not raise, and the healthy handle after the failing one must still
+    # be cleaned up.
+    await finalize_flow_memory_base_cleanup([failing_handle, healthy_handle])
+
+    healthy_backend.delete_collection.assert_awaited_once()
+    healthy_backend.teardown.assert_awaited_once()
+    delete_kb.assert_awaited_once_with(kb_name="kb_healthy", kb_username="alice")
+
+
+async def test_finalize_skips_remote_drop_for_local_chroma(monkeypatch):
+    # Local Chroma has no remote collection: create_backend must never be called,
+    # only the on-disk directory teardown.
+    create_backend = MagicMock()
+    monkeypatch.setattr("langflow.services.memory_base.flow_cleanup.create_backend", create_backend)
+    # delete_kb is filesystem-only; stub it so the test needs no KB root configured.
+    delete_kb = AsyncMock()
+    monkeypatch.setattr("langflow.services.memory_base.flow_cleanup.delete_kb", delete_kb)
+
+    handle = FlowMemoryBaseCleanup(
+        kb_name="kb_local",
+        user_id=uuid.uuid4(),
+        kb_username="alice",
+        backend_type="chroma",
+        backend_config={"mode": "local"},
+    )
+    await finalize_flow_memory_base_cleanup([handle])
+
+    create_backend.assert_not_called()
+    delete_kb.assert_awaited_once()


### PR DESCRIPTION
Memory Bases will cleanup alongside cascade deletion of flows. Deletion is atomic in DB and remote collections are cleaned up as a post-commit action.

MBs are scoped to a Flow. So when a flow is deleted, it should also delete the related MBs and their remote collections to avoid orphaned MBs (Underlying KBs and their remote vector collections with it)

Changes:
- Added memory base cleanup routine in `cascade_flow_deletion()`
- Unit tests created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flow, project, and user-state deletion when associated Memory Bases contain messages or ingestion records.
  * Memory Base database records are now removed safely during flow deletion, preventing related-record constraint errors.
  * External Memory Base resources are cleaned up after successful deletion, without blocking the deletion if cleanup encounters an error.
  * Local Chroma resources are preserved appropriately while remote collections are removed when applicable.
* **Tests**
  * Added coverage for flow and project deletion, database cleanup, remote resource removal, and cleanup failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->