### PR TITLE
fix: avoid redundant model provider refreshes

### DIFF
--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -502,8 +502,11 @@ async def _get_enabled_providers_result(
         # Get all variables (VariableRead objects)
         all_variables = await variable_service.get_all(user_id=current_user.id, session=session)
 
-        # Build a set of all variable names we have
-        all_variable_names = {var.name for var in all_variables}
+        # A stored credential can become unreadable after LANGFLOW_SECRET_KEY
+        # changes. DatabaseVariableService exposes that as has_value=False; do
+        # not treat the row's mere presence as configured or trigger live model
+        # discovery with an unusable credential.
+        available_variable_names = {var.name for var in all_variables if var.has_value}
 
         provider_variable_map = get_model_provider_variable_mapping()
         provider_candidates = [
@@ -530,7 +533,7 @@ async def _get_enabled_providers_result(
             all_required_present = (
                 is_api_key_optional(provider)
                 if not provider_vars
-                else all(v.get("variable_key") in all_variable_names for v in required_vars)
+                else all(v.get("variable_key") in available_variable_names for v in required_vars)
             )
 
             provider_status[provider] = all_required_present

--- a/src/backend/base/langflow/api/v1/models.py
+++ b/src/backend/base/langflow/api/v1/models.py
@@ -343,6 +343,7 @@ async def list_models(
         session=session,
         current_user=current_user,
         provider_policy=configuration_policy,
+        provider_status=provider_configured_status,
     )
     enabled_models_map = enabled_models_result.get("enabled_models", {})
 
@@ -499,15 +500,6 @@ async def _get_enabled_providers_result(
                 status_code=500,
                 detail="Variable service is not an instance of DatabaseVariableService",
             )
-        # Get all variables (VariableRead objects)
-        all_variables = await variable_service.get_all(user_id=current_user.id, session=session)
-
-        # A stored credential can become unreadable after LANGFLOW_SECRET_KEY
-        # changes. DatabaseVariableService exposes that as has_value=False; do
-        # not treat the row's mere presence as configured or trigger live model
-        # discovery with an unusable credential.
-        available_variable_names = {var.name for var in all_variables if var.has_value}
-
         provider_variable_map = get_model_provider_variable_mapping()
         provider_candidates = [
             *provider_variable_map,
@@ -517,6 +509,24 @@ async def _get_enabled_providers_result(
                 if provider not in provider_variable_map and is_api_key_optional(provider)
             ),
         ]
+
+        required_variable_names: set[str] = set()
+        for provider in provider_candidates:
+            if not provider_policy.allows(provider):
+                continue
+            for variable in get_provider_all_variables(provider):
+                variable_key = variable.get("variable_key")
+                if variable.get("required", False) and isinstance(variable_key, str):
+                    required_variable_names.add(variable_key)
+
+        # Only provider credentials matter here. Avoid materializing every user
+        # variable while still treating credentials encrypted under another
+        # LANGFLOW_SECRET_KEY as unavailable.
+        available_variable_names = await variable_service.get_available_variable_names(
+            user_id=current_user.id,
+            names=required_variable_names,
+            session=session,
+        )
 
         # Check which providers have all required variables saved
         enabled_providers = []
@@ -945,6 +955,7 @@ async def _get_enabled_models_result(
     current_user: CurrentActiveUser,
     provider_policy: ModelProviderPolicySnapshot,
     model_names: list[str] | None = None,
+    provider_status: dict[str, bool] | None = None,
 ):
     """Get enabled models for the current user."""
     all_models_by_provider = get_unified_models_detailed(
@@ -952,12 +963,13 @@ async def _get_enabled_models_result(
         include_deprecated=True,
     )
 
-    enabled_providers_result = await _get_enabled_providers_result(
-        session=session,
-        current_user=current_user,
-        provider_policy=provider_policy,
-    )
-    provider_status = enabled_providers_result.get("provider_status", {})
+    if provider_status is None:
+        enabled_providers_result = await _get_enabled_providers_result(
+            session=session,
+            current_user=current_user,
+            provider_policy=provider_policy,
+        )
+        provider_status = enabled_providers_result.get("provider_status", {})
 
     all_models_by_provider = [
         provider_data

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -397,6 +397,32 @@ class DatabaseVariableService(VariableService, Service):
         variables = await self.get_all(user_id=user_id, session=session)
         return [variable.name for variable in variables if variable]
 
+    async def get_available_variable_names(
+        self,
+        user_id: UUID | str,
+        names: set[str],
+        session: AsyncSession,
+    ) -> set[str]:
+        """Return requested variable names that have a usable owned value.
+
+        Args:
+            user_id: The user whose variables should be checked.
+            names: Variable names to check.
+            session: Database session.
+
+        Returns:
+            Names whose stored values are non-empty and, for credentials, decryptable.
+        """
+        if not names:
+            return set()
+
+        stmt = select(Variable).where(
+            Variable.user_id == user_id,
+            col(Variable.name).in_(names),
+        )
+        variables = (await session.exec(stmt)).all()
+        return {variable.name for variable in variables if has_variable_value(variable)}
+
     async def update_variable(
         self,
         user_id: UUID | str,

--- a/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
+++ b/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
@@ -113,6 +113,38 @@ async def test_enabled_providers_after_credential_creation(client: AsyncClient, 
 
 
 @pytest.mark.usefixtures("active_user")
+async def test_undecryptable_credential_does_not_configure_provider_or_trigger_live_discovery(
+    client: AsyncClient, openai_credential, logged_in_headers
+):
+    """A credential encrypted with another secret key must behave as unavailable."""
+    all_vars = await client.get("api/v1/variables/", headers=logged_in_headers)
+    openai_var_name = _provider_variable_mapping.get("OpenAI")
+    for var in all_vars.json():
+        if var.get("name") == openai_var_name:
+            await client.delete(f"api/v1/variables/{var['id']}", headers=logged_in_headers)
+
+    variable_payload = _create_variable_payload(openai_credential["provider"], openai_credential["value"])
+    with mock.patch("langflow.api.v1.variable.validate_model_provider_key", return_value=None):
+        create_response = await client.post("api/v1/variables/", json=variable_payload, headers=logged_in_headers)
+    assert create_response.status_code == status.HTTP_201_CREATED
+
+    with (
+        mock.patch("langflow.services.auth.utils.decrypt_api_key", return_value=""),
+        mock.patch("lfx.base.models.model_utils.get_live_models_for_provider") as live_models,
+    ):
+        enabled_response = await client.get("api/v1/models/enabled_providers", headers=logged_in_headers)
+        models_response = await client.get("api/v1/models", headers=logged_in_headers)
+
+    assert enabled_response.status_code == status.HTTP_200_OK
+    assert enabled_response.json()["provider_status"]["OpenAI"] is False
+    assert "OpenAI" not in enabled_response.json()["enabled_providers"]
+    assert models_response.status_code == status.HTTP_200_OK
+    openai = next(provider for provider in models_response.json() if provider["provider"] == "OpenAI")
+    assert openai["is_configured"] is False
+    live_models.assert_not_called()
+
+
+@pytest.mark.usefixtures("active_user")
 async def test_enabled_providers_multiple_credentials(
     client: AsyncClient, openai_credential, anthropic_credential, google_credential, logged_in_headers
 ):

--- a/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
+++ b/src/backend/tests/unit/api/v1/test_models_enabled_providers.py
@@ -113,6 +113,21 @@ async def test_enabled_providers_after_credential_creation(client: AsyncClient, 
 
 
 @pytest.mark.usefixtures("active_user")
+async def test_models_reuses_enabled_provider_status(client: AsyncClient, logged_in_headers):
+    """The models response should not query provider configuration twice."""
+    provider_result = {"enabled_providers": [], "provider_status": {}}
+    with mock.patch(
+        "langflow.api.v1.models._get_enabled_providers_result",
+        new_callable=mock.AsyncMock,
+        return_value=provider_result,
+    ) as get_enabled_providers:
+        response = await client.get("api/v1/models", headers=logged_in_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    get_enabled_providers.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("active_user")
 async def test_undecryptable_credential_does_not_configure_provider_or_trigger_live_discovery(
     client: AsyncClient, openai_credential, logged_in_headers
 ):

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -481,6 +481,66 @@ async def test_list_variables__empty(service, session: AsyncSession):
     assert isinstance(result, list)
 
 
+async def test_get_available_variable_names_only_checks_requested_owned_rows(service, session: AsyncSession):
+    user_id = uuid4()
+    other_user_id = uuid4()
+    session.add_all(
+        [
+            Variable(
+                user_id=user_id,
+                name="REQUESTED_VALID",
+                value="valid-ciphertext",
+                type=CREDENTIAL_TYPE,
+                default_fields=[],
+            ),
+            Variable(
+                user_id=user_id,
+                name="REQUESTED_BROKEN",
+                value="broken-ciphertext",
+                type=CREDENTIAL_TYPE,
+                default_fields=[],
+            ),
+            Variable(
+                user_id=user_id,
+                name="UNRELATED",
+                value="unrelated-ciphertext",
+                type=CREDENTIAL_TYPE,
+                default_fields=[],
+            ),
+            Variable(
+                user_id=other_user_id,
+                name="OTHER_USER_KEY",
+                value="other-user-ciphertext",
+                type=CREDENTIAL_TYPE,
+                default_fields=[],
+            ),
+        ]
+    )
+    await session.flush()
+
+    checked_values = []
+
+    def decrypt_requested_value(value: str) -> str:
+        checked_values.append(value)
+        return {
+            "valid-ciphertext": "usable-secret",
+            "broken-ciphertext": "",
+        }[value]
+
+    with patch(
+        "langflow.services.variable.service.auth_utils.decrypt_api_key",
+        side_effect=decrypt_requested_value,
+    ):
+        result = await service.get_available_variable_names(
+            user_id=user_id,
+            names={"REQUESTED_VALID", "REQUESTED_BROKEN", "OTHER_USER_KEY"},
+            session=session,
+        )
+
+    assert result == {"REQUESTED_VALID"}
+    assert set(checked_values) == {"valid-ciphertext", "broken-ciphertext"}
+
+
 async def test_update_variable(service, session: AsyncSession):
     user_id = uuid4()
     name = "name"

--- a/src/frontend/src/controllers/API/helpers/provider-scope.ts
+++ b/src/frontend/src/controllers/API/helpers/provider-scope.ts
@@ -3,6 +3,14 @@ export interface ProviderScopeParams {
   projectId?: string;
 }
 
+/**
+ * How long a provider-policy snapshot (catalog, provider-variable mapping,
+ * scoped credentials) is treated as current. Every provider-scoped query
+ * shares this window so consumers can reason about a single freshness
+ * boundary instead of a per-query one.
+ */
+export const PROVIDER_POLICY_STALE_TIME_MS = 30_000;
+
 export const appendProviderScope = (
   queryParams: URLSearchParams,
   scope?: ProviderScopeParams,

--- a/src/frontend/src/controllers/API/helpers/query-cache.ts
+++ b/src/frontend/src/controllers/API/helpers/query-cache.ts
@@ -22,6 +22,27 @@ export const isSettledSuccessfulQuery = (
   );
 };
 
+/**
+ * Returns true when an exact cache entry can no longer be trusted as a current
+ * snapshot: it was never fetched, it has been invalidated, or its data is
+ * older than ``staleTimeMs``.
+ *
+ * A refresh that is already in flight counts as fresh — the new snapshot is on
+ * its way, so asking for another one would only duplicate the request.
+ */
+export const isStaleQuery = (
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  staleTimeMs: number,
+): boolean => {
+  const state = queryClient.getQueryState(queryKey);
+  if (!state) return true;
+  if (state.fetchStatus !== "idle") return false;
+  if (state.status !== "success" || state.isInvalidated) return true;
+  if (!state.dataUpdatedAt) return true;
+  return Date.now() - state.dataUpdatedAt >= staleTimeMs;
+};
+
 export const getSettledSuccessfulQueryData = <T>(
   queryClient: QueryClient,
   queryKey: QueryKey,

--- a/src/frontend/src/controllers/API/queries/models/use-get-model-providers.ts
+++ b/src/frontend/src/controllers/API/queries/models/use-get-model-providers.ts
@@ -3,12 +3,11 @@ import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import {
   appendProviderScope,
+  PROVIDER_POLICY_STALE_TIME_MS,
   type ProviderScopeParams,
   providerScopeQueryKey,
 } from "../../helpers/provider-scope";
 import { UseRequestProcessor } from "../../services/request-processor";
-
-const PROVIDER_POLICY_STALE_TIME_MS = 30_000;
 
 export interface ModelProviderInfo {
   provider: string;

--- a/src/frontend/src/controllers/API/queries/models/use-get-provider-variables.ts
+++ b/src/frontend/src/controllers/API/queries/models/use-get-provider-variables.ts
@@ -4,14 +4,13 @@ import { api } from "../../api";
 import { getURL } from "../../helpers/constants";
 import {
   appendProviderScope,
+  PROVIDER_POLICY_STALE_TIME_MS,
   type ProviderScopeParams,
   providerScopeQueryKey,
 } from "../../helpers/provider-scope";
 import { UseRequestProcessor } from "../../services/request-processor";
 
 export type ProviderVariablesMapping = Record<string, ProviderVariable[]>;
-
-const PROVIDER_POLICY_STALE_TIME_MS = 30_000;
 
 export const getProviderVariablesQueryKey = (params?: ProviderScopeParams) =>
   ["useGetProviderVariables", ...providerScopeQueryKey(params)] as const;

--- a/src/frontend/src/modals/modelProviderModal/__tests__/modelProviderModal.scope.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/modelProviderModal.scope.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "@testing-library/react";
+import ModelProviderModal from "../index";
+
+// ``ModelProvidersContent`` owns ``useProviderConfiguration``. The modal keys
+// it on the authorization scope, so this stub only has to report when React
+// mounts and unmounts an instance.
+const mountEvents: string[] = [];
+
+jest.mock("../components/ModelProvidersContent", () => ({
+  __esModule: true,
+  default: ({ flowId, projectId }: { flowId?: string; projectId?: string }) => {
+    const { useEffect, useRef } = jest.requireActual("react");
+    // Capture the scope this instance was born with. An empty dependency list
+    // is what makes the assertion meaningful: it records mounts, not prop
+    // changes, so the test fails if the ``key`` stops forcing a remount.
+    const mountScopeRef = useRef(`${flowId ?? ""}:${projectId ?? ""}`);
+    useEffect(() => {
+      mountEvents.push(`mount:${mountScopeRef.current}`);
+      return () => {
+        mountEvents.push(`unmount:${mountScopeRef.current}`);
+      };
+    }, []);
+    return <div data-testid="model-providers-content" />;
+  },
+}));
+
+jest.mock("@/hooks/use-refresh-model-inputs", () => ({
+  useRefreshModelInputs: () => ({ refreshAllModelInputs: jest.fn() }),
+}));
+
+describe("ModelProviderModal authorization scope key", () => {
+  beforeEach(() => {
+    mountEvents.length = 0;
+  });
+
+  it("remounts the provider content when the authorization scope changes", () => {
+    const { rerender } = render(
+      <ModelProviderModal
+        open
+        onClose={jest.fn()}
+        modelType="all"
+        flowId="flow-one"
+        projectId="project-one"
+      />,
+    );
+
+    rerender(
+      <ModelProviderModal
+        open
+        onClose={jest.fn()}
+        modelType="all"
+        flowId="flow-two"
+        projectId="project-one"
+      />,
+    );
+
+    // A scope change destroys the hook instance instead of handing it new
+    // props, so ``useProviderConfiguration`` can never observe a scope change
+    // from inside a mounted instance. Anything that has to react to a scope
+    // change belongs on mount, not in a scope-identity comparison.
+    expect(mountEvents).toEqual([
+      "mount:flow-one:project-one",
+      "unmount:flow-one:project-one",
+      "mount:flow-two:project-one",
+    ]);
+  });
+
+  it("keeps the provider content mounted when only the model type changes", () => {
+    const { rerender } = render(
+      <ModelProviderModal
+        open
+        onClose={jest.fn()}
+        modelType="all"
+        flowId="flow-one"
+        projectId="project-one"
+      />,
+    );
+
+    rerender(
+      <ModelProviderModal
+        open
+        onClose={jest.fn()}
+        modelType="embeddings"
+        flowId="flow-one"
+        projectId="project-one"
+      />,
+    );
+
+    expect(mountEvents).toEqual(["mount:flow-one:project-one"]);
+  });
+});

--- a/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
@@ -292,6 +292,71 @@ describe("useProviderConfiguration.handleDisconnect", () => {
     );
   });
 
+  it("does not refetch provider data when only the selected provider changes", () => {
+    const openAIProvider: Provider = {
+      provider: "OpenAI",
+      icon: "OpenAI",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    };
+    const anthropicProvider: Provider = {
+      provider: "Anthropic",
+      icon: "Anthropic",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    };
+    mockModelProviders = [openAIProvider, anthropicProvider];
+
+    const { rerender } = renderScopedProviderConfiguration(
+      openAIProvider,
+      "flow-one",
+      "project-one",
+    );
+    mockInvalidateQueries.mockClear();
+    mockRefetchQueries.mockClear();
+
+    rerender({
+      provider: anthropicProvider,
+      flow: "flow-one",
+      project: "project-one",
+    });
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    expect(mockRefetchQueries).not.toHaveBeenCalled();
+  });
+
+  it("still refetches provider data when the authorization scope changes", async () => {
+    const selectedProvider: Provider = {
+      provider: "OpenAI",
+      icon: "OpenAI",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    };
+    mockModelProviders = [selectedProvider];
+
+    const { rerender } = renderScopedProviderConfiguration(
+      selectedProvider,
+      "flow-one",
+      "project-one",
+    );
+    mockInvalidateQueries.mockClear();
+
+    rerender({
+      provider: selectedProvider,
+      flow: "flow-two",
+      project: "project-one",
+    });
+
+    await waitFor(() =>
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["useGetModelProviders"],
+      }),
+    );
+  });
+
   it("deletes every variable for a multi-variable provider (OpenRouter)", async () => {
     // OpenRouter is the canonical multi-variable provider: API key + two
     // attribution headers. The pre-fix implementation looked up the variable

--- a/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
+++ b/src/frontend/src/modals/modelProviderModal/__tests__/useProviderConfigurationDisconnect.test.tsx
@@ -36,6 +36,19 @@ let mockModelProvidersIsError = false;
 let mockModelProvidersIsSuccess = true;
 let mockModelProvidersFetchStatus: "idle" | "fetching" | "paused" = "idle";
 let mockInvalidatedQueryKey: readonly unknown[] | null = null;
+// Age of every cached provider-policy snapshot unless a key is overridden
+// below. Defaults to "just fetched" so the shared caches read as fresh.
+let mockQueryDataUpdatedAt = Date.now();
+// Per-query-key overrides. A ``null`` entry models a cold cache slot, which is
+// what a scope the user has not visited yet looks like to ``getQueryState``.
+const mockQueryStateOverrides = new Map<
+  string,
+  { dataUpdatedAt: number } | null
+>();
+const setQueryStateOverride = (
+  queryKey: readonly unknown[],
+  state: { dataUpdatedAt: number } | null,
+) => mockQueryStateOverrides.set(JSON.stringify(queryKey), state);
 
 const deleteCalls: Array<{ id: string | undefined }> = [];
 const mockDeleteMutateAsync = jest.fn((params: { id: string | undefined }) => {
@@ -51,12 +64,25 @@ const mockSetErrorData = jest.fn();
 const mockInvalidateQueries = jest.fn();
 const mockRefetchQueries = jest.fn();
 const mockRefreshAllModelInputs = jest.fn(() => Promise.resolve());
-const mockGetQueryState = jest.fn((queryKey: readonly unknown[]) => ({
-  status: "success",
-  fetchStatus: "idle",
-  isInvalidated:
-    JSON.stringify(queryKey) === JSON.stringify(mockInvalidatedQueryKey),
-}));
+const mockGetQueryState = jest.fn((queryKey: readonly unknown[]) => {
+  const serializedKey = JSON.stringify(queryKey);
+  if (mockQueryStateOverrides.has(serializedKey)) {
+    const override = mockQueryStateOverrides.get(serializedKey);
+    if (!override) return undefined;
+    return {
+      status: "success",
+      fetchStatus: "idle",
+      isInvalidated: false,
+      ...override,
+    };
+  }
+  return {
+    status: "success",
+    fetchStatus: "idle",
+    isInvalidated: serializedKey === JSON.stringify(mockInvalidatedQueryKey),
+    dataUpdatedAt: mockQueryDataUpdatedAt,
+  };
+});
 const mockUseGetModelProviders = jest.fn(
   (_params?: unknown, _options?: unknown) => ({
     data: mockModelProviders,
@@ -252,6 +278,8 @@ describe("useProviderConfiguration.handleDisconnect", () => {
     mockModelProvidersIsSuccess = true;
     mockModelProvidersFetchStatus = "idle";
     mockInvalidatedQueryKey = null;
+    mockQueryDataUpdatedAt = Date.now();
+    mockQueryStateOverrides.clear();
     mockValidateMutateAsync.mockReset();
     mockValidateMutateAsync.mockResolvedValue({ valid: true });
     deleteCalls.length = 0;
@@ -327,7 +355,50 @@ describe("useProviderConfiguration.handleDisconnect", () => {
     expect(mockRefetchQueries).not.toHaveBeenCalled();
   });
 
-  it("still refetches provider data when the authorization scope changes", async () => {
+  it("refetches provider data when a provider switch finds the shared snapshot stale", async () => {
+    const openAIProvider: Provider = {
+      provider: "OpenAI",
+      icon: "OpenAI",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    };
+    const anthropicProvider: Provider = {
+      provider: "Anthropic",
+      icon: "Anthropic",
+      is_enabled: true,
+      is_configured: true,
+      models: [],
+    };
+    mockModelProviders = [openAIProvider, anthropicProvider];
+
+    const { rerender } = renderScopedProviderConfiguration(
+      openAIProvider,
+      "flow-one",
+      "project-one",
+    );
+    mockInvalidateQueries.mockClear();
+
+    // ``ModelProvidersContent`` is keyed on the authorization scope, so a
+    // mounted hook only ever sees provider switches. Once the cached snapshot
+    // ages past the policy window, a switch is the moment to pick up a
+    // credential that was revoked or rotated elsewhere.
+    mockQueryDataUpdatedAt = Date.now() - 60_000;
+
+    rerender({
+      provider: anthropicProvider,
+      flow: "flow-one",
+      project: "project-one",
+    });
+
+    await waitFor(() =>
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["useGetModelProviders"],
+      }),
+    );
+  });
+
+  it("refetches provider data for an authorization scope with no cached snapshot", async () => {
     const selectedProvider: Provider = {
       provider: "OpenAI",
       icon: "OpenAI",
@@ -343,6 +414,18 @@ describe("useProviderConfiguration.handleDisconnect", () => {
       "project-one",
     );
     mockInvalidateQueries.mockClear();
+
+    setQueryStateOverride(
+      [
+        "useGetModelProviders",
+        true,
+        undefined,
+        "flow-two",
+        "project-one",
+        "configure",
+      ],
+      null,
+    );
 
     rerender({
       provider: selectedProvider,

--- a/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
+++ b/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
@@ -7,8 +7,14 @@ import {
   VARIABLE_CATEGORY,
 } from "@/constants/providerConstants";
 import { getAxiosErrorMessage } from "@/controllers/API/helpers/get-axios-error-message";
-import type { ProviderScopeParams } from "@/controllers/API/helpers/provider-scope";
-import { isSettledSuccessfulQuery } from "@/controllers/API/helpers/query-cache";
+import {
+  PROVIDER_POLICY_STALE_TIME_MS,
+  type ProviderScopeParams,
+} from "@/controllers/API/helpers/provider-scope";
+import {
+  isSettledSuccessfulQuery,
+  isStaleQuery,
+} from "@/controllers/API/helpers/query-cache";
 import {
   getModelProvidersQueryOptions,
   useGetModelProviders,
@@ -101,10 +107,8 @@ export const useProviderConfiguration = ({
   const _validationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const providerScopeKey = `${flowId ?? ""}\0${projectId ?? ""}`;
   const configurationContextKey = `${flowId ?? ""}\0${projectId ?? ""}\0${selectedProvider?.provider ?? ""}`;
   const previousConfigurationContextRef = useRef(configurationContextKey);
-  const previousProviderScopeRef = useRef(providerScopeKey);
   const activeConfigurationContextRef = useRef<string | null>(
     configurationContextKey,
   );
@@ -231,6 +235,27 @@ export const useProviderConfiguration = ({
     ],
   );
 
+  // True when the shared provider-policy snapshot has aged out, been
+  // invalidated, or was never fetched for this authorization scope. All three
+  // caches are scope-keyed, so a scope the user has not visited yet reports
+  // stale here and refetches on arrival.
+  const isProviderPolicyStale = useCallback(
+    (): boolean =>
+      [
+        providerCatalogQueryKey,
+        globalVariablesQueryKey,
+        providerVariablesQueryKey,
+      ].some((queryKey) =>
+        isStaleQuery(queryClient, queryKey, PROVIDER_POLICY_STALE_TIME_MS),
+      ),
+    [
+      globalVariablesQueryKey,
+      providerCatalogQueryKey,
+      providerVariablesQueryKey,
+      queryClient,
+    ],
+  );
+
   // Invalidate all provider-related caches after successful create/update
   const invalidateProviderQueries = useCallback(async (): Promise<void> => {
     await Promise.all([
@@ -251,10 +276,7 @@ export const useProviderConfiguration = ({
   useEffect(() => {
     const didConfigurationContextChange =
       configurationContextKey !== previousConfigurationContextRef.current;
-    const didProviderScopeChange =
-      providerScopeKey !== previousProviderScopeRef.current;
     previousConfigurationContextRef.current = configurationContextKey;
-    previousProviderScopeRef.current = providerScopeKey;
 
     if (didConfigurationContextChange) {
       setVariableValues({});
@@ -270,14 +292,22 @@ export const useProviderConfiguration = ({
         _validationTimeoutRef.current = null;
       }
 
-      // A provider selection only changes local form state. The cached catalog,
-      // variables, and enabled-model status are shared across every provider in
-      // the same authorization scope, so refetch them only when that scope moves.
-      if (didProviderScopeChange) {
+      // A provider selection only changes local form state: the catalog,
+      // variables, and enabled-model status are shared by every provider in the
+      // same authorization scope, so a switch does not need a fresh copy of
+      // data that was just fetched. It does need one once that shared snapshot
+      // has gone stale — the modal keeps its query observers mounted, so
+      // without this a credential revoked elsewhere would keep reading as
+      // configured until the modal is reopened or the window regains focus.
+      if (isProviderPolicyStale()) {
         void invalidateProviderQueries();
       }
     }
-  }, [configurationContextKey, invalidateProviderQueries, providerScopeKey]);
+  }, [
+    configurationContextKey,
+    invalidateProviderQueries,
+    isProviderPolicyStale,
+  ]);
 
   // Calculate provider variables
   const providerVariables = useMemo((): ProviderVariable[] => {

--- a/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
+++ b/src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts
@@ -101,8 +101,10 @@ export const useProviderConfiguration = ({
   const _validationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const providerScopeKey = `${flowId ?? ""}\0${projectId ?? ""}`;
   const configurationContextKey = `${flowId ?? ""}\0${projectId ?? ""}\0${selectedProvider?.provider ?? ""}`;
   const previousConfigurationContextRef = useRef(configurationContextKey);
+  const previousProviderScopeRef = useRef(providerScopeKey);
   const activeConfigurationContextRef = useRef<string | null>(
     configurationContextKey,
   );
@@ -249,7 +251,10 @@ export const useProviderConfiguration = ({
   useEffect(() => {
     const didConfigurationContextChange =
       configurationContextKey !== previousConfigurationContextRef.current;
+    const didProviderScopeChange =
+      providerScopeKey !== previousProviderScopeRef.current;
     previousConfigurationContextRef.current = configurationContextKey;
+    previousProviderScopeRef.current = providerScopeKey;
 
     if (didConfigurationContextChange) {
       setVariableValues({});
@@ -265,10 +270,14 @@ export const useProviderConfiguration = ({
         _validationTimeoutRef.current = null;
       }
 
-      // Force refetch models when switching provider or authorization scope.
-      void invalidateProviderQueries();
+      // A provider selection only changes local form state. The cached catalog,
+      // variables, and enabled-model status are shared across every provider in
+      // the same authorization scope, so refetch them only when that scope moves.
+      if (didProviderScopeChange) {
+        void invalidateProviderQueries();
+      }
     }
-  }, [configurationContextKey, invalidateProviderQueries]);
+  }, [configurationContextKey, invalidateProviderQueries, providerScopeKey]);
 
   // Calculate provider variables
   const providerVariables = useMemo((): ProviderVariable[] => {


### PR DESCRIPTION
## Summary

- Stop invalidating shared provider data when switching between provider cards; flow and project scope changes still refetch.
- Query only the required provider variables and treat undecryptable credentials as unavailable.
- Reuse provider configuration status while building the model response instead of querying it twice.
- Add regression coverage for provider switching, authorization scope changes, targeted credential lookup, lost secret keys, and provider-status reuse.

## Why

The settings screen was reloading the provider catalog on every provider selection. The backend also scanned and checked every user variable multiple times while building a single model response.

## Testing

- Backend model-provider and variable-service suites: 66 passed.
- Frontend ModelSelection, ProviderList, and provider-configuration suites: 88 passed.
- Ruff, Biome, secret scanning, and repository pre-commit checks passed.
- The repository-wide TypeScript check still reports existing errors in unrelated files; none reference the changed files.