### PR TITLE
fix: detect WebKit engine, not Safari by name

### DIFF
--- a/src/frontend/src/components/common/__tests__/safari-scroll-fix.test.tsx
+++ b/src/frontend/src/components/common/__tests__/safari-scroll-fix.test.tsx
@@ -1,0 +1,89 @@
+// The scroll workaround must run wherever WebKit does, not only where the
+// user agent happens to say "Safari".
+//
+// An embedded WKWebView (Tauri, and other native shells) reports
+//   Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)
+// with no "Safari/" token, so the previous /safari/ sniff was false there. The
+// Playground then ran without the workaround in a WebKit runtime, while Safari
+// itself received it — the scroll jumped back to the top of a reply as soon as
+// streaming finished.
+
+// ESM-only package; these assertions never reach the hook (the component
+// returns before using it, or is asserted as an unrendered element), so a stub
+// keeps the suite out of the jest ESM transform allowlist.
+jest.mock("use-stick-to-bottom", () => ({
+  useStickToBottomContext: () => ({
+    scrollRef: { current: null },
+    stopScroll: () => {},
+  }),
+}));
+
+const TAURI_WKWEBVIEW =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)";
+const SAFARI =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15";
+const CHROME =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36";
+const EDGE_WEBVIEW2 =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36 Edg/141.0.0.0";
+const ANDROID_WEBVIEW =
+  "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/141.0.0.0 Mobile Safari/537.36";
+const FIREFOX =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0";
+
+const originalUserAgent = navigator.userAgent;
+
+const setUserAgent = (userAgent: string) => {
+  Object.defineProperty(navigator, "userAgent", {
+    value: userAgent,
+    configurable: true,
+  });
+};
+
+const loadModule = () => {
+  let loaded: typeof import("../safari-scroll-fix");
+  jest.isolateModules(() => {
+    loaded = require("../safari-scroll-fix");
+  });
+  return loaded!;
+};
+
+describe("safari-scroll-fix WebKit detection", () => {
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+  });
+
+  describe("engine predicate", () => {
+    it.each([
+      ["an embedded WKWebView", TAURI_WKWEBVIEW, true],
+      ["Safari", SAFARI, true],
+      ["Chrome", CHROME, false],
+      ["Edge / WebView2", EDGE_WEBVIEW2, false],
+      ["Android WebView", ANDROID_WEBVIEW, false],
+      ["Firefox", FIREFOX, false],
+    ])(
+      "should_report_%s_correctly_when_matching_the_engine",
+      (_label, userAgent, expected) => {
+        const { isWebKitEngine } = loadModule();
+
+        expect(isWebKitEngine(userAgent as string)).toBe(expected);
+      },
+    );
+  });
+
+  describe("component gating", () => {
+    it("should_mount_the_workaround_when_running_in_an_embedded_webkit_view", () => {
+      setUserAgent(TAURI_WKWEBVIEW);
+      const { SafariScrollFix } = loadModule();
+
+      expect(SafariScrollFix()).not.toBeNull();
+    });
+
+    it("should_not_mount_the_workaround_when_running_in_chromium", () => {
+      setUserAgent(CHROME);
+      const { SafariScrollFix } = loadModule();
+
+      expect(SafariScrollFix()).toBeNull();
+    });
+  });
+});

