### PR TITLE
fix(jobs): atomically claim expired HITL pauses

### DIFF
--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -896,20 +896,33 @@ class JobService(Service):
 
         Returns the ids transitioned to FAILED.
         """
+        from sqlmodel import update
+
         error_payload = {"type": "input_timed_out"}
         reconciled: list[UUID] = []
         async with session_scope() as session:
             result = await session.exec(select(Job).where(Job.status == JobStatus.SUSPENDED))
             now = datetime.now(timezone.utc)
+            deadline_expr = col(Job.job_metadata)["input_deadline_at"].as_string()
             for job in result.all():
                 deadline = (job.job_metadata or {}).get("input_deadline_at")
                 if not deadline or self._parse_deadline(deadline) is None or self._parse_deadline(deadline) > now:
                     continue
-                job.status = JobStatus.FAILED
-                job.error = dict(error_payload)
-                job.finished_timestamp = now
-                session.add(job)
-                reconciled.append(job.job_id)
+                # A resume, a newer pause, or another sweeper can win after the
+                # SELECT. Only the worker claiming this exact expired pause may
+                # emit its terminal event and delete the checkpoint.
+                claim = (
+                    update(Job)
+                    .where(
+                        Job.job_id == job.job_id,
+                        Job.status == JobStatus.SUSPENDED,
+                        deadline_expr == deadline,
+                    )
+                    .values(status=JobStatus.FAILED, error=dict(error_payload), finished_timestamp=now)
+                )
+                claim_result = await session.exec(claim)  # type: ignore[call-overload]
+                if claim_result.rowcount == 1:
+                    reconciled.append(job.job_id)
             await session.flush()
         for job_id in reconciled:
             await self.append_event(job_id, "input_timed_out", dict(error_payload))

--- a/src/backend/tests/unit/background_execution/test_input_deadline_races.py
+++ b/src/backend/tests/unit/background_execution/test_input_deadline_races.py
@@ -1,0 +1,73 @@
+"""A stale timeout scan must not overwrite a newer HITL decision or deadline."""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from langflow.services.database.models.jobs.model import JobStatus
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.mark.real_services
+@pytest.mark.no_blockbuster
+@pytest.mark.parametrize("transition", ["resume", "complete", "cancel", "new_deadline", "other_sweep"])
+async def test_stale_input_deadline_scan_preserves_winning_transition(
+    real_services_job_service, monkeypatch, transition
+):
+    """Interleave another real transaction after the sweep reads its candidates."""
+    service = real_services_job_service
+    job_id = uuid4()
+    await service.create_job(job_id=job_id, flow_id=uuid4(), user_id=uuid4())
+    await service.update_job_status(job_id, JobStatus.SUSPENDED)
+    await service.update_job_metadata(
+        job_id,
+        {"input_deadline_at": (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()},
+    )
+    await service.save_checkpoint(job_id, "graph", "saved checkpoint")
+
+    original_exec = AsyncSession.exec
+    scan_read = False
+
+    async def exec_with_concurrent_transition(session, statement, *args, **kwargs):
+        nonlocal scan_read
+        result = await original_exec(session, statement, *args, **kwargs)
+        if not scan_read:
+            scan_read = True
+            # The first statement is the sweep's SELECT. Its ORM objects remain
+            # stale while the competing worker commits through a separate session.
+            if transition == "resume":
+                assert await service.claim_suspended_for_resume(job_id, owner="resuming-worker")
+            elif transition == "complete":
+                await service.update_job_status(job_id, JobStatus.COMPLETED, finished_timestamp=True)
+            elif transition == "cancel":
+                assert await service.claim_suspended_for_cancel(job_id)
+            elif transition == "new_deadline":
+                await service.update_job_metadata(
+                    job_id,
+                    {"input_deadline_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()},
+                )
+            else:
+                assert await service.sweep_input_deadlines() == [job_id]
+        return result
+
+    with monkeypatch.context() as context:
+        context.setattr(AsyncSession, "exec", exec_with_concurrent_transition)
+        expired = await service.sweep_input_deadlines()
+
+    assert expired == []
+    job = await service.get_job_by_job_id(job_id)
+    expected_status = {
+        "resume": JobStatus.IN_PROGRESS,
+        "complete": JobStatus.COMPLETED,
+        "cancel": JobStatus.CANCELLED,
+        "new_deadline": JobStatus.SUSPENDED,
+        "other_sweep": JobStatus.FAILED,
+    }[transition]
+    assert job.status == expected_status
+    events = await service.read_events(job_id)
+    timeout_events = [event for event in events if event.event_type == "input_timed_out"]
+    assert len(timeout_events) == (1 if transition == "other_sweep" else 0)
+    checkpoint = await service.load_checkpoint(job_id, "graph")
+    assert checkpoint == (None if transition == "other_sweep" else "saved checkpoint")
+    if transition != "other_sweep":
+        assert job.error is None


### PR DESCRIPTION
## Summary

A deadline sweep that reads a suspended job can currently overwrite a concurrent resume/cancel/completion or renewed deadline and delete its checkpoint. Claim expiry with a conditional UPDATE matching both `SUSPENDED` and the observed deadline; only the winning worker emits the timeout event and removes the checkpoint.

Fixes #14941

## Validation

- Five deterministic stale-read regression scenarios: resume, complete, cancel, deadline extension, and another sweeper. The competing transition commits through a separate real database session.
- Before the fix: all five SQLite regression cases fail.
- After the fix: **25 passed** across `test_input_deadline.py` and `test_input_deadline_races.py`, using both SQLite and PostgreSQL 17 on Windows/Python 3.13.
- Ruff format/check and `git diff --check` pass.

No API or database schema changes. This uses the same conditional-UPDATE claim pattern as the existing job lease/resume transitions. It preserves existing deadline parsing and only changes which worker is allowed to terminalize a pause.

The full repository suite and external provider integrations were not run.

## CI follow-up

The [real-service CI job](https://github.com/langflow-ai/langflow/actions/runs/33977491742/job/101336657488) timed out in the existing `test_legacy_empty_overrides_restart_safely[sqlite]`, after cancellation/aiosqlite cleanup messages and before the new deadline-race tests were reached. That existing test passes when run individually locally with the unmodified JobService/test code. The cause of the CI timeout is **not established**; this is not classified as an unrelated baseline failure.

A job rerun was attempted, but GitHub returned HTTP 403 (`Must have admin rights to Repository`). A maintainer rerun is needed to continue that CI investigation. Other checks are still running; the local 25-test result above does not mean the full CI suite passed.
