### PR TITLE
fix(jobs): atomically claim expired HITL pauses

### DIFF
--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -896,25 +896,33 @@ class JobService(Service):
 
         Returns the ids transitioned to FAILED.
         """
+        from sqlmodel import update
+
         error_payload = {"type": "input_timed_out"}
         reconciled: list[UUID] = []
         async with session_scope() as session:
             result = await session.exec(select(Job).where(Job.status == JobStatus.SUSPENDED))
             now = datetime.now(timezone.utc)
+            deadline_expr = col(Job.job_metadata)["input_deadline_at"].as_string()
             for job in result.all():
                 deadline = (job.job_metadata or {}).get("input_deadline_at")
                 if not deadline or self._parse_deadline(deadline) is None or self._parse_deadline(deadline) > now:
                     continue
-                job.status = JobStatus.FAILED
-                job.error = dict(error_payload)
-                job.finished_timestamp = now
-                session.add(job)
-                reconciled.append(job.job_id)
+                claim = (
+                    update(Job)
+                    .where(
+                        Job.job_id == job.job_id,
+                        Job.status == JobStatus.SUSPENDED,
+                        deadline_expr == deadline,
+                    )
+                    .values(status=JobStatus.FAILED, error=dict(error_payload), finished_timestamp=now)
+                )
+                claim_result = await session.exec(claim)  # type: ignore[call-overload]
+                if claim_result.rowcount == 1:
+                    reconciled.append(job.job_id)
             await session.flush()
         for job_id in reconciled:
             await self.append_event(job_id, "input_timed_out", dict(error_payload))
-            # Why: a deadline timeout terminalizes the run, so its durable checkpoint is dead weight
-            # that _all() keeps full-scanning (expires_at is never set); drop it like the cancel path.
             with contextlib.suppress(Exception):
                 await self.delete_checkpoint(job_id, "graph")
         return reconciled

--- a/src/backend/tests/unit/background_execution/test_input_deadline_races.py
+++ b/src/backend/tests/unit/background_execution/test_input_deadline_races.py
@@ -1,0 +1,71 @@
+"""A stale timeout scan must not overwrite a newer HITL decision or deadline."""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from langflow.services.database.models.jobs.model import JobStatus
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.mark.real_services
+@pytest.mark.no_blockbuster
+@pytest.mark.parametrize("transition", ["resume", "complete", "cancel", "new_deadline", "other_sweep"])
+async def test_stale_input_deadline_scan_preserves_winning_transition(
+    real_services_job_service, monkeypatch, transition
+):
+    """Interleave another real transaction after the sweep reads its candidates."""
+    service = real_services_job_service
+    job_id = uuid4()
+    await service.create_job(job_id=job_id, flow_id=uuid4(), user_id=uuid4())
+    await service.update_job_status(job_id, JobStatus.SUSPENDED)
+    await service.update_job_metadata(
+        job_id,
+        {"input_deadline_at": (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()},
+    )
+    await service.save_checkpoint(job_id, "graph", "saved checkpoint")
+
+    original_exec = AsyncSession.exec
+    scan_read = False
+
+    async def exec_with_concurrent_transition(session, statement, *args, **kwargs):
+        nonlocal scan_read
+        result = await original_exec(session, statement, *args, **kwargs)
+        if not scan_read:
+            scan_read = True
+            if transition == "resume":
+                assert await service.claim_suspended_for_resume(job_id, owner="resuming-worker")
+            elif transition == "complete":
+                await service.update_job_status(job_id, JobStatus.COMPLETED, finished_timestamp=True)
+            elif transition == "cancel":
+                assert await service.claim_suspended_for_cancel(job_id)
+            elif transition == "new_deadline":
+                await service.update_job_metadata(
+                    job_id,
+                    {"input_deadline_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()},
+                )
+            else:
+                assert await service.sweep_input_deadlines() == [job_id]
+        return result
+
+    with monkeypatch.context() as context:
+        context.setattr(AsyncSession, "exec", exec_with_concurrent_transition)
+        expired = await service.sweep_input_deadlines()
+
+    assert expired == []
+    job = await service.get_job_by_job_id(job_id)
+    expected_status = {
+        "resume": JobStatus.IN_PROGRESS,
+        "complete": JobStatus.COMPLETED,
+        "cancel": JobStatus.CANCELLED,
+        "new_deadline": JobStatus.SUSPENDED,
+        "other_sweep": JobStatus.FAILED,
+    }[transition]
+    assert job.status == expected_status
+    events = await service.read_events(job_id)
+    timeout_events = [event for event in events if event.event_type == "input_timed_out"]
+    assert len(timeout_events) == (1 if transition == "other_sweep" else 0)
+    checkpoint = await service.load_checkpoint(job_id, "graph")
+    assert checkpoint == (None if transition == "other_sweep" else "saved checkpoint")
+    if transition != "other_sweep":
+        assert job.error is None


### PR DESCRIPTION
## What does this PR do?

Prevents a stale HITL deadline sweep from overwriting a resume, cancellation, completion, or renewed deadline. The sweep now atomically claims the exact suspended row and deadline before marking it failed, emitting `input_timed_out`, and deleting its checkpoint.

Fixes #14941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired suspended jobs when concurrent status or deadline changes occur.
  * Prevented stale timeout processing from overwriting newer job updates.
  * Preserved job events, checkpoints, and error state when a more recent transition wins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->