### PR TITLE
fix(tasks): handle synchronous Celery cancellation

### DIFF
--- a/src/backend/base/langflow/services/task/backends/celery.py
+++ b/src/backend/base/langflow/services/task/backends/celery.py
@@ -51,6 +51,9 @@ class CeleryBackend(TaskBackend):
         from celery.result import AsyncResult
 
         try:
-            return AsyncResult(task_id, app=self.celery_app).revoke(terminate=True)
+            AsyncResult(task_id, app=self.celery_app).revoke(terminate=True)
         except TaskRevokedError:
             return True
+        # AsyncResult.revoke returns None after broadcasting. Success means the
+        # command was sent, not that a worker has acknowledged termination.
+        return True

--- a/src/backend/base/langflow/services/task/service.py
+++ b/src/backend/base/langflow/services/task/service.py
@@ -92,7 +92,9 @@ class TaskService(Service):
 
     async def revoke_task(self, task_id: UUID | str) -> bool:
         if self.use_celery:
-            return await self.backend.revoke_task(str(task_id))
+            # Celery publishes the revoke command synchronously; broker I/O
+            # must not block the request's event loop.
+            return await asyncio.to_thread(self.backend.revoke_task, str(task_id))
 
         job_queue_service = get_queue_service()
         try:

--- a/src/backend/tests/unit/services/tasks/test_celery_cancellation.py
+++ b/src/backend/tests/unit/services/tasks/test_celery_cancellation.py
@@ -1,0 +1,64 @@
+"""Cancellation must support Celery's synchronous, fire-and-forget revoke API."""
+
+import threading
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from langflow.services.task.service import TaskService
+
+
+@pytest.fixture
+def celery_task_service(monkeypatch):
+    celery = pytest.importorskip("celery")
+    # Exercise the real AsyncResult/control/transport stack without an external
+    # broker or a worker. A successful broadcast is not a worker acknowledgement.
+    with celery.Celery("cancellation-test", broker="memory://", set_as_current=False) as app:
+        monkeypatch.setattr("langflow.worker.celery_app", app)
+        yield TaskService(SimpleNamespace(settings=SimpleNamespace(celery_enabled=True)))
+
+
+@pytest.mark.no_blockbuster
+async def test_celery_revoke_accepts_successful_broadcast(celery_task_service):
+    assert await celery_task_service.revoke_task(uuid4()) is True
+
+
+@pytest.mark.no_blockbuster
+async def test_celery_revoke_runs_broker_io_off_event_loop(celery_task_service, monkeypatch):
+    caller_thread = threading.get_ident()
+    calls = []
+    control = celery_task_service.backend.celery_app.control
+    original_revoke = control.revoke
+
+    def record_revoke(task_id, **kwargs):
+        calls.append((threading.get_ident(), task_id, kwargs["terminate"]))
+        return original_revoke(task_id, **kwargs)
+
+    monkeypatch.setattr(control, "revoke", record_revoke)
+    task_id = uuid4()
+    assert await celery_task_service.revoke_task(task_id) is True
+    assert len(calls) == 1
+    worker_thread, sent_task_id, terminate = calls[0]
+    assert worker_thread != caller_thread
+    assert sent_task_id == str(task_id)
+    assert terminate is True
+
+
+async def test_celery_revoke_preserves_broker_failure(celery_task_service, monkeypatch):
+    def fail_revoke(*_args, **_kwargs):
+        message = "broker unavailable"
+        raise ConnectionError(message)
+
+    monkeypatch.setattr(celery_task_service.backend.celery_app.control, "revoke", fail_revoke)
+    with pytest.raises(ConnectionError, match="broker unavailable"):
+        await celery_task_service.revoke_task(uuid4())
+
+
+async def test_celery_revoke_accepts_already_revoked_task(celery_task_service, monkeypatch):
+    from celery.exceptions import TaskRevokedError
+
+    def already_revoked(*_args, **_kwargs):
+        raise TaskRevokedError
+
+    monkeypatch.setattr(celery_task_service.backend.celery_app.control, "revoke", already_revoked)
+    assert await celery_task_service.revoke_task(uuid4()) is True


### PR DESCRIPTION
## Summary

With Celery enabled, cancellation currently publishes the revoke command and then raises `TypeError` because `TaskService` awaits the synchronous backend's `None` result. Workflow and KB cancellation therefore fail before updating their cancellation state and performing subsequent cleanup.

Run the synchronous revoke in `asyncio.to_thread` and return `True` after successful publication. Preserve broker failures and the existing already-revoked handling. `True` means the command was sent, not that a worker has acknowledged termination.

Fixes #14943

## Validation

- New tests use a real Celery app with the memory transport. They cover successful publication, UUID conversion and `terminate=True`, broker I/O running off the event loop, broker failure propagation, and already-revoked handling.
- Before the fix: **2 failed, 1 passed**, with the real `await None` TypeError.
- After the fix: **21 passed** across the new tests and existing workflow-stop API tests (19 unrelated tests deselected).
- Final new-test-only rerun: **4 passed** on Windows/Python 3.13/Celery 5.6.3.
- Ruff format/check and `git diff --check` pass.

No API or schema changes. The synchronous Celery backend interface is preserved. No external worker was started; actual worker termination, the full repository suite, and external provider integrations were not tested locally.

```sh
uv run pytest src/backend/tests/unit/services/tasks/test_celery_cancellation.py src/backend/tests/unit/api/v2/test_workflow.py -k 'celery_revoke or stop_workflow' -q
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cancellation handling for Celery-backed tasks.
  * Prevented cancellation requests from blocking the request event loop.
  * Cancellation now reports success when the revoke command is dispatched, including already-revoked tasks.
  * Broker connection errors continue to be reported to callers.

* **Tests**
  * Added coverage for successful cancellation, asynchronous execution, revoked tasks, and broker failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->