### PR TITLE
fix(admin): harden conflict and prune handling

### DIFF
--- a/docs/docs/Develop/admin-api-cli.mdx
+++ b/docs/docs/Develop/admin-api-cli.mdx
@@ -174,4 +174,4 @@ Manual membership and role-assignment mutations cannot remove IdP-only state. Th
 
 Before a membership or effective role assignment changes, the installed authorization plugin can enforce its access ceiling. A rejected privilege escalation returns `409` with `X-Langflow-Error-Code: access_ceiling`.
 
-Every administration mutation supplies its operation ID to the audit path. Audit details include the actor, target, action, source, and changed field names. Passwords, API keys, and secret values are never included.
+Administration auditing is opt-in. Set `LANGFLOW_AUTHZ_AUDIT_ENABLED=true` and restart Langflow to write administration decisions and mutations to `authz_audit_log`; the default is `false`, so a default installation does not retain this audit trail. When auditing is enabled, every administration mutation supplies its operation ID to the audit path. Audit details include the actor, target, action, source, and changed field names. Passwords, API keys, and secret values are never included.

--- a/src/backend/base/langflow/api/v1/authz_roles.py
+++ b/src/backend/base/langflow/api/v1/authz_roles.py
@@ -204,6 +204,10 @@ async def create_role(
 ) -> RoleRead:
     """Create a custom (non-system) role."""
     await _require_role_administrator(current_user, action="role:create", obj="role:*", operation_id=operation_id)
+    # Rollback expires the JWT-authenticated ORM user because authentication
+    # and this handler share a request session. Keep the scalar actor id usable
+    # by the conflict audit after rollback.
+    actor_user_id = current_user.id
     authorization_service = get_authorization_service()
     await acquire_identity_mutation_lock(
         authorization_service,
@@ -233,13 +237,13 @@ async def create_role(
         is_system=False,
         permissions=list(payload.permissions),
         parent_role_id=payload.parent_role_id,
-        created_by=current_user.id,
+        created_by=actor_user_id,
     )
     session.add(role)
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.ROLE_CREATED,
         entity_id=role.id,
-        actor_user_id=current_user.id,
+        actor_user_id=actor_user_id,
         role_id=role.id,
         policy_relevant_fields=("name", "permissions", "parent_role_id"),
     )
