### PR TITLE
fix: surface the custom-component policy behind a substituted build failure

### DIFF
--- a/src/lfx/src/lfx/graph/vertex/base.py
+++ b/src/lfx/src/lfx/graph/vertex/base.py
@@ -22,6 +22,7 @@ from lfx.schema.data import Data
 from lfx.schema.message import Message
 from lfx.schema.properties import Usage
 from lfx.schema.schema import INPUT_FIELD_NAME, OutputValue, build_output_logs
+from lfx.utils.flow_validation import explain_restricted_component_mismatch
 from lfx.utils.schemas import ChatOutputResponse
 from lfx.utils.util import sync_to_async
 
@@ -795,6 +796,13 @@ class Vertex:
                     str(flow_id), source=self, target=None, status="error", error=str(exc)
                 )
             msg = f"Error building Component {self.display_name}: \n\n{exc}"
+            # In restricted mode this vertex may have been rebuilt with this server's component
+            # code rather than the code saved in the flow. When the saved component does not
+            # match the one that actually ran, say so: otherwise the policy that discarded it is
+            # invisible and only the substituted component's own complaint reaches the user.
+            mismatch = explain_restricted_component_mismatch(self.data.get("type"), self.data.get("node"))
+            if mismatch:
+                msg = f"{msg}\n\n{mismatch}"
             raise ComponentBuildError(msg, tb) from exc
 
     def _update_built_object_and_artifacts(self, result: Any | tuple[Any, dict] | tuple[Component, Any, dict]) -> None:

--- a/src/lfx/src/lfx/upgrade/checker.py
+++ b/src/lfx/src/lfx/upgrade/checker.py
@@ -184,7 +184,14 @@ def _registry_supports_tool_mode(registry_entry: Mapping[str, Any]) -> bool:
     return any(isinstance(field_data, Mapping) and field_data.get("tool_mode") for field_data in template.values())
 
 
-def _has_breaking_change(registry_entry: dict, node_info: dict) -> bool:
+def has_breaking_change(registry_entry: Mapping[str, Any], node_info: Mapping[str, Any]) -> bool:
+    """Return True when re-stamping this node with the registry's code would break it.
+
+    Public because the restricted-mode build path reports the same condition: there a saved
+    node's code is replaced by this server's copy for the same component type, so a node the
+    checker calls breaking is one whose saved configuration cannot drive the component that
+    actually runs. See ``describe_restricted_component_mismatch``.
+    """
     registry_outputs = registry_entry.get("outputs") or []
     flow_outputs = node_info.get("outputs") or []
     if _node_is_in_tool_mode(flow_outputs):
@@ -231,7 +238,7 @@ def _classify_node(node: dict, registry: dict[str, dict]) -> NodeStatus | None:
     if registry_code is None or node_code == registry_code:
         return NodeStatus(node_id=node_id, component_type=component_type, display_name=display_name, status="ok")
 
-    if _has_breaking_change(registry_entry, node_info):
+    if has_breaking_change(registry_entry, node_info):
         return NodeStatus(
             node_id=node_id, component_type=component_type, display_name=display_name, status="outdated_breaking"
         )

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -1322,6 +1322,102 @@ def _log_outdated_component_code_substitution(swapped: list[str]) -> None:
     )
 
 
