### PR TITLE
fix(kb): allow recreating names after locked deletion

### DIFF
--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -785,18 +785,21 @@ async def create_knowledge_base(
         if kb_path is not None and kb_path.exists():
             # No DB row but a directory survives. If it carries the
             # ``.kb_deleted`` sentinel, a previous delete could not remove the
-            # bytes (typically a held Chroma SQLite lock) — reusing the name now
-            # would silently adopt the old collection's vectors.
+            # bytes (typically because of a held Chroma SQLite lock). Retry the
+            # cleanup now: after a restart the lock should be gone, but clearing
+            # only the sentinel would risk adopting the old collection's vectors.
             if KBStorageHelper.is_kb_dir_deleted(kb_path):
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"Knowledge base '{kb_name}' was recently deleted but its on-disk files "
-                        "are still being released by another process. Restart the server (or wait "
-                        "for the lock to clear) before recreating it with the same name."
-                    ),
-                )
-            raise HTTPException(status_code=409, detail=f"Knowledge base '{kb_name}' already exists")
+                KBStorageHelper.delete_storage(kb_path, kb_name)
+                if kb_path.exists():
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Knowledge base '{kb_name}' was deleted, but its on-disk files are still locked "
+                            "by another process. Close that process, restart Langflow if needed, and try again."
+                        ),
+                    )
+            else:
+                raise HTTPException(status_code=409, detail=f"Knowledge base '{kb_name}' already exists")
 
         await _validate_create_backend(
             backend_type=backend_type_value,

--- a/src/backend/base/langflow/api/v1/knowledge_bases.py
+++ b/src/backend/base/langflow/api/v1/knowledge_bases.py
@@ -789,7 +789,7 @@ async def create_knowledge_base(
             # cleanup now: after a restart the lock should be gone, but clearing
             # only the sentinel would risk adopting the old collection's vectors.
             if KBStorageHelper.is_kb_dir_deleted(kb_path):
-                KBStorageHelper.delete_storage(kb_path, kb_name)
+                await asyncio.to_thread(KBStorageHelper.delete_storage, kb_path, kb_name)
                 if kb_path.exists():
                     raise HTTPException(
                         status_code=409,

--- a/src/backend/tests/unit/test_knowledge_bases_api.py
+++ b/src/backend/tests/unit/test_knowledge_bases_api.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from langchain_core.documents import Document
 from langflow.api.utils import knowledge_base_service
 from langflow.api.utils.kb_helpers import (
+    KB_DELETED_SENTINEL,
     KBAnalysisHelper,
     KBIngestionHelper,
     KBStorageHelper,
@@ -373,6 +374,88 @@ class TestKnowledgeBaseAPI:
         # A remote-backed KB touches no local storage at all: no directory, and
         # certainly no metadata sidecar.
         assert not (tmp_path / active_user.username / kb_name).exists()
+
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.delete_storage")
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_fresh_chroma_client")
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_create_knowledge_base_retries_cleanup_of_deleted_directory(
+        self,
+        mock_root,
+        mock_fresh_client,
+        mock_delete_storage,
+        client: AsyncClient,
+        logged_in_headers,
+        active_user,
+        tmp_path,
+    ):
+        mock_root.return_value = tmp_path
+        mock_fresh_client.return_value = MagicMock()
+        kb_name = "Recreated_KB"
+        kb_path = tmp_path / active_user.username / kb_name
+        kb_path.mkdir(parents=True)
+        (kb_path / "chroma.sqlite3").touch()
+        (kb_path / KB_DELETED_SENTINEL).touch()
+
+        def remove_released_storage(path, name):
+            assert path == kb_path
+            assert name == kb_name
+            for child in path.iterdir():
+                child.unlink()
+            path.rmdir()
+            return True
+
+        mock_delete_storage.side_effect = remove_released_storage
+
+        response = await client.post(
+            "api/v1/knowledge_bases",
+            headers=logged_in_headers,
+            json={
+                "name": kb_name,
+                "embedding_provider": "OpenAI",
+                "embedding_model": "text-embedding-3-small",
+            },
+        )
+
+        assert response.status_code == 201, response.json()
+        mock_delete_storage.assert_called_once_with(kb_path, kb_name)
+        assert kb_path.is_dir()
+        assert not (kb_path / KB_DELETED_SENTINEL).exists()
+        assert await knowledge_base_service.get_by_user_and_name(active_user.id, kb_name) is not None
+
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.delete_storage", return_value=True)
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_fresh_chroma_client")
+    @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")
+    async def test_create_knowledge_base_keeps_409_while_deleted_directory_is_locked(
+        self,
+        mock_root,
+        mock_fresh_client,
+        mock_delete_storage,
+        client: AsyncClient,
+        logged_in_headers,
+        active_user,
+        tmp_path,
+    ):
+        mock_root.return_value = tmp_path
+        kb_name = "Locked_KB"
+        kb_path = tmp_path / active_user.username / kb_name
+        kb_path.mkdir(parents=True)
+        (kb_path / KB_DELETED_SENTINEL).touch()
+
+        response = await client.post(
+            "api/v1/knowledge_bases",
+            headers=logged_in_headers,
+            json={
+                "name": kb_name,
+                "embedding_provider": "OpenAI",
+                "embedding_model": "text-embedding-3-small",
+            },
+        )
+
+        assert response.status_code == 409
+        assert "still locked" in response.json()["detail"]
+        mock_delete_storage.assert_called_once_with(kb_path, kb_name)
+        mock_fresh_client.assert_not_called()
+        assert await knowledge_base_service.get_by_user_and_name(active_user.id, kb_name) is None
 
     @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_fresh_chroma_client")
     @patch("langflow.api.v1.knowledge_bases.KBStorageHelper.get_root_path")

--- a/src/backend/tests/unit/test_knowledge_bases_api.py
+++ b/src/backend/tests/unit/test_knowledge_bases_api.py
@@ -1,5 +1,6 @@
 import io
 import json
+import threading
 import uuid
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -395,10 +396,12 @@ class TestKnowledgeBaseAPI:
         kb_path.mkdir(parents=True)
         (kb_path / "chroma.sqlite3").touch()
         (kb_path / KB_DELETED_SENTINEL).touch()
+        event_loop_thread_id = threading.get_ident()
 
         def remove_released_storage(path, name):
             assert path == kb_path
             assert name == kb_name
+            assert threading.get_ident() != event_loop_thread_id
             for child in path.iterdir():
                 child.unlink()
             path.rmdir()


### PR DESCRIPTION
## Summary
- retry storage cleanup when a create finds a sentinel-marked Knowledge Base directory
- recreate only after the old directory is physically removed, preserving protection against stale-vector adoption
- keep an actionable 409 while files remain locked and add coverage for both outcomes

## Testing
- `uv run pytest src/backend/tests/unit/test_knowledge_bases_api.py src/backend/tests/unit/test_kb_storage_deletion.py -q` (130 passed)
- `uv run ruff check src/backend/base/langflow/api/v1/knowledge_bases.py src/backend/tests/unit/test_knowledge_bases_api.py`
- `uv run ruff format --check src/backend/base/langflow/api/v1/knowledge_bases.py src/backend/tests/unit/test_knowledge_bases_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Knowledge bases can now be recreated when leftover files from a previous deletion are successfully cleaned up.
  - Users receive a clearer conflict message when existing files remain locked and prevent recreation.
  - Prevented incomplete knowledge-base creation when stale files cannot be removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->