### PR TITLE
fix(tracing): name Langfuse traces after the flow instead of its UUID

### DIFF
--- a/src/backend/base/langflow/services/tracing/langfuse.py
+++ b/src/backend/base/langflow/services/tracing/langfuse.py
@@ -340,6 +340,8 @@ class LangFuseTracer(BaseTracer):
     """
 
     flow_id: str
+    flow_name: str
+    flow_display_name: str
     _trace_context: TraceContext
     langfuse_trace_id: str | None
 
@@ -362,7 +364,13 @@ class LangFuseTracer(BaseTracer):
         self.user_id = user_id
         self.tracing_user_id = tracing_user_id
         self.session_id = session_id
-        self.flow_id = trace_name.split(" - ")[-1]
+        # ``trace_name`` arrives as ``f"{flow_name} - {flow_id}"`` (lfx graph/base.py). Split from the
+        # right so a display name that itself contains " - " survives intact.
+        self.flow_name, _, self.flow_id = trace_name.rpartition(" - ")
+        # The graph formats a missing flow name as the literal "None". Detect it like the LangWatch and
+        # Arize tracers do, but fall back to the flow id (not the project name) so the trace stays
+        # uniquely identifiable.
+        self.flow_display_name = self.flow_name if self.flow_name and self.flow_name != "None" else self.flow_id
         self.spans: dict[str, LangfuseSpan] = OrderedDict()
         self._input_trace_names: dict[str, str] = {}
         self._output_trace_names: dict[str, str] = {}
@@ -411,9 +419,10 @@ class LangFuseTracer(BaseTracer):
             # parent_span_id is NotRequired but ty doesn't fully support this yet
             self._trace_context = TraceContext(trace_id=langfuse_trace_id)  # type: ignore[call-arg]
 
-            # Create root span for the flow - this also creates the trace implicitly
+            # Create root span for the flow - this also creates the trace implicitly. It is named
+            # after the flow so traces can be found by name in Langfuse; the id stays in metadata.
             self._root_span = self._client.start_span(
-                name=self.flow_id,
+                name=self.flow_display_name,
                 trace_context=self._trace_context,
                 metadata={"flow_id": self.flow_id, "project_name": self.project_name},
             )
@@ -423,14 +432,18 @@ class LangFuseTracer(BaseTracer):
             # provides an override via ``tracing_user_id``, stamp it under
             # ``langflow.tracing_user_id`` so it is still recoverable from trace
             # metadata without changing the meaning of ``trace.userId``.
-            trace_kwargs: dict[str, Any] = {
-                "name": self.flow_id,
-                "user_id": self.user_id,
-                "session_id": self.session_id,
-            }
+            # ``flow_id`` is stamped on the trace up front so traces stay filterable
+            # by flow now that the trace name is the display name; ``end()`` later
+            # merges the graph metadata (which also carries it) on top.
+            trace_metadata: dict[str, Any] = {"flow_id": self.flow_id}
             if self.tracing_user_id and self.tracing_user_id != self.user_id:
-                trace_kwargs["metadata"] = {"langflow.tracing_user_id": self.tracing_user_id}
-            self._root_span.update_trace(**trace_kwargs)
+                trace_metadata["langflow.tracing_user_id"] = self.tracing_user_id
+            self._root_span.update_trace(
+                name=self.flow_display_name,
+                user_id=self.user_id,
+                session_id=self.session_id,
+                metadata=trace_metadata,
+            )
 
         except ImportError:
             logger.exception("Could not import langfuse. Please install it with `pip install langfuse`.")

--- a/src/backend/tests/unit/services/tracing/test_langfuse_orphan_generation.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_orphan_generation.py
@@ -295,13 +295,18 @@ class TestRootGenerationNestsUnderFlowTrace:
                 client.shutdown()
 
         spans = {s.name: s for s in exporter.get_finished_spans()}
-        assert "flow-xyz" in spans, f"missing flow root span; got {list(spans)}"
+        # The flow root span carries the flow *display name*, not its id (LE-2451 / #14865).
+        assert "repro" in spans, f"missing flow root span; got {list(spans)}"
         assert "Ollama" in spans, f"missing component span; got {list(spans)}"
         assert "ChatOllama" in spans, f"missing generation span; got {list(spans)}"
 
-        root_span = spans["flow-xyz"]
+        root_span = spans["repro"]
         component_span = spans["Ollama"]
         generation_span = spans["ChatOllama"]
+
+        # Langfuse indexes ``langfuse.trace.name`` for its name search; the id stays in metadata.
+        assert root_span.attributes.get("langfuse.trace.name") == "repro"
+        assert root_span.attributes.get("langfuse.observation.metadata.flow_id") == "flow-xyz"
 
         # The generation is recorded as a langfuse generation (carries token usage).
         assert generation_span.attributes.get("langfuse.observation.type") == "generation"
@@ -311,6 +316,176 @@ class TestRootGenerationNestsUnderFlowTrace:
         # And nest under the component span (not be a root of its own trace).
         assert generation_span.parent is not None
         assert generation_span.parent.span_id == component_span.context.span_id
+
+
+class TestFlowNameParsing:
+    """``LangFuseTracer`` names the trace after the flow, parsed out of ``trace_name``.
+
+    The graph builds ``trace_name`` as ``f"{flow_name} - {flow_id}"`` (LE-2451 / #14865).
+    """
+
+    @staticmethod
+    def _make_tracer(trace_name: str):
+        pytest.importorskip("langfuse")
+        from langflow.services.tracing.langfuse import LangFuseTracer
+
+        with patch("langflow.services.tracing.langfuse._get_or_create_shared_client") as mock_client:
+            mock_client.return_value.auth_check.return_value = True
+            tracer = LangFuseTracer(
+                trace_name=trace_name,
+                trace_type="flow",
+                project_name="test-project",
+                trace_id=uuid.uuid4(),
+            )
+        assert tracer.ready, "tracer setup failed; the SDK calls below were never made"
+        return tracer, mock_client.return_value
+
+    @pytest.mark.parametrize(
+        ("trace_name", "expected_name", "expected_flow_id"),
+        [
+            ("demo flow - flow-xyz", "demo flow", "flow-xyz"),
+            # A display name containing the separator must not be truncated.
+            ("Customer - Agent - flow-xyz", "Customer - Agent", "flow-xyz"),
+        ],
+    )
+    def test_trace_is_named_after_the_flow(self, trace_name, expected_name, expected_flow_id):
+        tracer, client = self._make_tracer(trace_name)
+
+        assert tracer.flow_name == expected_name
+        assert tracer.flow_id == expected_flow_id
+        assert client.start_span.call_args.kwargs["name"] == expected_name
+        assert client.start_span.call_args.kwargs["metadata"]["flow_id"] == expected_flow_id
+        trace_update = client.start_span.return_value.update_trace.call_args.kwargs
+        assert trace_update["name"] == expected_name
+        assert trace_update["metadata"]["flow_id"] == expected_flow_id
+
+    def test_unnamed_flow_falls_back_to_flow_id(self):
+        # An unnamed graph formats its run name as "None - <id>"; the trace must not be called "None".
+        tracer, client = self._make_tracer("None - flow-xyz")
+
+        assert tracer.flow_id == "flow-xyz"
+        assert client.start_span.call_args.kwargs["name"] == "flow-xyz"
+        assert client.start_span.return_value.update_trace.call_args.kwargs["name"] == "flow-xyz"
+
+
+class TestGraphRunNamesTraceAfterFlow:
+    """A real multi-component graph run names the Langfuse trace after the flow (LE-2451 / #14865).
+
+    Drives the real graph engine and the real ``TracingService`` so the run name reaches
+    ``LangFuseTracer`` exactly as in production (``f"{flow_name} - {flow_id}"``), then inspects
+    the spans the langfuse SDK exports.
+    """
+
+    @staticmethod
+    def _build_graph(flow_name: str, flow_id: str):
+        from lfx.components.input_output import ChatInput, ChatOutput, TextInputComponent, TextOutputComponent
+        from lfx.components.processing import CombineTextComponent
+        from lfx.graph.graph.base import Graph
+
+        chat_in = ChatInput(_id="chat-in")
+        chat_in.set(input_value="hello", should_store_message=False, session_id="session-le2451")
+        text_in = TextInputComponent(_id="text-in")
+        text_in.set(input_value="from text input")
+        combine = CombineTextComponent(_id="combine")
+        combine.set(text1=chat_in.message_response, text2=text_in.text_response, delimiter=" | ")
+        text_out = TextOutputComponent(_id="text-out")
+        text_out.set(input_value=combine.combine_texts)
+        chat_out = ChatOutput(_id="chat-out")
+        chat_out.set(input_value=text_out.text_response, should_store_message=False, session_id="session-le2451")
+        return Graph(start=chat_in, end=chat_out, flow_id=flow_id, flow_name=flow_name, user_id="user-le2451")
+
+    @pytest.mark.asyncio
+    async def test_five_component_graph_run(self):
+        pytest.importorskip("langfuse")
+        import asyncio
+        import contextlib
+        from unittest.mock import MagicMock
+
+        import langflow.services.tracing.langfuse as langfuse_module
+        from langflow.services.tracing.base import BaseTracer
+        from langflow.services.tracing.langfuse import LangFuseTracer
+        from langflow.services.tracing.service import TracingService
+        from lfx.services.settings.base import Settings
+        from lfx.services.settings.service import SettingsService
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+        class _InertTracer(BaseTracer):
+            """Stands in for every non-Langfuse provider so only Langfuse is exercised."""
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            @property
+            def ready(self):
+                return False
+
+            def add_trace(self, *args, **kwargs):
+                pass
+
+            def end_trace(self, *args, **kwargs):
+                pass
+
+            def end(self, *args, **kwargs):
+                pass
+
+            def get_langchain_callback(self):
+                return None
+
+        flow_id = str(uuid.uuid4())
+        flow_name = "Customer - Agent"
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        client = _build_real_langfuse_client_or_skip(provider)
+
+        settings = Settings()
+        settings.deactivate_tracing = False
+        service = TracingService(SettingsService(settings, MagicMock()))
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                patch.object(langfuse_module, "_get_or_create_shared_client", lambda config: client)  # noqa: ARG005
+            )
+            stack.enter_context(
+                patch("langflow.services.tracing.service._get_langfuse_tracer", return_value=LangFuseTracer)
+            )
+            # Components resolve the tracing service lazily through lfx deps.
+            stack.enter_context(patch("lfx.services.deps.get_tracing_service", return_value=service))
+            for name in ("langsmith", "langwatch", "arize_phoenix", "opik", "traceloop", "native", "openlayer"):
+                stack.enter_context(
+                    patch(f"langflow.services.tracing.service._get_{name}_tracer", return_value=_InertTracer)
+                )
+            try:
+                graph = self._build_graph(flow_name, flow_id)
+                graph._tracing_service = service
+                graph._tracing_service_initialized = True
+                graph.session_id = "session-le2451"
+                graph.prepare()
+                ran = [result.vertex.id async for result in graph.async_start() if hasattr(result, "vertex")]
+                # The graph ends the trace in a background task; wait for it before reading spans.
+                await asyncio.gather(*graph._end_trace_tasks)
+            finally:
+                client.shutdown()
+
+        assert ran == ["chat-in", "text-in", "combine", "text-out", "chat-out"]
+
+        spans = exporter.get_finished_spans()
+        exported_ids = {s.context.span_id for s in spans}
+        roots = [s for s in spans if s.parent is None or s.parent.span_id not in exported_ids]
+        assert [s.name for s in roots] == [flow_name], f"unexpected root spans; got {[s.name for s in spans]}"
+        root = roots[0]
+
+        assert root.attributes.get("langfuse.trace.name") == flow_name
+        assert root.attributes.get("langfuse.observation.metadata.flow_id") == flow_id
+        assert root.attributes.get("langfuse.trace.metadata.flow_id") == flow_id
+
+        children = [s for s in spans if s is not root]
+        assert {s.name for s in children} == {"Chat Input", "Text Input", "Combine Text", "Text Output", "Chat Output"}
+        assert all(s.parent.span_id == root.context.span_id for s in children)
+        assert len({s.context.trace_id for s in spans}) == 1
 
 
 def test_handler_deepcopy_returns_self(monkeypatch):

--- a/src/backend/tests/unit/services/tracing/test_langfuse_v3_compatibility.py
+++ b/src/backend/tests/unit/services/tracing/test_langfuse_v3_compatibility.py
@@ -229,8 +229,8 @@ class TestLangfuseTracerFunctionality:
 
         update_kwargs = mock_langfuse["root_span"].update_trace.call_args.kwargs
         assert update_kwargs["user_id"] == "auth-user"
-        # No override → no metadata payload was supplied for the override.
-        assert "metadata" not in update_kwargs
+        # No override → only the flow id is stamped; nothing recorded for the override.
+        assert update_kwargs["metadata"] == {"flow_id": "flow-123"}
 
     def test_trace_user_id_stays_auth_user_and_override_goes_to_metadata(self, mock_langfuse):
         """``tracing_user_id`` must not redefine ``trace.userId``; it is stamped in metadata.
@@ -254,7 +254,7 @@ class TestLangfuseTracerFunctionality:
 
         update_kwargs = mock_langfuse["root_span"].update_trace.call_args.kwargs
         assert update_kwargs["user_id"] == "auth-user"
-        assert update_kwargs["metadata"] == {"langflow.tracing_user_id": "end-user-456"}
+        assert update_kwargs["metadata"] == {"flow_id": "flow-123", "langflow.tracing_user_id": "end-user-456"}
 
     def test_tracing_user_id_equal_to_auth_user_is_not_stamped(self, mock_langfuse):
         """When the override matches the auth user there is nothing extra to record."""
@@ -272,7 +272,7 @@ class TestLangfuseTracerFunctionality:
 
         update_kwargs = mock_langfuse["root_span"].update_trace.call_args.kwargs
         assert update_kwargs["user_id"] == "same-user"
-        assert "metadata" not in update_kwargs
+        assert update_kwargs["metadata"] == {"flow_id": "flow-123"}
 
     def test_add_trace_creates_child_span(self, mock_langfuse):
         """Test that add_trace creates a child span using v3 API."""


### PR DESCRIPTION
With Langfuse tracing on, every trace showed up named after the flow's UUID. Typing the flow's name into Langfuse's search found nothing, even though the trace was there, because the name only ever reached Langfuse as metadata.

`LangFuseTracer` was splitting the run name (`"{flow_name} - {flow_id}"`) and keeping just the id for both the root span and the trace name. It now keeps the display name too, uses it for both, and right-partitions so a name like `Customer - Agent` isn't truncated. A graph with no name (which the engine renders as the literal `None`) falls back to the id rather than shipping a trace called `None`. The flow id is also stamped on the trace metadata at creation so traces stay filterable by flow.

Tested against a local Langfuse 4.28 with a five-component flow named `demo flow`:

<table>
<tr><td width="50%"><b>Before</b></td><td width="50%"><b>After</b></td></tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-langfuse-trace-name/before-search.png" alt="Langfuse tracing search for demo flow returns No results, Total 0; the only name suggestion is the flow UUID" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-langfuse-trace-name/after-search.png" alt="Langfuse tracing search for demo flow returns Total 1, a trace whose Trace Name column reads demo flow" width="100%"></td>
</tr>
<tr>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-langfuse-trace-name/before-trace.png" alt="Trace detail whose header is the flow UUID, with Chat Input, Text Input, Combine Text, Text Output and Chat Output nested beneath it" width="100%"></td>
  <td><img src="https://raw.githubusercontent.com/viktoravelino/pr-assets/main/langflow/fix-langfuse-trace-name/after-trace.png" alt="Trace detail whose header reads demo flow, with the same five component spans nested beneath it" width="100%"></td>
</tr>
</table>

Tests: the existing end-to-end test now expects the display name, parsing cases cover a plain name, an embedded ` - `, and the `None` fallback, and a new test runs a real five-component graph through the tracing service and checks the exported span tree (root named after the flow, all component spans under it, one trace id, flow id in metadata).

Fixes #14865


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing names to display the flow name while preserving the flow ID.
  * Added reliable fallback naming for unnamed flows.
  * Ensured trace metadata consistently includes the flow ID.
  * Improved span organization so component activity appears under the correct flow trace.

* **Tests**
  * Added coverage for flow-name parsing, fallback behavior, metadata, and nested tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->