@@ -251,7 +255,7 @@ async def create_role(
         await session.rollback()
         is_name_conflict = _is_role_name_conflict(exc)
         await _audit_deny(
-            user_id=current_user.id,
+            user_id=actor_user_id,
             action="role:create",
             obj="role:*",
             status_code=status.HTTP_409_CONFLICT,
@@ -303,6 +307,7 @@ async def update_role(
         obj=f"role:{role_id}",
         operation_id=operation_id,
     )
+    actor_user_id = current_user.id
     authorization_service = get_authorization_service()
     await acquire_identity_mutation_lock(
         authorization_service,
@@ -434,7 +439,7 @@ async def update_role(
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.ROLE_UPDATED,
         entity_id=role.id,
-        actor_user_id=current_user.id,
+        actor_user_id=actor_user_id,
         role_id=role.id,
         policy_relevant_fields=tuple(sorted(fields_set & {"name", "permissions", "parent_role_id"})),
         previous_identifier=previous_name if role.name != previous_name else None,
@@ -447,7 +452,7 @@ async def update_role(
         await session.rollback()
         is_name_conflict = _is_role_name_conflict(exc)
         await _audit_deny(
-            user_id=current_user.id,
+            user_id=actor_user_id,
             action="role:update",
             obj=f"role:{role_id}",
             status_code=status.HTTP_409_CONFLICT,

--- a/src/backend/base/langflow/api/v1/authz_teams.py
+++ b/src/backend/base/langflow/api/v1/authz_teams.py
@@ -197,6 +197,9 @@ async def create_team(
     operation_id: OperationId = None,
 ) -> TeamRead:
     await _require_team_administrator(current_user, action="team:create", obj="team:*", operation_id=operation_id)
+    # Preserve the actor across a rollback: JWT authentication returns a
+    # session-bound User that rollback expires, unlike API-key authentication.
+    actor_user_id = current_user.id
     authorization_service = get_authorization_service()
     await acquire_identity_mutation_lock(
         authorization_service,
@@ -224,7 +227,7 @@ async def create_team(
     except IntegrityError as exc:
         await session.rollback()
         await _audit_deny(
-            user_id=current_user.id,
+            user_id=actor_user_id,
             action="team:create",
             obj="team:*",
             status_code=status.HTTP_409_CONFLICT,
@@ -266,6 +269,7 @@ async def update_team(
         obj=f"team:{team_id}",
         operation_id=operation_id,
     )
+    actor_user_id = current_user.id
     authorization_service = get_authorization_service()
     await acquire_identity_mutation_lock(
         authorization_service,
@@ -306,7 +310,7 @@ async def update_team(
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.TEAM_UPDATED,
         entity_id=team.id,
-        actor_user_id=current_user.id,
+        actor_user_id=actor_user_id,
         team_id=team.id,
         policy_relevant_fields=tuple(sorted(set(changed_fields) & {"adom_name", "is_active"})),
         previous_identifier=previous_adom_name if team.adom_name != previous_adom_name else None,
@@ -318,7 +322,7 @@ async def update_team(
     except IntegrityError as exc:
         await session.rollback()
         await _audit_deny(
-            user_id=current_user.id,
+            user_id=actor_user_id,
             action="team:update",
             obj=f"team:{team_id}",
             status_code=status.HTTP_409_CONFLICT,
@@ -455,6 +459,7 @@ async def add_member(
         obj=f"team:{team_id}",
         operation_id=operation_id,
     )
+    actor_user_id = current_user.id
     authorization_service = get_authorization_service()
     await acquire_identity_mutation_lock(
         authorization_service,
@@ -507,7 +512,7 @@ async def add_member(
     mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.TEAM_MEMBER_ADDED,
         entity_id=member.id,
-        actor_user_id=current_user.id,
+        actor_user_id=actor_user_id,
         affected_user_ids=(payload.user_id,),
         team_id=team_id,
         policy_relevant_fields=("team_id", "user_id", "source"),
@@ -520,7 +525,7 @@ async def add_member(
             team_id=team_id,
             user_id=payload.user_id,
             source_kind="manual",
-            administrative_actor=current_user.id,
+            administrative_actor=actor_user_id,
             membership=member,
             membership_is_new=member_is_new,
         )
@@ -530,7 +535,7 @@ async def add_member(
         await session.commit()
     except AuthorizationMutationRejected as exc:
         await _audit_deny(
-            user_id=current_user.id,
+            user_id=actor_user_id,
             action="team_member:create",
             obj=f"team:{team_id}",
             status_code=status.HTTP_409_CONFLICT,
@@ -545,7 +550,7 @@ async def add_member(
     except IntegrityError as exc:
         await session.rollback()
         await _audit_deny(
-            user_id=current_user.id,
+            user_id=actor_user_id,
             action="team_member:create",
             obj=f"team:{team_id}",
             status_code=status.HTTP_409_CONFLICT,

--- a/src/backend/base/langflow/api/v1/users.py
+++ b/src/backend/base/langflow/api/v1/users.py
@@ -163,6 +163,10 @@ async def add_user(
 
     User activation is controlled by the NEW_USER_IS_ACTIVE setting.
     """
+    # Rollback expires session-bound ORM instances. Snapshot the actor before
+    # any write so conflict auditing never tries to refresh the authenticated
+    # user from the rolled-back request transaction.
+    actor_user_id = current_user.id if current_user is not None else None
     settings_service = get_settings_service()
     auth_settings = settings_service.auth_settings
     # An authenticated active administrator (the admin "add user" flow) may always
@@ -178,7 +182,7 @@ async def add_user(
     )
     if not is_admin_caller and (auth_settings.AUTO_LOGIN or not auth_settings.ENABLE_SIGNUP):
         await _audit_deny(
-            user_id=current_user.id if current_user is not None else None,
+            user_id=actor_user_id,
             action="user:create",
             obj="user:*",
             status_code=403,
@@ -205,7 +209,7 @@ async def add_user(
         if not folder:
             await session.rollback()
             await _audit_deny(
-                user_id=current_user.id if current_user is not None else None,
+                user_id=actor_user_id,
                 action="user:create",
                 obj=f"user:{new_user.id}",
                 status_code=500,
@@ -216,7 +220,7 @@ async def add_user(
     except IntegrityError as e:
         await session.rollback()
         await _audit_deny(
-            user_id=current_user.id if current_user is not None else None,
+            user_id=actor_user_id,
             action="user:create",
             obj="user:*",
             status_code=400,
@@ -228,7 +232,7 @@ async def add_user(
     lifecycle_mutation = AuthorizationMutation(
         kind=AuthorizationMutationKind.USER_CREATED,
         entity_id=new_user.id,
-        actor_user_id=current_user.id if current_user is not None else None,
+        actor_user_id=actor_user_id,
         affected_user_ids=(new_user.id,),
         policy_relevant_fields=("is_active", "is_superuser"),
         user_before=None,
@@ -249,7 +253,7 @@ async def add_user(
         await stage_identity_mutation(authorization_service, session, lifecycle_mutation)
         audit_staged = stage_audit_decision(
             session=session,
-            user_id=current_user.id if current_user is not None else new_user.id,
+            user_id=actor_user_id if actor_user_id is not None else new_user.id,
             action="user:create",
             obj=f"user:{new_user.id}",
             result="allow",

--- a/src/backend/base/langflow/cli/admin/commands.py
+++ b/src/backend/base/langflow/cli/admin/commands.py
@@ -553,6 +553,8 @@ def apply_state(
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Confirm a pruning apply.")] = False,
 ) -> None:
     state = _load_manifest_or_fail(file)
+    if prune and not yes and not sys.stdin.isatty():
+        _fail(ValueError("--prune requires --yes in non-interactive use"), usage=True)
     reconciler = _api_call(lambda: _reconciler_from_context(ctx))
     if prune:
         try:
@@ -562,11 +564,8 @@ def apply_state(
         except (AdminAPIError, httpx.HTTPError, ConnectionConfigurationError) as exc:
             _fail(exc, usage=isinstance(exc, ConnectionConfigurationError))
         _emit(ctx, drift, stderr=True)
-        if not yes:
-            if not sys.stdin.isatty():
-                _fail(ValueError("--prune requires --yes in non-interactive use"), usage=True)
-            if not typer.confirm("Apply this pruning plan?"):
-                raise typer.Abort
+        if not yes and not typer.confirm("Apply this pruning plan?"):
+            raise typer.Abort
     try:
         report = reconciler.apply(state, prune=prune)
     except ManifestResolutionError as exc:

--- a/src/backend/base/langflow/cli/admin/reconcile.py
+++ b/src/backend/base/langflow/cli/admin/reconcile.py
@@ -412,9 +412,20 @@ class AdminReconciler:
             desired_assignments_by_subject.setdefault((item.subject.type, item.subject.name), set()).add(
                 (item.role, item.domain.type, str(item.domain.domain_id) if item.domain.domain_id else None)
             )
-        prune_subjects = {("user", item.username) for item in state.users} | {
-            ("team", item.adom_name) for item in state.teams
-        }
+        prune_subjects = {("user", item.username) for item in state.users}
+        if prune and state.teams:
+            if self._team_assignments_available():
+                prune_subjects.update(("team", item.adom_name) for item in state.teams)
+            else:
+                skipped.extend(
+                    {
+                        "action": "revoke",
+                        "resource": "role_assignment",
+                        "key": f"team:{item.adom_name}/*",
+                        "reason": "unsupported",
+                    }
+                    for item in sorted(state.teams, key=lambda team: team.adom_name)
+                )
         subjects = set(desired_assignments_by_subject) | (prune_subjects if prune else set())
         for subject_type, subject_name in sorted(subjects):
             if subject_type == "user":

--- a/src/backend/tests/unit/api/v1/test_authz_admin_routes.py
+++ b/src/backend/tests/unit/api/v1/test_authz_admin_routes.py
@@ -12,12 +12,16 @@ authz service installed via monkeypatch.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
+import anyio
 import pytest
 from fastapi import HTTPException, Response
 from sqlalchemy.exc import IntegrityError
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
 
 # --- shared fakes ----------------------------------------------------- #
 
@@ -159,6 +163,11 @@ class _StubAuthz:
 
 def _make_user(*, is_superuser: bool = False) -> SimpleNamespace:
     return SimpleNamespace(id=uuid4(), is_superuser=is_superuser, username="u")
+
+
+async def _request_without_hanging(client: AsyncClient, method: str, url: str, **kwargs):
+    with anyio.fail_after(5):
+        return await client.request(method, url, **kwargs)
 
 
 def _make_role_row(
@@ -2238,3 +2247,103 @@ async def test_role_list_supports_exact_name_filter(stub_authz):
     )
     compiled = str(captured["stmt"].compile(compile_kwargs={"literal_binds": True}))
     assert "authz_role.name = 'administrator'" in compiled
+
+
+@pytest.mark.asyncio
+async def test_bearer_authenticated_admin_conflicts_return_without_hanging(
+    client: AsyncClient,
+    logged_in_headers_super_user,
+    active_super_user,
+):
+    """Every documented uniqueness conflict must answer session-JWT callers."""
+    from langflow.services.deps import get_settings_service
+
+    headers = logged_in_headers_super_user
+    user_payload = {"username": "conflict-user", "password": "password123"}  # pragma: allowlist secret
+    role_one = await client.post(
+        "api/v1/authz/roles",
+        json={"name": "conflict-role", "permissions": ["flow:read"]},
+        headers=headers,
+    )
+    role_two = await client.post(
+        "api/v1/authz/roles",
+        json={"name": "rename-role", "permissions": ["flow:read"]},
+        headers=headers,
+    )
+    team_one = await client.post(
+        "api/v1/authz/teams",
+        json={"team_name": "Conflict Team", "adom_name": "conflict-team"},
+        headers=headers,
+    )
+    team_two = await client.post(
+        "api/v1/authz/teams",
+        json={"team_name": "Rename Team", "adom_name": "rename-team"},
+        headers=headers,
+    )
+    user_one = await client.post("api/v1/users/", json=user_payload, headers=headers)
+    assert [
+        role_one.status_code,
+        role_two.status_code,
+        team_one.status_code,
+        team_two.status_code,
+        user_one.status_code,
+    ] == [
+        201,
+        201,
+        201,
+        201,
+        201,
+    ]
+
+    membership = await client.post(
+        f"api/v1/authz/teams/{team_one.json()['id']}/members",
+        json={"user_id": str(active_super_user.id)},
+        headers=headers,
+    )
+    assert membership.status_code == 201
+
+    auth_settings = get_settings_service().auth_settings
+    original_audit_enabled = auth_settings.AUTHZ_AUDIT_ENABLED
+    original_audit_durable = auth_settings.AUTHZ_AUDIT_DURABLE
+    auth_settings.AUTHZ_AUDIT_ENABLED = True
+    auth_settings.AUTHZ_AUDIT_DURABLE = True
+    try:
+        requests = [
+            ("POST", "api/v1/users/", {"json": user_payload}, 400),
+            (
+                "POST",
+                "api/v1/authz/roles",
+                {"json": {"name": "conflict-role", "permissions": ["flow:read"]}},
+                409,
+            ),
+            (
+                "PATCH",
+                f"api/v1/authz/roles/{role_two.json()['id']}",
+                {"json": {"name": "conflict-role"}},
+                409,
+            ),
+            (
+                "POST",
+                "api/v1/authz/teams",
+                {"json": {"team_name": "Duplicate Team", "adom_name": "conflict-team"}},
+                409,
+            ),
+            (
+                "PATCH",
+                f"api/v1/authz/teams/{team_two.json()['id']}",
+                {"json": {"adom_name": "conflict-team"}},
+                409,
+            ),
+            (
+                "POST",
+                f"api/v1/authz/teams/{team_one.json()['id']}/members",
+                {"json": {"user_id": str(active_super_user.id)}},
+                409,
+            ),
+        ]
+        for method, url, kwargs, expected_status in requests:
+            response = await _request_without_hanging(client, method, url, headers=headers, **kwargs)
+            assert response.status_code == expected_status, response.text
+    finally:
+        auth_settings.AUTHZ_AUDIT_ENABLED = original_audit_enabled
+        auth_settings.AUTHZ_AUDIT_DURABLE = original_audit_durable

--- a/src/backend/tests/unit/cli/test_admin_cli.py
+++ b/src/backend/tests/unit/cli/test_admin_cli.py
@@ -534,3 +534,26 @@ def test_pruning_preview_maps_api_errors_to_stable_cli_output(monkeypatch, tmp_p
     assert result.exit_code == 1
     assert "Error [directory_unavailable]: Directory catalog is unavailable" in result.output
     assert "Traceback" not in result.output
+
+
+def test_noninteractive_prune_requires_yes_before_api_calls(monkeypatch, tmp_path: Path) -> None:
+    manifest = tmp_path / "admin-state.yaml"
+    manifest.write_text(
+        "apiVersion: langflow.ai/v1\nkind: AdminState\nteams:\n  - adom_name: ops\n    display_name: Operators\n",
+        encoding="utf-8",
+    )
+
+    reconciler_calls = []
+
+    def reconciler_from_context(_ctx):
+        reconciler_calls.append(_ctx)
+        return object()
+
+    monkeypatch.setattr("langflow.cli.admin.commands._reconciler_from_context", reconciler_from_context)
+
+    result = CliRunner().invoke(app, ["admin", "apply", str(manifest), "--prune"])
+
+    assert result.exit_code == 2
+    assert "--prune requires --yes in non-interactive use" in result.output
+    assert "Traceback" not in result.output
+    assert reconciler_calls == []

--- a/src/backend/tests/unit/cli/test_admin_reconcile.py
+++ b/src/backend/tests/unit/cli/test_admin_reconcile.py
@@ -222,6 +222,7 @@ def test_apply_is_dependency_ordered_and_rerun_converges() -> None:
 
 def test_prune_removes_only_manual_records_and_reports_idp_skips() -> None:
     client = FakeAdminClient()
+    client.team_assignments_supported = True
     client.users = [
         {"id": ALICE_ID, "username": "alice", "is_active": True},
         {"id": BOB_ID, "username": "bob", "is_active": True},
@@ -314,6 +315,42 @@ def test_team_assignment_capability_is_cached_for_reconciler_lifetime() -> None:
     reconciler.diff(state)
 
     assert client.capability_calls == 1
+
+
+def test_prune_skips_team_assignments_when_target_does_not_support_them() -> None:
+    team_assignment_requests: list[str] = []
+
+    class OssAdminClient(FakeAdminClient):
+        def list_role_assignments(self, *, user: str | None = None, team: str | None = None) -> list[dict[str, Any]]:
+            if team is not None:
+                team_assignment_requests.append(team)
+            return super().list_role_assignments(user=user, team=team)
+
+    client = OssAdminClient()
+    client.teams = [
+        {"id": TEAM_ID, "adom_name": "ops", "team_name": "Operators", "description": None, "is_active": True}
+    ]
+    state = AdminState.model_validate(
+        {
+            "apiVersion": "langflow.ai/v1",
+            "kind": "AdminState",
+            "teams": [{"adom_name": "ops", "display_name": "Operators"}],
+        }
+    )
+
+    report = AdminReconciler(client).apply(state, prune=True)
+
+    assert report["status"] == "success"
+    assert report["applied"] == []
+    assert team_assignment_requests == []
+    assert report["skipped"] == [
+        {
+            "action": "revoke",
+            "resource": "role_assignment",
+            "key": "team:ops/*",
+            "reason": "unsupported",
+        }
+    ]
 
 
 def test_apply_resolves_entire_manifest_before_writing() -> None:


### PR DESCRIPTION
## Summary
- preserve the authenticated actor ID before database rollback so duplicate user, role, team, and membership requests return their documented 400/409 responses for session JWTs
- skip Enterprise-only team-assignment pruning when the server capability is unavailable and reject non-interactive prune without --yes before making API calls
- document that administration auditing is opt-in and disabled by default

## Verification
- 143 targeted backend and CLI tests passed
- Ruff format and lint passed on changed Python files
- repository commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that administration auditing is disabled by default, how to enable it, log destinations, retained details, and secret-redaction behavior.

- **Bug Fixes**
  - Improved reliability of administrative role, team, and user operations when conflicts occur, preventing requests from hanging and preserving audit records.
  - Prevented non-interactive pruning from proceeding without confirmation.
  - Pruning now skips unsupported team role assignments and reports them clearly instead of attempting invalid changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->