+RESTRICTED_MODE_MISMATCH_HINT = (
+    "Note: custom components are disabled on this server (LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false), so "
+    'the build ran this server\'s "{component_type}" component instead of the component code saved in '
+    "the flow, and the saved component does not match it{missing_clause}. If the error above does not "
+    "match how this component is configured in the flow, that substitution is why: update the component "
+    "in the flow editor, or set LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true to run the flow's own code."
+)
+
+
+def _registry_entry_for_component_type(component_type: str) -> Mapping[str, Any] | None:
+    """Return this server's registry entry for ``component_type``, aliases included."""
+    from lfx.interface.components import component_cache
+    from lfx.upgrade.checker import build_registry_lookup
+
+    with component_cache.state_lock:
+        all_types_dict = component_cache.all_types_dict if component_cache.all_types_ready else None
+    if not all_types_dict:
+        return None
+    return build_registry_lookup(all_types_dict).get(component_type)
+
+
+def _unfillable_required_fields(registry_template: Mapping[str, Any], flow_template: Mapping[str, Any]) -> list[str]:
+    """Name the server inputs a saved node cannot supply, using the checker's own rule.
+
+    These are exactly the fields ``_template_keys_compatible`` refuses to introduce silently: a
+    required input the saved node has no key for and whose declared state cannot fill it.
+    """
+    from lfx.upgrade.checker import new_template_field_keys
+
+    missing = []
+    for key in new_template_field_keys(registry_template, flow_template):
+        field = registry_template.get(key)
+        if isinstance(field, Mapping) and field.get("required") and field.get("value") in (None, ""):
+            missing.append(key)
+    return sorted(missing)
+
+
+def describe_restricted_component_mismatch(component_type: Any, node_info: Any) -> str | None:
+    """Explain a build failure caused by restricted mode running server code for a saved component.
+
+    In restricted mode a node's stored code never runs: the build executes this server's
+    component of the same ``data.type`` instead (:func:`substitute_outdated_component_code_in_place`
+    for drifted built-ins, :func:`resolve_trusted_code_for_build` at instantiation). That is what
+    keeps a flow saved before an upgrade runnable, but it is silent — so a node that is a
+    *customized* copy of a built-in is quietly rebuilt as the stock component, and the build fails
+    with whatever that component complains about. A customized Agent surfaces as "No model
+    selected", naming neither the customization nor the policy that discarded it.
+
+    Returns a sentence to append to the build error when the saved component is structurally
+    incompatible with this server's component of the same type -- the same condition the upgrade
+    checker reports as a breaking change, and the frontend as "flow needs review". Returns ``None``
+    in permissive mode, for an unknown type (already refused by :func:`check_flow_and_raise`), when
+    the registry is unavailable, and for a node this server's component can still drive: a legacy
+    Agent carrying ``agent_llm``/``model_name`` runs fine after the swap and must not be blamed.
+    """
+    from lfx.services.deps import get_settings_service
+
+    settings_service = get_settings_service()
+    if settings_service is None or getattr(settings_service.settings, "allow_custom_components", True):
+        return None
+    if not isinstance(component_type, str) or not component_type or not isinstance(node_info, Mapping):
+        return None
+
+    registry_entry = _registry_entry_for_component_type(component_type)
+    if registry_entry is None:
+        return None
+
+    from lfx.upgrade.checker import has_breaking_change
+
+    if not has_breaking_change(registry_entry, node_info):
+        return None
+
+    registry_template = registry_entry.get("template")
+    flow_template = node_info.get("template")
+    missing_clause = ""
+    if isinstance(registry_template, Mapping) and isinstance(flow_template, Mapping):
+        missing = _unfillable_required_fields(registry_template, flow_template)
+        if missing:
+            missing_clause = f" (missing required input: {', '.join(missing)})"
+
+    return RESTRICTED_MODE_MISMATCH_HINT.format(component_type=component_type, missing_clause=missing_clause)
+
+
+def explain_restricted_component_mismatch(component_type: Any, node_info: Any) -> str | None:
+    """Never-raising wrapper for :func:`describe_restricted_component_mismatch`.
+
+    The only caller is a build-error handler, where a diagnostic that raises would replace the
+    component's real error with an unrelated one.
+    """
+    try:
+        return describe_restricted_component_mismatch(component_type, node_info)
+    except Exception:  # noqa: BLE001 -- diagnosis is best effort; never mask the original failure
+        logger.debug("Could not diagnose restricted-mode component mismatch", exc_info=True)
+        return None
+
+
 async def _ensure_public_component_lookup_snapshot(
     settings_service: Any,
 ) -> tuple[dict[str, str], Mapping[str, set[str]]]:

--- a/src/lfx/tests/unit/utils/test_restricted_component_mismatch.py
+++ b/src/lfx/tests/unit/utils/test_restricted_component_mismatch.py
@@ -1,0 +1,180 @@
+"""Restricted-mode diagnosis for a saved component this server replaced with its own.
+
+With ``LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false`` a node's stored code never runs: the build
+executes this server's component of the same ``data.type`` instead. That keeps flows saved
+before an upgrade runnable, but it is silent, so a node that is a *customized* copy of a
+built-in is quietly rebuilt as the stock component and fails with whatever that component
+complains about -- a customized Agent surfaces as "No model selected", naming neither the
+customization nor the policy that discarded it.
+
+These tests pin the diagnosis appended to such a failure, and the cases it must stay quiet for.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from lfx.interface.components import component_cache
+from lfx.utils.flow_validation import (
+    describe_restricted_component_mismatch,
+    explain_restricted_component_mismatch,
+)
+
+SERVER_AGENT_CODE = "# Agent (this server)"
+
+SERVER_AGENT_OUTPUTS = [
+    {
+        "name": "response",
+        "display_name": "Response",
+        "types": ["Message"],
+        "method": "message_response",
+        "allows_loop": False,
+    }
+]
+
+
+def _registry() -> dict:
+    """A one-component registry whose Agent declares a required, unfillable ``model`` input."""
+    return {
+        "models_and_agents": {
+            "Agent": {
+                "template": {
+                    "code": {"value": SERVER_AGENT_CODE, "required": True, "show": True},
+                    "model": {"required": True, "value": "", "show": True, "_input_type": "ModelInput"},
+                    "system_prompt": {"required": False, "value": "", "show": True},
+                },
+                "outputs": SERVER_AGENT_OUTPUTS,
+                "metadata": {"code_hash": "hash-agent"},
+            }
+        }
+    }
+
+
+def _saved_agent(*, template: dict | None = None) -> dict:
+    return {
+        "display_name": "Agent",
+        "template": template
+        if template is not None
+        else {
+            "code": {"value": SERVER_AGENT_CODE, "required": True, "show": True},
+            "model": {"required": True, "value": "", "show": True, "_input_type": "ModelInput"},
+            "system_prompt": {"required": False, "value": "", "show": True},
+        },
+        "outputs": SERVER_AGENT_OUTPUTS,
+    }
+
+
+def _customized_agent() -> dict:
+    """A fork of the built-in Agent: same ``type``, its own provider inputs, no ``model``."""
+    return _saved_agent(
+        template={
+            "code": {"value": SERVER_AGENT_CODE + "\n# customization\n", "required": True, "show": True},
+            "provider": {"required": True, "value": "", "show": True, "_input_type": "DropdownInput"},
+            "system_prompt": {"required": False, "value": "", "show": True},
+        }
+    )
+
+
+def _restrict(monkeypatch, *, allow_custom=False, registry=_registry, ready=True) -> None:
+    monkeypatch.setattr(
+        "lfx.services.deps.get_settings_service",
+        lambda: SimpleNamespace(settings=SimpleNamespace(allow_custom_components=allow_custom)),
+    )
+    monkeypatch.setattr(component_cache, "all_types_dict", registry() if registry else None)
+    monkeypatch.setattr(component_cache, "all_types_ready", ready)
+
+
+def test_customized_builtin_is_named_with_the_policy_that_replaced_it(monkeypatch):
+    _restrict(monkeypatch)
+
+    hint = describe_restricted_component_mismatch("Agent", _customized_agent())
+
+    assert hint is not None
+    assert "LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false" in hint
+    assert '"Agent"' in hint
+    assert "missing required input: model" in hint
+
+
+def test_permissive_mode_says_nothing(monkeypatch):
+    """With custom components allowed the node's own code runs, so nothing was replaced."""
+    _restrict(monkeypatch, allow_custom=True)
+
+    assert describe_restricted_component_mismatch("Agent", _customized_agent()) is None
+
+
+def test_component_matching_this_server_says_nothing(monkeypatch):
+    """A node this server's component can drive must not be blamed for an unrelated failure."""
+    _restrict(monkeypatch)
+
+    assert describe_restricted_component_mismatch("Agent", _saved_agent()) is None
+
+
+def test_unknown_component_type_says_nothing(monkeypatch):
+    """An unrecognized type never reaches a build -- ``check_flow_and_raise`` blocks it first."""
+    _restrict(monkeypatch)
+
+    assert describe_restricted_component_mismatch("TotallyCustom", _customized_agent()) is None
+
+
+def test_registry_not_loaded_says_nothing(monkeypatch):
+    _restrict(monkeypatch, registry=None, ready=False)
+
+    assert describe_restricted_component_mismatch("Agent", _customized_agent()) is None
+
+
+@pytest.mark.parametrize(("component_type", "node_info"), [(None, _customized_agent()), ("Agent", None), ("", {})])
+def test_malformed_input_says_nothing(monkeypatch, component_type, node_info):
+    _restrict(monkeypatch)
+
+    assert describe_restricted_component_mismatch(component_type, node_info) is None
+
+
+def test_breaking_outputs_are_reported_without_a_missing_input_clause(monkeypatch):
+    """Not every mismatch is a missing input; the clause is dropped rather than left empty."""
+    _restrict(monkeypatch)
+    node_info = _saved_agent()
+    node_info["outputs"] = [{"name": "renamed", "display_name": "Renamed", "types": ["Message"]}]
+
+    hint = describe_restricted_component_mismatch("Agent", node_info)
+
+    assert hint is not None
+    assert "missing required input" not in hint
+
+
+def test_explain_never_raises(monkeypatch):
+    """The only caller is an error handler: a raising diagnosis would mask the real failure."""
+
+    def _boom():
+        msg = "registry exploded"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("lfx.services.deps.get_settings_service", _boom)
+
+    assert explain_restricted_component_mismatch("Agent", _customized_agent()) is None
+
+
+def test_build_error_carries_the_diagnosis(monkeypatch):
+    """The failure a user actually sees names the policy, not just the stock component's complaint."""
+    from lfx.exceptions.component import ComponentBuildError
+    from lfx.graph.vertex.base import Vertex
+
+    _restrict(monkeypatch)
+
+    async def _raise(**_kwargs):
+        msg = "No model selected. Please select a language model from the available options."
+        raise ValueError(msg)
+
+    monkeypatch.setattr("lfx.interface.initialize.loading.get_instance_results", _raise)
+
+    vertex = Vertex.__new__(Vertex)
+    vertex.display_name = "Agent"
+    vertex.data = {"type": "Agent", "node": _customized_agent()}
+    vertex.graph = SimpleNamespace(flow_id=None)
+
+    with pytest.raises(ComponentBuildError) as excinfo:
+        asyncio.run(vertex._build_results(custom_component=None, custom_params={}, base_type="component"))
+
+    message = str(excinfo.value)
+    assert "No model selected" in message
+    assert "LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false" in message
+    assert "missing required input: model" in message