--- a/src/frontend/src/components/common/safari-scroll-fix.tsx
+++ b/src/frontend/src/components/common/safari-scroll-fix.tsx
@@ -1,10 +1,22 @@
 import { useEffect, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 
-export const isSafari =
-  typeof navigator !== "undefined" &&
-  /safari/i.test(navigator.userAgent) &&
-  !/chrome|chromium|android/i.test(navigator.userAgent);
+// Engine detection, not browser-name detection.
+//
+// This workaround targets WebKit's scroll behaviour, but the gate used to sniff
+// for the browser name "Safari". An embedded WKWebView reports
+//   Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)
+// with no "Safari/" token, so the gate was false there — the workaround never
+// reached a WebKit runtime that needs it, while Safari itself got it.
+//
+// Chromium runtimes (Chrome, Edge, WebView2, Android WebView) also carry
+// "AppleWebKit" in their UA and must stay excluded.
+export const isWebKitEngine = (userAgent: string): boolean =>
+  /applewebkit/i.test(userAgent) &&
+  !/chrome|chromium|android|edg\//i.test(userAgent);
+
+export const isWebKitRuntime =
+  typeof navigator !== "undefined" && isWebKitEngine(navigator.userAgent);
 
 /** Minimum pixels to detect intentional touch scroll */
 const TOUCH_SCROLL_THRESHOLD = 10;
@@ -16,14 +28,14 @@ const BOTTOM_PROXIMITY_THRESHOLD = 20;
 const JITTER_THRESHOLD = 200;
 
 /**
- * Safari-specific workaround for scroll jitter when using stick-to-bottom behavior.
+ * WebKit workaround for scroll jitter when using stick-to-bottom behavior.
  *
- * Safari exhibits scroll position jumps when content height changes dynamically.
+ * WebKit exhibits scroll position jumps when content height changes dynamically.
  * This component uses a RAF loop to enforce scroll position and detect/block
  * unnatural scroll jumps while preserving user scroll intent.
  */
 export function SafariScrollFix() {
-  if (!isSafari) return null;
+  if (!isWebKitRuntime) return null;
   return <SafariScrollFixInner />;
 }
 


### PR DESCRIPTION
## Problem

The Playground scroll workaround (`components/common/safari-scroll-fix.tsx`) gated itself on a browser-name check:

```js
/safari/i.test(navigator.userAgent) && !/chrome|chromium|android/i.test(navigator.userAgent)
```

An embedded WKWebView reports a user agent with **no `Safari/` token**:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)
```

So the gate was `false` in that runtime. The workaround never reached a WebKit environment that needs it, while Safari itself — which does emit the token — received it.

The visible symptom: while a reply streams the view follows it correctly, but the moment streaming finishes the view jumps back to the top of that reply, and the user has to scroll down manually.

Measured across environments, the correlation is exact — the only cell running WebKit *without* the workaround is the only one that reproduces:

| Environment | Engine | Gate | Workaround | Bug |
|---|---|---|---|---|
| Chrome | Chromium | false | no | no (Chromium lacks the jitter) |
| Safari | WebKit | **true** | **yes** | **no** |
| Embedded WKWebView | WebKit | **false** | **no** | **yes** |

## Fix

Detect the **engine** rather than the browser name: `AppleWebKit` present and Chromium absent.

Chrome, Edge, WebView2 and Android WebView all carry `AppleWebKit` in their user agent and remain excluded, so nothing changes for them.

`isSafari` had no importers outside this module, so it is replaced by a pure, testable `isWebKitEngine(userAgent)` plus the `isWebKitRuntime` constant the component gates on. The three consumers import only `SafariScrollFix`, whose signature is unchanged.

## Tests

New: `src/components/common/__tests__/safari-scroll-fix.test.tsx` — 8 tests.

- Engine predicate across six real user agents: embedded WKWebView and Safari resolve true; Chrome, Edge/WebView2, Android WebView and Firefox resolve false.
- Component gating: mounts under an embedded WebKit view, returns `null` under Chromium.

The gating test is the regression: before this change it failed with `expected null not to be null` for the WKWebView user agent.

`use-stick-to-bottom` is stubbed because it is ESM-only; these assertions never reach the hook, so the suite stays out of the jest ESM transform allowlist.

```
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in embedded WebKit-based runtimes, including WKWebView.
  * Prevented the Safari-specific workaround from being applied to Chromium-based browsers.
* **Tests**
  * Added coverage for WebKit detection across Safari, embedded WebKit, Chromium, Android WebView, and Firefox environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->