### PR TITLE
fix(mcp): let slow-starting MCP servers connect instead of timing out at 20s

### DIFF
--- a/docs/docs/Agents/mcp-server.mdx
+++ b/docs/docs/Agents/mcp-server.mdx
@@ -430,7 +430,7 @@ The following environment variables set behaviors related to your Langflow proje
 | `LANGFLOW_MCP_SERVER_ENABLE_PROGRESS_NOTIFICATIONS` | Boolean | `False` | If `true`, Langflow MCP servers send progress notifications. |
 | `LANGFLOW_SKIP_MCP_AUTO_INIT` | Boolean | `False` | If `true`, skip background MCP server auto-initialization on startup. Use this on offline, firewalled, or CI hosts so startup does not wait on outbound MCP connections. |
 | `LANGFLOW_MCP_COMPOSER_ENABLED` | Boolean | `True` | Whether to start the MCP Composer service. |
-| `LANGFLOW_MCP_SERVER_TIMEOUT` | Integer | `20` | Timeout in seconds for MCP connection setup and tool execution. See [Configure tool execution timeouts](#configure-tool-execution-timeouts). |
+| `LANGFLOW_MCP_SERVER_TIMEOUT` | Integer | `60` | Timeout in seconds for MCP connection setup and tool execution. See [Configure tool execution timeouts](#configure-tool-execution-timeouts). |
 | `LANGFLOW_MCP_TOOL_EXECUTION_TIMEOUT` | Integer | `180` | Global timeout in seconds for MCP tool calls. See [Configure tool execution timeouts](#configure-tool-execution-timeouts). |
 | `LANGFLOW_MCP_MAX_SESSIONS_PER_SERVER` | Integer | `10` | Maximum number of MCP sessions to keep per unique server. |
 | `LANGFLOW_ADD_PROJECTS_TO_MCP_SERVERS` | Boolean | `True` | Whether to automatically add newly created projects to the user's MCP servers configuration. If `false`, projects must be manually added to MCP servers. |

--- a/docs/versioned_docs/version-1.12.0/Agents/mcp-server.mdx
+++ b/docs/versioned_docs/version-1.12.0/Agents/mcp-server.mdx
@@ -430,7 +430,7 @@ The following environment variables set behaviors related to your Langflow proje
 | `LANGFLOW_MCP_SERVER_ENABLE_PROGRESS_NOTIFICATIONS` | Boolean | `False` | If `true`, Langflow MCP servers send progress notifications. |
 | `LANGFLOW_SKIP_MCP_AUTO_INIT` | Boolean | `False` | If `true`, skip background MCP server auto-initialization on startup. Use this on offline, firewalled, or CI hosts so startup does not wait on outbound MCP connections. |
 | `LANGFLOW_MCP_COMPOSER_ENABLED` | Boolean | `True` | Whether to start the MCP Composer service. |
-| `LANGFLOW_MCP_SERVER_TIMEOUT` | Integer | `20` | Timeout in seconds for MCP connection setup and tool execution. See [Configure tool execution timeouts](#configure-tool-execution-timeouts). |
+| `LANGFLOW_MCP_SERVER_TIMEOUT` | Integer | `60` | Timeout in seconds for MCP connection setup and tool execution. See [Configure tool execution timeouts](#configure-tool-execution-timeouts). |
 | `LANGFLOW_MCP_TOOL_EXECUTION_TIMEOUT` | Integer | `180` | Global timeout in seconds for MCP tool calls. See [Configure tool execution timeouts](#configure-tool-execution-timeouts). |
 | `LANGFLOW_MCP_MAX_SESSIONS_PER_SERVER` | Integer | `10` | Maximum number of MCP sessions to keep per unique server. |
 | `LANGFLOW_ADD_PROJECTS_TO_MCP_SERVERS` | Boolean | `True` | Whether to automatically add newly created projects to the user's MCP servers configuration. If `false`, projects must be manually added to MCP servers. |

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -60,6 +60,9 @@ is_dangerous_mcp_env_var = mcp_security.is_dangerous_mcp_env_var
 # Minimum cleanup interval to prevent tight-loop CPU spin if settings return 0 or fail.
 _MCP_CLEANUP_INTERVAL_MIN = 30  # seconds
 _SESSION_VALIDATION_TIMEOUT_FLOOR = 10.0
+# Mirrors the McpSettings.mcp_server_timeout default. Only used when the settings object lacks
+# the field or carries a non-positive value, so a misconfiguration cannot resurrect a shorter cap.
+_SESSION_INIT_TIMEOUT_FALLBACK = 60.0
 
 
 def _validate_mcp_stdio_env(env: dict[str, str] | None) -> dict[str, str]:
@@ -102,6 +105,23 @@ def get_session_validation_timeout() -> float:
     if connect_timeout is None:
         return _SESSION_VALIDATION_TIMEOUT_FLOOR
     return max(_SESSION_VALIDATION_TIMEOUT_FLOOR, float(connect_timeout) / 3.0)
+
+
+def get_session_init_timeout() -> float:
+    """Budget for a new transport session to finish ``initialize``.
+
+    Derived from ``mcp_server_timeout`` so the inner readiness wait in the session
+    creators and the outer ``connect_to_server`` budget are the same number. This used
+    to be a hardcoded 30 s, which silently capped ``LANGFLOW_MCP_SERVER_TIMEOUT`` at 30
+    and, on the ``run_tool`` path (no outer connect budget), was the real connect limit.
+
+    Non-positive values are treated as unset, like ``_resolve_mcp_tool_execution_timeout``,
+    because ``asyncio.wait_for`` fails immediately for any timeout <= 0.
+    """
+    connect_timeout = _get_mcp_setting("mcp_server_timeout", None)
+    if connect_timeout is None or float(connect_timeout) <= 0:
+        return _SESSION_INIT_TIMEOUT_FALLBACK
+    return float(connect_timeout)
 
 
 def get_max_sessions_per_server() -> int:
@@ -1503,9 +1523,10 @@ class MCPSessionManager:
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-        # Wait for session to be ready (use longer timeout for remote connections)
+        # Wait for the session to be ready within the configured connect budget. A cold stdio
+        # server (e.g. a packaged interpreter importing Langflow) can take well over 20 s here.
         try:
-            session = await asyncio.wait_for(session_future, timeout=30.0)
+            session = await asyncio.wait_for(session_future, timeout=get_session_init_timeout())
         except asyncio.CancelledError:
             self._abort_session_task(task)
             raise
@@ -1672,7 +1693,7 @@ class MCPSessionManager:
         task.add_done_callback(self._background_tasks.discard)
 
         try:
-            session = await asyncio.wait_for(session_future, timeout=30.0)
+            session = await asyncio.wait_for(session_future, timeout=get_session_init_timeout())
             if used_transport:
                 transport_used = used_transport[0]
                 await logger.ainfo(f"Session {session_id} successfully established using {transport_used}")

--- a/src/lfx/src/lfx/services/settings/groups/mcp.py
+++ b/src/lfx/src/lfx/services/settings/groups/mcp.py
@@ -16,8 +16,19 @@ class McpSettings(BaseModel):
     When empty (default): the backend builds URLs from host/port (0.0.0.0 -> localhost) and the
     frontend falls back to the browser's window.location.origin."""
 
-    mcp_server_timeout: int = 20
-    """The number of seconds to wait before giving up on establishing a connection to the MCP server."""
+    mcp_server_timeout: int = 60
+    """The number of seconds to wait before giving up on establishing a connection to the MCP server.
+
+    Bounds the outer ``connect_to_server`` call for every transport and the wait for a new
+    stdio or Streamable HTTP session to become ready. It does not change the per-attempt 2 s
+    cap on the Streamable HTTP ``initialize`` handshake, so a slow-to-start server is only
+    tolerated over stdio. The default is sized for a cold stdio server inside a packaged
+    interpreter (Langflow Desktop's bundled ``langflow.agentic.mcp`` takes 18-25 s to import
+    on first launch), not a warm developer venv.
+
+    It also acts as a floor for ``mcp_tool_execution_timeout``: tool calls wait for the larger
+    of the two, so lowering the tool timeout below this value has no effect.
+    Env var: LANGFLOW_MCP_SERVER_TIMEOUT."""
 
     mcp_tool_execution_timeout: float = 180.0
     """Maximum seconds to wait for MCP tool execution before timing out.

--- a/src/lfx/tests/unit/mcp/test_tool_execution_timeout.py
+++ b/src/lfx/tests/unit/mcp/test_tool_execution_timeout.py
@@ -1,5 +1,6 @@
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from lfx.base.mcp.util import (
@@ -7,6 +8,7 @@ from lfx.base.mcp.util import (
     MCPStdioClient,
     MCPStreamableHttpClient,
     _resolve_mcp_tool_execution_timeout,
+    get_session_init_timeout,
     get_session_validation_timeout,
 )
 from lfx.observability import _root_error_type
@@ -135,6 +137,114 @@ async def test_repeated_tool_timeout_preserves_the_root_error(client_class, conn
 
     assert isinstance(exc_info.value.__cause__, TimeoutError)
     assert _root_error_type(exc_info.value) == "TimeoutError"
+
+
+@pytest.mark.parametrize(
+    ("server_timeout", "expected"),
+    [
+        (None, 60.0),
+        (0, 60.0),
+        (-1, 60.0),
+        (20, 20.0),
+        (60, 60.0),
+        (120, 120.0),
+    ],
+)
+def test_get_session_init_timeout_uses_connection_budget(server_timeout, expected):
+    """The session readiness wait must follow mcp_server_timeout, not a hardcoded 30 s.
+
+    Missing or non-positive values fall back to the settings default rather than a shorter cap.
+    """
+    with patch("lfx.base.mcp.util._get_mcp_setting", return_value=server_timeout):
+        assert get_session_init_timeout() == expected
+
+
+class _ReadyClientSession:
+    """ClientSession stand-in whose initialize completes immediately."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def initialize(self):
+        return None
+
+
+_real_wait_for = asyncio.wait_for
+
+
+def _recording_wait_for(observed: list[float]):
+    """Record every timeout handed to asyncio.wait_for while still enforcing it."""
+
+    async def wait_for(awaitable, *, timeout):
+        observed.append(timeout)
+        return await _real_wait_for(awaitable, timeout=timeout)
+
+    return wait_for
+
+
+@pytest.mark.asyncio
+async def test_stdio_session_creation_waits_with_configured_budget():
+    """LE-2507: a raised LANGFLOW_MCP_SERVER_TIMEOUT must reach the stdio readiness wait."""
+    manager = MCPSessionManager()
+    observed: list[float] = []
+    stdio_client = MagicMock()
+    stdio_client.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+    stdio_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    task = None
+    try:
+        with (
+            patch("lfx.base.mcp.util.get_session_init_timeout", return_value=45.0),
+            patch("lfx.base.mcp.util.ClientSession", return_value=_ReadyClientSession()),
+            patch("mcp.client.stdio.stdio_client", stdio_client),
+            patch("lfx.base.mcp.util.asyncio.wait_for", side_effect=_recording_wait_for(observed)),
+        ):
+            _session, task = await manager._create_stdio_session("test_session", MagicMock())
+    finally:
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        await manager.cleanup_all()
+
+    # The patch is process-wide for the block, so assert on presence rather than exact shape.
+    assert 45.0 in observed
+    assert 30.0 not in observed
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_session_creation_waits_with_configured_budget():
+    """LE-2507: the same budget must reach the Streamable HTTP readiness wait."""
+    manager = MCPSessionManager()
+    observed: list[float] = []
+    http_client = MagicMock()
+    http_client.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), MagicMock()))
+    http_client.return_value.__aexit__ = AsyncMock(return_value=None)
+    connection_params = {"url": "http://127.0.0.1:9931/mcp", "headers": {}, "timeout_seconds": 5}
+
+    task = None
+    try:
+        with (
+            patch("lfx.base.mcp.util.get_session_init_timeout", return_value=45.0),
+            patch("lfx.base.mcp.util.ClientSession", return_value=_ReadyClientSession()),
+            patch("mcp.client.streamable_http.streamablehttp_client", http_client),
+            patch("lfx.base.mcp.util.asyncio.wait_for", side_effect=_recording_wait_for(observed)),
+        ):
+            _session, task, transport, _locked = await manager._create_streamable_http_session(
+                "test_session", connection_params
+            )
+    finally:
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        await manager.cleanup_all()
+
+    assert transport == "streamable_http"
+    # The background task also bounds session.initialize() (2 s); the readiness wait is the budget.
+    assert 45.0 in observed
+    assert 30.0 not in observed
 
 
 # Made with Bob


### PR DESCRIPTION
On Langflow Desktop, dropping an **MCP Tools** component on the canvas and picking the bundled `langflow-agentic` server left the Tool dropdown empty with "Timeout updating tool list". The server was fine. It just takes 18-25 s to import the Langflow stack inside the packaged interpreter, and the client gave up at 20 s. Any stdio MCP server with a slow cold start hit the same wall, and the error's own advice to raise `LANGFLOW_MCP_SERVER_TIMEOUT` silently stopped working above 30 s because the session readiness wait was a hardcoded `30.0`.

Now there is one connect budget. `mcp_server_timeout` bounds both the outer connect call and the session readiness wait on stdio and Streamable HTTP, and the default is 60 s so a cold packaged interpreter fits. Zero or negative values fall back to the default rather than failing every connection instantly.

Driving the real `MCPStdioClient.connect_to_server` against a stdio server with a controlled startup delay:

| Case | Server ready | `mcp_server_timeout` | Before | After |
| --- | --- | --- | --- | --- |
| Default settings | ~25 s | default | `TimeoutError` at 20.0 s | connects at 25.3 s |
| Env override | ~33 s | 60 | `Timeout waiting for STDIO session` at 32.0 s | connects at 33.2 s |
| Real `python -m langflow.agentic.mcp` | ~20 s cold | 90 | connects at 19.8 s (on the boundary) | connects |

Tradeoffs worth knowing:

- `GET /api/v2/mcp/servers?action_count=true` checks every configured server concurrently with this budget, so a dead server can hold that request for up to 60 s instead of 20 s.
- The Streamable HTTP `initialize` handshake still has its own 2 s per-attempt cap, so the longer budget only rescues slow-starting **stdio** servers. The settings docstring says so.
- `mcp_server_timeout` was already a floor for `mcp_tool_execution_timeout`; that coupling is now documented rather than changed.

Desktop needs no code change. It picks this up with the next bundled langflow wheel.

Jira: [LE-2507](https://datastax.jira.com/browse/LE-2507)


[LE-2507]: https://datastax.jira.com/browse/LE-2507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the default MCP server connection timeout from 20 to 60 seconds.
  * Session initialization now follows the configured MCP server timeout, with a 60-second fallback when no valid value is provided.
  * Added support for configuring the timeout through the `LANGFLOW_MCP_SERVER_TIMEOUT` environment variable.

* **Documentation**
  * Updated current and versioned documentation to reflect the new 60-second default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->