### PR DESCRIPTION
## Problem

With the IBM Langflow defaults

```
LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
LANGFLOW_CUSTOM_COMPONENT_ADMIN_ONLY=true
```

running a flow that contains a **customized Agent** fails with a message about model
selection, not about custom components:

```
Error building Component Agent:

No model selected. Please select a language model from the available options.
```

Nothing tells the user that their customized component was discarded, or that the
server's policy is what discarded it.

### Why it happens

In restricted mode a node's stored code never runs. `substitute_outdated_component_code`
(default `true`) rebuilds a node whose `data.type` is a known server component with **this
server's** code, and `resolve_trusted_code_for_build` substitutes again by code hash at
instantiation. That is deliberate — it is what keeps a flow saved before an upgrade
runnable instead of refusing it over code that was never going to execute (#14455).

But the swap replaces only `template.code.value`; the node keeps its saved template. A
customized fork of the built-in Agent still declares `data.type: "Agent"`, so it is not
blocked as a custom component — it is silently rebuilt as the stock Agent, which then
finds none of the inputs the fork declared and complains about the model.

Reproduced against `release-1.12.1` (`Simple Agent` starter project, Agent node's code
edited and its `model` input replaced with the fork's own provider field):

```
[1] pristine flow: PASSES validation (expected)
[2] CUSTOMIZED flow: PASSES validation  <-- should be reported
[2] substituted nodes: ['Agent (Agent-EXpSZ)']
[2] code after substitution == server code: True
[2] template still has 'model'?  False
```

then, at build time:

```
Error building Component Agent:

No model selected. Please select a language model from the available options.
```

Note this is **not** enterprise-only — it reproduces on OSS with the two env vars above.
With `custom_component_admin_only=true` alone (custom components still allowed), the
existing strict hash gate blocks the node correctly; only the
`allow_custom_components=false` + substitution combination is affected.

## Fix

Diagnose the substitution at the point the user sees the failure. When a component build
fails in restricted mode and the saved component is structurally incompatible with this
server's component of the same type, append the reason:

```
Error building Component Agent:

No model selected. Please select a language model from the available options.

Note: custom components are disabled on this server (LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false),
so the build ran this server's "Agent" component instead of the component code saved in the
flow, and the saved component does not match it (missing required input: model). If the error
above does not match how this component is configured in the flow, that substitution is why:
update the component in the flow editor, or set LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true to run
the flow's own code.
```

"Structurally incompatible" is not a new rule: it is `lfx.upgrade.checker`'s existing
breaking-change check — the same condition the editor already renders as *flow needs review*
and the update modal as a breaking change. `_has_breaking_change` becomes public
(`has_breaking_change`) so the build path and the checker cannot drift apart.

### Why a diagnosis and not a refusal

Refusing every structurally-incompatible substitution would break the upgrades substitution
exists to serve. A legacy Agent saved with `agent_llm`/`model_name` and no `model` input is
just as "incompatible" by template shape, yet it still runs after the swap through
`AgentComponent._resolve_selected_model`'s legacy path — verified on this branch, it reaches
the API-key check rather than failing model selection. The two cases are only distinguishable
by running, so the change enriches the failure that already happens and leaves the working
case working.

The wording states facts and offers the causal link conditionally, so it stays accurate on
the false-positive path (an outdated-but-working component failing for an unrelated reason
still gets correct advice: update it).

## Changes

- `lfx/utils/flow_validation.py`: `describe_restricted_component_mismatch` plus its
  never-raising wrapper `explain_restricted_component_mismatch` (the only caller is an error
  handler; a raising diagnosis would mask the real failure).
- `lfx/graph/vertex/base.py`: append the diagnosis to `ComponentBuildError`.
- `lfx/upgrade/checker.py`: `_has_breaking_change` → public `has_breaking_change`.

No behavior change in permissive mode (the default): the helper returns `None` before
touching the registry.

## Test plan

- [x] New `src/lfx/tests/unit/utils/test_restricted_component_mismatch.py` (11 tests):
      the customized built-in is named with the policy and the missing input; permissive
      mode, a matching component, an unknown type, an unloaded registry, and malformed
      input all stay silent; a breaking-outputs mismatch drops the missing-input clause;
      the wrapper never raises; and the `ComponentBuildError` a user sees carries the
      diagnosis.
- [x] Mutation-verified: stubbing out the `vertex/base.py` wiring fails
      `test_build_error_carries_the_diagnosis` (10 passed, 1 failed), so the test covers
      the seam rather than just the helper.
- [x] `uv run pytest tests/unit/utils tests/unit/upgrade` in `src/lfx` — 885 passed, 2 skipped.
- [x] `tests/unit/graph` — the 2 failures in `test_graph.py`
      (`CatalogPolicyIdentityUnavailableError`) reproduce unchanged on `release-1.12.1`
      without this patch; they are pre-existing and unrelated.
- [x] End-to-end against the `Simple Agent` starter project with
      `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` and `LANGFLOW_CUSTOM_COMPONENT_ADMIN_ONLY=true`:
      customized Agent now reports the policy; unedited legacy Agent still builds past model
      resolution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build errors now provide clearer explanations when restricted mode replaces a saved component with a structurally incompatible server version.
  * Diagnostics identify relevant policies and unsatisfied required inputs where applicable.
* **Improvements**
  * Breaking-change checks are now available through a broader public interface.
* **Tests**
  * Added coverage for restricted-mode mismatches, compatible components, malformed data, and diagnostic error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->