### PR TITLE
docs(integrations): write the GA-swap procedure, exercise it, and two engine follow-ups

### DIFF
--- a/BUNDLE_API.md
+++ b/BUNDLE_API.md
@@ -217,6 +217,13 @@ the deserialize half is covered by
 
 ### v0 (this release)
 
+- **`discovered_tool()` accepts a recorded `tools/list` entry.**
+  `lfx.base.mcp.pinned.discovered_tool()` (and therefore `tools_list_digest()`)
+  now normalizes a plain mapping in addition to a live MCP tool object, so a
+  bundle author can compute a pin's `tools_list_hash` directly from the recorded
+  `tools/list` response that the pin is derived from. Additive;
+  `BUNDLE_API_VERSION` remains `1`.
+
 - **Pinned action-to-tool mode for preset MCP components (additive).**
   `MCPPresetComponent` gains a `_pinned_spec()` hook returning a
   `PinnedServerSpec` (`lfx.base.mcp.pinned`); in pinned mode the component fixes

--- a/design/dedicated-integrations/README.md
+++ b/design/dedicated-integrations/README.md
@@ -19,14 +19,15 @@ these files are the historical record the checker keeps guarding.
 |---|---|---|---|---|
 | 1 | Three approved matrices, at most 8 actions each | `matrices/google.json`, `matrices/microsoft.json`, `matrices/slack.json` | `check_capability_matrices.py`: JSON Schema, included-action cap, required fields, enums | Google 5 included (Gmail search excluded), Microsoft 8 included, Slack 7 included (all Web API) |
 | 2 | Every scope classified; every restricted scope has a written decision | scope entries in the matrices; `decisions/google-restricted-scopes.md` | classification present and sourced; every scope on an included action tagged `required`, `optional`, or `alternative`; conditional rows carry a structured predicate naming a real action input; at least one scope is required; restricted scopes need a `restricted_scope_decisions` entry pointing at an existing record | accepted: avoid on the hosted app; Gmail search excluded, Drive on drive.file |
-| 3 | Substrate decision per provider with the server's GA status | `decisions/substrate-google.md`, `decisions/substrate-microsoft.md`, `decisions/substrate-slack.md`; `substrate_decision` in each matrix | included actions must use a chosen substrate; non-GA MCP rows cannot be high confidence | accepted: Google sdk, Microsoft rest, Slack rest; Slack MCP deferred to 1.14 pending exact tool evidence |
+| 3 | Substrate decision per provider with the server's GA status | `decisions/substrate-google.md`, `decisions/substrate-microsoft.md`, `decisions/substrate-slack.md`; `substrate_decision` in each matrix | included actions must use a chosen substrate; non-GA MCP rows cannot be high confidence | accepted: Google sdk, Microsoft rest, Slack rest; Slack MCP still waits on exact tool evidence, though the pinned engine itself ships in 1.13 (`ga-swap-procedure.md`) |
 | 4 | INT-2 connection-resolution contract signed off by lfx, langflow-base, Enterprise owners | `connection-contract.md` | sign-off coverage: every declared owner role has a row in the sign-off table below that lists the record | drafted 2026-09-01; 12 sections, owner questions in section 12 |
 | 5 | Frontend surface list | `frontend-surfaces.md` | none | drafted 2026-09-01; 14 extend + 9 new, including the operator governance surface; MVP/defer split |
 | 6 | Trigger/webhook track recorded as deferred | `triggers-deferred.md` | none | governing-plan findings folded in; provider transport and delivery discovery remains deferred |
-| 7 | Re-issued estimate | `estimate.md` | none | re-issued 2026-09-01 and amended 2026-09-02: 48.75 engineer-weeks under the confirmed decisions |
+| 7 | Re-issued estimate | `estimate.md` | none | re-issued 2026-09-01, amended 2026-09-02 and 2026-09-04: 51.75 engineer-weeks under the confirmed decisions (INT-9 restored to 1.13) |
 | + | KB OAuth connector adoption decision (added by the release owner) | `decisions/kb-oauth-connector-adoption.md` | none | accepted: adopt in 1.13 (release owner overrode the gate's defer recommendation); +1.5 engineer-weeks |
 | + | Palette naming next to Composio components (added by the release owner) | `decisions/palette-naming.md` | none | accepted: 'Product: Verb Object' names, new Microsoft 365 and Slack groups, Composio unchanged |
 | + | Desktop OAuth registration ownership (added by the release owner, 2026-09-02) | `decisions/desktop-oauth-ownership.md` | none | accepted: Langflow-owned public clients on Desktop, customer-owned registrations remain the override; +0.25 engineer-weeks |
+| + | GA-swap procedure, SDK/REST to pinned MCP (INT-9, release owner decision 2026-09-04) | `ga-swap-procedure.md` | exercised by `src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py` | accepted: INT-9 ships the pinned engine and this procedure in 1.13; the Slack adoption still waits on the dated `tools/list` capture |
 
 Gate close means: every row above is done, every record under `decisions/` is `Status: accepted` (the checker walks
 them all, not only the ones a matrix references), every declared owner has completed both sign-off tables, and
@@ -43,7 +44,7 @@ fails blank or invalid Name, Date, and PR cells. Role placeholders remain until 
 
 | Role | Signs off on | Name | Date | PR |
 |---|---|---|---|---|
-| lfx owner | `connection-contract.md`, `decisions/substrate-google.md`, `decisions/substrate-microsoft.md`, `decisions/substrate-slack.md`, `decisions/kb-oauth-connector-adoption.md` | | | |
+| lfx owner | `connection-contract.md`, `ga-swap-procedure.md`, `decisions/substrate-google.md`, `decisions/substrate-microsoft.md`, `decisions/substrate-slack.md`, `decisions/kb-oauth-connector-adoption.md` | | | |
 | langflow-base owner | `connection-contract.md`, `decisions/substrate-google.md`, `decisions/substrate-microsoft.md`, `decisions/substrate-slack.md`, `decisions/google-restricted-scopes.md`, `decisions/kb-oauth-connector-adoption.md`, `decisions/desktop-oauth-ownership.md` | | | |
 | Enterprise owner | `connection-contract.md`, `decisions/substrate-google.md`, `decisions/substrate-microsoft.md`, `decisions/substrate-slack.md`, `decisions/google-restricted-scopes.md` | | | |
 | frontend owner | `connection-contract.md` (section 12.d), `frontend-surfaces.md`, `decisions/palette-naming.md` | | | |
@@ -88,6 +89,7 @@ connection-contract.md             (Phase 5) INT-2 design for sign-off
 frontend-surfaces.md               (Phase 7)
 triggers-deferred.md               deferred track with re-open trigger
 estimate.md                        (Phase 8)
+ga-swap-procedure.md               INT-9: moving one action from SDK/REST to a pinned MCP server (2026-09-04)
 ```
 
 ## Matrix field glossary

--- a/design/dedicated-integrations/decisions/substrate-slack.md
+++ b/design/dedicated-integrations/decisions/substrate-slack.md
@@ -4,7 +4,7 @@ Status: accepted
 Decision ID: substrate-slack
 Applies to: matrices/slack.json, all actions; identity split user vs bot
 Owners (sign-off roles): lfx owner, langflow-base owner, Enterprise owner, hosted-app owner, release owner
-Last verified: 2026-09-01
+Last verified: 2026-09-04 (amended; see "Amendment 2026-09-04")
 
 ## Context
 
@@ -34,7 +34,8 @@ has no authenticated, dated `tools/list` capture. That evidence boundary blocks 
 
 Pros: exercises the strategic substrate where it is closest to production; user-identity reads on MCP are not
 subject to the non-Marketplace Web API reduction (fact 6); Slack maintains the tool schemas.
-Cons: two auth and error paths in one bundle; requires INT-9 pinned mode (3 engineer-weeks) in 1.13; the hosted
+Cons: two auth and error paths in one bundle; requires INT-9 pinned mode (3 engineer-weeks, delivered in 1.13 by the
+2026-09-04 amendment below); the hosted
 Langflow-owned app must be directory-published (fact 2), which is a Slack review with its own lead time; GA is now cited (fact 3); tool identifiers for the four user actions are not in the docs (fact 8).
 Cost: INT-9 plus the Marketplace listing lead time for hosted.
 
@@ -65,9 +66,36 @@ The strategic MCP path is deferred to the 1.14 planning gate. It may replace a R
 authorization exchange for that action. A future adoption changes this decision and the matrix before component
 implementation; INT-9 is not a post-gate discovery task for 1.13.
 
+## Amendment 2026-09-04 (release owner decision)
+
+**The Slack substrate decision is unchanged. What changed is INT-9's release, not Slack's substrate.**
+
+The release owner decided on 2026-09-04 that INT-9 ships in 1.13 as a *provider-neutral* capability: the pinned
+action-to-tool engine in `lfx.base.mcp.pinned` / `MCPPresetComponent`, the `IntegrationCapability.mcp_pin` manifest
+field, the typed `incompatible-tool` error, and the written GA-swap procedure (`../ga-swap-procedure.md`). None of
+that moves a Slack action off the Web API.
+
+Consequently:
+
+- `matrices/slack.json` `substrate_decision.chosen` remains `["rest"]` and all seven `slack.user.*` / `slack.bot.*`
+  actions remain `substrate: "rest"`. INT-12 is unaffected and still has no MCP implementation dependency.
+- The re-open trigger below is unchanged and still binding: no Slack action moves to MCP without a dated
+  authenticated `tools/list` capture under `evidence/`. That capture does not exist as of this amendment.
+- Because no capture exists, the GA-swap procedure is exercised on a sample action of a fictional provider against a
+  recorded fixture that is labeled synthetic inside the file
+  (`src/lfx/tests/unit/base/mcp/fixtures/slack-mcp-tools-list.synthetic.json`, exercised by
+  `src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py`). The fixture is Slack-*shaped* and is deliberately NOT
+  stored under `evidence/`: it is not evidence, its tool identifiers and schemas are invented, and it may not be
+  cited as a fact in this record.
+- `../ga-swap-procedure.md` names the exact files an `lfx-slack` adoption would touch once the capture exists, and
+  the two Slack-specific questions the capture must answer (whether the MCP server accepts INT-5's
+  `oauth.v2.user.access` user token as a Bearer; whether the pinned tool schemas map onto INT-12's REST-shaped
+  inputs without changing a flow-facing field name).
+
 ## Consequences
 
-- INT-9 moves to 1.14; INT-12 has no MCP implementation dependency in 1.13.
+- INT-9's engine and GA-swap procedure ship in 1.13 (amendment 2026-09-04); the Slack MCP *adoption* is still
+  deferred pending the capture, and INT-12 has no MCP implementation dependency in 1.13.
 - The hosted Slack app still needs a Slack Marketplace listing to avoid the reduced
   `conversations.replies` rate tier; the estimate records it as calendar risk.
 - Desktop hides bot actions in both options (fact 5).
@@ -92,4 +120,4 @@ Re-verify by: the 1.14 planning gate.
 | langflow-base owner | | | |
 | Enterprise owner | | | |
 | hosted-app owner | | | |
-| release owner | Eric Hare | 2026-09-01 | #14906 (confirmed in the planning session) |
+| release owner | Eric Hare | 2026-09-04 | #14906; amended by the release owner decision of 2026-09-04 |

--- a/design/dedicated-integrations/estimate.md
+++ b/design/dedicated-integrations/estimate.md
@@ -1,8 +1,8 @@
 # Re-issued estimate for INT-1 through INT-14
 
-Status: re-issued 2026-09-01 under the release owner's confirmed decisions; amended 2026-09-02 for the Desktop registration decision
+Status: re-issued 2026-09-01 under the release owner's confirmed decisions; amended 2026-09-02 for the Desktop registration decision; amended 2026-09-04 for the INT-9 release decision
 Owners (sign-off roles): release owner
-Last verified: 2026-09-02
+Last verified: 2026-09-04
 
 The gate's last exit criterion is a re-issued estimate. The original ticket breakdown summed to 49
 engineer-weeks including INT-1. The numbers below apply the gate's findings ticket by ticket; every delta names the
@@ -23,16 +23,18 @@ public clients per the release owner's 2026-09-02 decision).
 | INT-6 Executing identity | 3 | 3 | 0 | the allow/deny table is already written per family in the contract |
 | INT-7 Governance | 3 | 3 | 0 | mirrors the model-provider policy pattern and includes the operator policy panel in `frontend-surfaces.md` B9 |
 | INT-8 Frontend Connections UX | 5 | 6 | +1 | OAuth return handling (popup plus `postMessage` or callback route) is greenfield; scope-coverage picker; a11y baseline spec; i18n in seven locales (`frontend-surfaces.md` B3, B5, A14) |
-| INT-9 MCP pinned mode | 3 | 0 | -3 | deferred to 1.14 because the gate has no dated authenticated `tools/list` evidence to freeze exact Slack tool ids and schemas (`decisions/substrate-slack.md`) |
+| INT-9 MCP pinned mode | 3 | 3 | 0 | restored to 1.13 by the release owner's 2026-09-04 decision: the pinned engine and the GA-swap procedure are provider-neutral and do not need the Slack capture. The Slack *adoption* is still gated on that capture (`decisions/substrate-slack.md` amendment 2026-09-04, `ga-swap-procedure.md`), so the 3 weeks buy the engine, the manifest pin, the typed `incompatible-tool` error, and a procedure exercised on a synthetic fixture -- not a live provider action on MCP |
 | INT-10 lfx-google wave 1 | 5 | 4.75 | -0.25 | include set shrinks to five SDK actions with no restricted scope and no MCP (-1); the `GoogleOAuthToken` deprecation and upgrade-checker rule remain; KB Drive ingestion source on connections (+0.75, `decisions/kb-oauth-connector-adoption.md`) |
 | INT-11 lfx-microsoft | 5 | 5.75 | +0.75 | eight Graph actions, a new bundle's eight registration points, the Entra guide; KB OneDrive, SharePoint, and Graph ingestion sources on connections plus the KB connector picker (`decisions/kb-oauth-connector-adoption.md`) |
 | INT-12 lfx-slack | 4 | 3 | -1 | seven Web API actions share one SDK and error-normalization path; separate named user OAuth and bot-install profiles remain |
 | INT-13 Headless reference | 1.5 | 1.5 | 0 | the env resolver is the sample |
 | INT-14 GA validation | 4 | 4 | 0 | contexts reduce to two callback paths times two client types, offset by three providers' verification runbooks |
-| **Total** | **49** | **48.75** | **-0.25** | inside the plan's 45 to 55 working range |
+| **Total** | **49** | **51.75** | **+2.75** | inside the plan's 45 to 55 working range |
 
-Sensitivity: adopting Slack MCP in 1.14 adds the deferred INT-9 estimate (3 engineer-weeks) plus any action-specific
-migration work established by the required `tools/list` capture. Accepting CASA instead of avoiding restricted
+Sensitivity: adopting Slack MCP no longer carries the INT-9 engine cost (it is in the 1.13 total above); what it
+still carries is the action-specific migration work established by the required `tools/list` capture -- an argument
+mapping if the pinned tool schemas do not line up with INT-12's REST-shaped inputs, plus the drift and
+swap-equivalence tests per adopted action (roughly 0.5 engineer-weeks per action on top of the capture itself). Accepting CASA instead of avoiding restricted
 scopes adds no engineer-weeks to INT-10 but adds several weeks of calendar lead time and an annual recurring
 assessment that no ticket currently carries.
 
@@ -47,7 +49,7 @@ assessment that no ticket currently carries.
 | Slack Marketplace listing | hosted, required to lift the non-Marketplace `conversations.replies` rate reduction | Slack review; weeks, not documented | `matrices/slack.json` sources `slack-conversations-replies`, `slack-rate-limits` |
 | Google Desktop client and Entra desktop platform on the hosted registrations | desktop | none beyond hosted: Google verification is per project consent screen and Microsoft publisher verification is per registration, so Desktop inherits both | `decisions/desktop-oauth-ownership.md` facts 2 and 4 |
 | Second Langflow-owned Slack app (PKCE, Desktop) | desktop | none to create; the Marketplace listing question is shared with hosted because any distributed non-Marketplace app runs `conversations.replies` at the reduced tier | `decisions/desktop-oauth-ownership.md` facts 5 and 6 |
-| Slack MCP tool identifiers | deferred 1.14 track | authenticated `tools/list` capture before any action is moved from REST to MCP | `decisions/substrate-slack.md` |
+| Slack MCP tool identifiers | Slack adoption track (the INT-9 engine itself no longer waits on it) | authenticated `tools/list` capture before any action is moved from REST to MCP | `decisions/substrate-slack.md` amendment 2026-09-04 |
 
 ## What the estimate does not include
 

--- a/design/dedicated-integrations/ga-swap-procedure.md
+++ b/design/dedicated-integrations/ga-swap-procedure.md
@@ -1,0 +1,153 @@
+# GA-swap procedure: moving one action from SDK/REST to a pinned MCP server
+
+Status: accepted
+Owners (sign-off roles): lfx owner, release owner
+Last verified: 2026-09-04
+
+This is INT-9's second half: the written procedure a provider bundle follows when a provider's official MCP server
+reaches GA and one action should run on it instead of on the bundle's SDK or REST adapter. The promise the procedure
+has to keep is narrow and testable: **the component identity and the saved-flow schema do not change**. A flow saved
+before the swap keeps working, by the same node, with the same fields, after it.
+
+The engine that makes the swap safe is the pinned mode in `src/lfx/src/lfx/base/mcp/pinned.py` and
+`src/lfx/src/lfx/base/mcp/preset.py` (`MCPPresetComponent._pinned_spec`). The pin itself is manifest data
+(`IntegrationCapability.mcp_pin`), which is what keeps the swap out of the component's identity.
+
+## What the swap may and may not change
+
+| Must not change | May change |
+|---|---|
+| Component class `name` (the registry key saved flows store) | The class's base (`Component` to `MCPPresetComponent`) |
+| `display_name`, `icon`, palette group, `documentation` | The body of the action method |
+| Input names, input types, requiredness, defaults, and order | How those inputs are turned into a provider call |
+| Output names, types, and the method they bind to | Which transport and credential header the call uses |
+| The `migration_table.json` row for the component | — |
+| Capability `id`, `policy_keys`, `auth_profile_id`, `identity`, `required_scopes`, `component_ref`, `risk`, `maturity`, `deployment_contexts` | Capability `substrate`, and the new `mcp_tool` and `mcp_pin` |
+
+Two consequences worth stating plainly, because both are easy to get wrong:
+
+- **A pinned single-action component does not declare `preset_control_inputs`.** Those inputs (Tool dropdown, raw
+  JSON arguments, timeout, SSL toggle) are for a *picker* component. Adding them during a swap would add fields to
+  every saved node, which is exactly the schema change the procedure forbids. A pinned single-action component sets
+  the tool from its pin and builds the arguments from its own declared inputs.
+- **The provider's argument names are not the flow's field names.** The pinned input schema is provider-shaped; the
+  saved flow is Langflow-shaped. The mapping between them lives in the component, and it is the component author's
+  job to keep the flow-facing names identical across the swap even when the provider's differ.
+
+## Procedure
+
+1. **Capture the evidence.** Obtain a dated, authenticated `tools/list` from the official server with the app the
+   bundle actually uses, and record, per candidate action: server URL, `InitializeResult.serverInfo` (name and
+   version, if any), the exact tool identifier, the raw `inputSchema`, the raw `outputSchema`, and the authorization
+   exchange the server accepted. Store it under `design/dedicated-integrations/evidence/`. This capture is the
+   re-open trigger in the provider's substrate decision record; without it, stop here.
+2. **Re-open the substrate decision.** Amend `decisions/substrate-<provider>.md` (new dated amendment section, facts
+   with citations, `Status: accepted` by the release owner) and add `mcp` to `substrate_decision.chosen` in
+   `matrices/<provider>.json`. Flip the action's row to `substrate: "mcp"` with a source whose `kind` is
+   `mcp_tools_list` pointing at the capture. Run `scripts/ci/check_capability_matrices.py`; it rejects an included
+   action whose substrate is outside `chosen`, and rejects `confidence: high` on a non-GA MCP row.
+3. **Pin every tool the server exposes, not just the one you use.** Add `mcp_tool` and `mcp_pin` to each MCP
+   capability in the bundle's capability manifest. `pinned_spec_from_capabilities()` unions the MCP capabilities that
+   share one server into the complete tool set the component may see, so a tool that is present on the server but
+   absent from the manifest is an *added* tool and fails closed. All capabilities on one server must agree on
+   `server_url`, `transport`, `tools_list_hash`, `server_name`, and `server_version`.
+4. **Compute the pin values from the capture.** `tools_list_hash` is
+   `lfx.base.mcp.pinned.tools_list_digest(recording["result"]["tools"])` — the helper accepts the raw recorded
+   entries. Set `server_name`/`server_version` only if the server actually publishes `serverInfo`; a pinned version
+   that the server later stops sending fails closed, by design.
+5. **Swap the adapter.** Rebase the component on `MCPPresetComponent`, keep the class `name`, inputs, and outputs
+   byte-identical, set `add_tool_output = False` if the pre-swap node had no Toolset output, implement
+   `_pinned_spec()` to return the manifest pin, implement `_mcp_server_config()` to return the credential headers
+   (`Authorization: Bearer {await lease.get_token()}` per `connection-contract.md` section 6 — the pinned mode
+   supplies the URL and transport itself), and expose the tool name and arguments from the component's own inputs.
+6. **Keep the action method.** The output method the saved flow binds to keeps its name and its return type; its
+   body becomes `return await self.run_tool()`.
+7. **Prove the invariants.** Add a swap-equivalence test in the bundle: identity fields equal, input/output shapes
+   equal, one saved-flow value set producing the same rows on both halves, and the manifest diff limited to
+   `substrate`, `mcp_tool`, `mcp_pin`. `src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py` is the worked
+   example.
+8. **Prove it fails closed.** Add drift tests driven by a copy of the capture: a tool added, a tool removed, a tool
+   renamed, an argument schema widened, a result schema drifted, a server version moved. Each must raise
+   `IncompatibleToolError` (`incompatible-tool`) and none may return a partial toolset.
+9. **Release the bundle.** Bump the bundle version through `scripts/ci/bundle_release_plan.py`, raise the bundle's
+   `lfx` floor through `scripts/ci/sync_bundle_lfx_pin.py` (pinned mode is new lfx surface), and add the
+   `BUNDLE_API.md` changelog line if the bundle's own public surface moved.
+10. **Update the estimate and the matrices' `last_verified`** so the record and the code agree on the same date.
+
+## Failure behavior and the support answer
+
+Drift does not degrade: it raises `IncompatibleToolError`, whose `code` is `incompatible-tool` and whose sanitized
+`details` name what was added, removed, renamed, changed, and which server pin failed. The remedy is a bundle
+release whose pin matches the server (or a provider-side rollback) — there is no operator override, because an
+override would silently reintroduce exactly the drift the pin exists to catch. Support answer: "this action's
+provider tools changed; upgrade the provider bundle."
+
+Three deliberate boundaries:
+
+- The digest covers tool identity and schemas, not descriptions. Descriptions are prompt material that providers
+  edit routinely; folding them in would turn a copy edit into an outage. Descriptions still pass through the MCP
+  redaction path.
+- The pin fails on *any* input or output schema difference, including a new optional property. Relaxing that (for
+  example, tolerating additive optional inputs) is a later decision record, not a runtime option.
+- The transport is part of the pin: pinned server configs set `allow_sse_fallback=False`, so an endpoint that only
+  answers on the legacy transport surfaces as a failure rather than a silent downgrade.
+
+## What was exercised for 1.13, and what was not
+
+The release owner's 2026-09-04 decision puts INT-9 in 1.13 (see `estimate.md` and the amendment in
+`decisions/substrate-slack.md`). The engine and this procedure ship; the *Slack adoption* does not, because step 1's
+capture does not exist and cannot be manufactured.
+
+So the procedure is exercised end to end on a **sample action belonging to a fictional `example` provider**, against
+a recorded `tools/list` fixture at `src/lfx/tests/unit/base/mcp/fixtures/slack-mcp-tools-list.synthetic.json`. That
+fixture is Slack-*shaped* and clearly labeled synthetic inside the file: its tool identifiers and schemas are
+invented, it is not a capture, and it is not stored under `evidence/` because it is not evidence. The exercise is in
+`src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py`: it swaps one action, holds every invariant in the table
+above, runs the swapped action, and fails closed on six kinds of drift.
+
+Not exercised in 1.13, and honestly so: a live end-to-end run against an official server (no capture, and Slack MCP
+admits only directory-published or internal apps — `decisions/substrate-slack.md` fact 2), and any real provider
+action running on MCP.
+
+## How `lfx-slack` adopts this
+
+`lfx-slack` (INT-12) ships all seven actions on the Slack Web API in 1.13; `matrices/slack.json`
+`substrate_decision.chosen` stays `["rest"]`. When the capture in step 1 exists, the first adoption is expected to
+be `slack.user.search`, and it touches exactly these files:
+
+- `design/dedicated-integrations/evidence/slack-mcp-tools-list-<date>.json` (new; the capture)
+- `design/dedicated-integrations/decisions/substrate-slack.md` (amendment re-opening the substrate)
+- `design/dedicated-integrations/matrices/slack.json` (`chosen` gains `mcp`; the `slack.user.search` row moves to
+  `substrate: "mcp"` with an `mcp_tools_list` source)
+- `src/bundles/slack/src/lfx_slack/integrations/capabilities.json` (or wherever INT-12 puts the capability
+  manifest): every Slack MCP capability gains `mcp_tool` and `mcp_pin`
+- the Slack search component: same class name, same inputs and output, rebased on `MCPPresetComponent` with
+  `_pinned_spec()` returning the manifest pin and `_mcp_server_config()` returning the Bearer header from the
+  connection lease
+- the bundle's swap-equivalence and drift tests, modeled on the worked example above
+- bundle version bump and `lfx` floor pin
+
+Two Slack-specific facts the capture must settle before that PR is written: whether `https://mcp.slack.com/mcp`
+accepts the user token minted by INT-5's `oauth.v2.user.access` exchange as a Bearer, or requires its own
+authorization flow tied to the app's fixed app id (`decisions/substrate-slack.md` fact 9); and whether the pinned
+tool schemas map onto the REST-shaped inputs INT-12 ships without changing a single flow-facing field name. If they
+do not, the swap needs an argument-mapping layer in the component and the "no saved-flow change" promise must be
+re-proved by the equivalence test before the PR merges.
+
+## Open items handed on
+
+- The client-facing error mapping for `incompatible-tool` is INT-6's `IntegrationError` branch in
+  `src/backend/base/langflow/api/utils/execution_errors.py`; until it lands, the typed code does not reach an API
+  client. INT-9 only adds the code to `INTEGRATION_ERROR_CODES`.
+- The frontend keys its call to action on `code` (`connection-contract.md` section 7). `frontend-surfaces.md` has no
+  MCP-drift row; INT-8 should add one whose action is "upgrade the provider bundle", not "reconnect".
+- Token rotation on a pinned server still orphans the MCP session, because `_get_server_key` hashes `url|headers`
+  (`connection-contract.md` open question 12.a.7). Pinned mode tolerates it; the session is reclaimed by idle
+  cleanup.
+
+## Sign-off
+
+| Role | Name | Date | PR |
+|------|------|------|----|
+| lfx owner | | | |
+| release owner | Eric Hare | 2026-09-04 | release owner decision, 2026-09-04 |

--- a/design/dedicated-integrations/ga-swap-procedure.md
+++ b/design/dedicated-integrations/ga-swap-procedure.md
@@ -53,8 +53,10 @@ Two consequences worth stating plainly, because both are easy to get wrong:
    `server_url`, `transport`, `tools_list_hash`, `server_name`, and `server_version`.
 4. **Compute the pin values from the capture.** `tools_list_hash` is
    `lfx.base.mcp.pinned.tools_list_digest(recording["result"]["tools"])` — the helper accepts the raw recorded
-   entries. Set `server_name`/`server_version` only if the server actually publishes `serverInfo`; a pinned version
-   that the server later stops sending fails closed, by design.
+   entries. It must cover *exactly* the tools the manifest pins: `pinned_spec_from_capabilities()` recomputes the
+   digest and refuses a hash taken over a wider recording, so that authoring slip is a bundle error at build time
+   rather than a runtime "drift" complaint. Set `server_name`/`server_version` only if the server actually publishes
+   `serverInfo`; a pinned version that the server later stops sending fails closed, by design.
 5. **Swap the adapter.** Rebase the component on `MCPPresetComponent`, keep the class `name`, inputs, and outputs
    byte-identical, set `add_tool_output = False` if the pre-swap node had no Toolset output, implement
    `_pinned_spec()` to return the manifest pin, implement `_mcp_server_config()` to return the credential headers
@@ -68,7 +70,10 @@ Two consequences worth stating plainly, because both are easy to get wrong:
    example.
 8. **Prove it fails closed.** Add drift tests driven by a copy of the capture: a tool added, a tool removed, a tool
    renamed, an argument schema widened, a result schema drifted, a server version moved. Each must raise
-   `IncompatibleToolError` (`incompatible-tool`) and none may return a partial toolset.
+   `IncompatibleToolError` (`incompatible-tool`) and none may return a partial toolset. Drive at least one case
+   through the real engine (`update_tools` against a fake transport) rather than only through test doubles: a
+   double's attribute surface is not the pydantic tool `update_tools` actually builds, and that gap has already
+   hidden one defect (a LangChain tool is a `Runnable`, which owns `input_schema`/`output_schema` names of its own).
 9. **Release the bundle.** Bump the bundle version through `scripts/ci/bundle_release_plan.py`, raise the bundle's
    `lfx` floor through `scripts/ci/sync_bundle_lfx_pin.py` (pinned mode is new lfx surface), and add the
    `BUNDLE_API.md` changelog line if the bundle's own public surface moved.
@@ -82,7 +87,7 @@ release whose pin matches the server (or a provider-side rollback) — there is 
 override would silently reintroduce exactly the drift the pin exists to catch. Support answer: "this action's
 provider tools changed; upgrade the provider bundle."
 
-Three deliberate boundaries:
+Four deliberate boundaries:
 
 - The digest covers tool identity and schemas, not descriptions. Descriptions are prompt material that providers
   edit routinely; folding them in would turn a copy edit into an outage. Descriptions still pass through the MCP
@@ -91,6 +96,10 @@ Three deliberate boundaries:
   example, tolerating additive optional inputs) is a later decision record, not a runtime option.
 - The transport is part of the pin: pinned server configs set `allow_sse_fallback=False`, so an endpoint that only
   answers on the legacy transport surfaces as a failure rather than a silent downgrade.
+- Call-time argument checking covers *both* of a tool's call paths (the async `coroutine` the Agent and `run_tool`
+  use, and the synchronous `func`), and only an argument the pin does not declare is drift. An omitted **required**
+  argument is not: an agent forgetting a field is a caller mistake no bundle release can fix, so it falls through to
+  the derived args schema, whose validation error names the field and is self-correctable on the next turn.
 
 ## What was exercised for 1.13, and what was not
 
@@ -138,7 +147,9 @@ re-proved by the equivalence test before the PR merges.
 
 - The client-facing error mapping for `incompatible-tool` is INT-6's `IntegrationError` branch in
   `src/backend/base/langflow/api/utils/execution_errors.py`; until it lands, the typed code does not reach an API
-  client. INT-9 only adds the code to `INTEGRATION_ERROR_CODES`.
+  client. Nothing is owed there by INT-9 or by an adopting bundle: that branch is generic
+  (`isinstance(error, IntegrationError)`, reading `error.code`), not an enumerated code list, so `incompatible-tool`
+  crosses the boundary the moment INT-6 merges, as a 400 (the error sets no `http_status`).
 - The frontend keys its call to action on `code` (`connection-contract.md` section 7). `frontend-surfaces.md` has no
   MCP-drift row; INT-8 should add one whose action is "upgrade the provider bundle", not "reconnect".
 - Token rotation on a pinned server still orphans the MCP session, because `_get_server_key` hashes `url|headers`

--- a/src/lfx/src/lfx/base/mcp/pinned.py
+++ b/src/lfx/src/lfx/base/mcp/pinned.py
@@ -117,12 +117,20 @@ class DiscoveredTool:
 
 
 def discovered_tool(tool: Any) -> DiscoveredTool:
-    """Normalize an MCP ``types.Tool`` or an ``MCPStructuredTool`` for comparison.
+    """Normalize an MCP ``types.Tool``, an ``MCPStructuredTool``, or a raw entry.
 
     ``update_tools`` turns each discovered tool into a ``StructuredTool`` whose
     derived ``args_schema`` has already lost the raw JSON Schema, so the raw
-    schemas are carried forward on the tool's ``metadata`` instead.
+    schemas are carried forward on the tool's ``metadata`` instead.  A plain
+    mapping is accepted too, so a pin author can compute the digest straight
+    from a recorded ``tools/list`` response.
     """
+    if isinstance(tool, Mapping):
+        return DiscoveredTool(
+            name=str(tool.get("name") or ""),
+            input_schema=dict(tool.get("inputSchema") or tool.get("input_schema") or {}),
+            output_schema=_optional_schema(tool.get("outputSchema") or tool.get("output_schema")),
+        )
     name = getattr(tool, "name", None) or ""
     input_schema = getattr(tool, "inputSchema", None) or getattr(tool, "input_schema", None)
     output_schema = getattr(tool, "outputSchema", None) or getattr(tool, "output_schema", None)
@@ -137,6 +145,10 @@ def discovered_tool(tool: Any) -> DiscoveredTool:
         input_schema=dict(input_schema) if isinstance(input_schema, Mapping) else {},
         output_schema=dict(output_schema) if isinstance(output_schema, Mapping) else None,
     )
+
+
+def _optional_schema(value: Any) -> dict[str, Any] | None:
+    return dict(value) if isinstance(value, Mapping) else None
 
 
 # --------------------------------------------------------------------- digest

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1337,7 +1337,11 @@ class MCPSessionManager:
             # Include URL and headers for uniqueness
             url = connection_params["url"]
             headers = str(sorted((connection_params.get("headers", {})).items()))
-            key_input = f"{url}|{headers}"
+            # A caller that pinned the transport must not inherit a session (or a cached
+            # transport preference) that an unpinned caller established over SSE. The
+            # suffix is appended only in that case, so existing keys are unchanged.
+            pinned = "" if connection_params.get("allow_sse_fallback", True) else "|pinned_transport"
+            key_input = f"{url}|{headers}{pinned}"
             return f"streamable_http_{hash(key_input)}"
 
         # Fallback to a generic key
@@ -2286,8 +2290,8 @@ class MCPStreamableHttpClient:
             }
         elif headers:
             self._connection_params["headers"] = validated_headers
-        # Kept out of the server key on purpose: the key identifies the endpoint, not
-        # the caller's transport policy.
+        # Part of the server key (see ``_get_server_key``): a pinned-transport caller
+        # gets its own session rather than inheriting an SSE one.
         self._connection_params["allow_sse_fallback"] = allow_sse_fallback
 
         # If no session context is set, create a default one

--- a/src/lfx/tests/unit/base/mcp/fixtures/slack-mcp-tools-list.synthetic.json
+++ b/src/lfx/tests/unit/base/mcp/fixtures/slack-mcp-tools-list.synthetic.json
@@ -1,0 +1,81 @@
+{
+  "_synthetic": true,
+  "_label": "SYNTHETIC FIXTURE - NOT A CAPTURE",
+  "_warning": "This file was written by hand for the INT-9 GA-swap exercise. It is NOT a capture from https://mcp.slack.com/mcp, the tool identifiers and schemas below are INVENTED, and it is not evidence of anything Slack publishes. Slack documents tool identifiers only for slack_get_file_upload_url and slack_complete_file_upload (decisions/substrate-slack.md fact 8). Moving a real Slack action to the MCP substrate still requires the dated authenticated tools/list capture named in that record's re-open trigger, stored under design/dedicated-integrations/evidence/.",
+  "_provider": "example (Slack-shaped)",
+  "_recorded_on": "2026-09-04",
+  "_initialize_result": {
+    "_note": "serverInfo comes from the MCP initialize handshake, not from tools/list; it is recorded here so the pin can name a server version.",
+    "protocolVersion": "2025-06-18",
+    "serverInfo": {
+      "name": "example-workspace-mcp",
+      "version": "2026.09.1"
+    }
+  },
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "example_search_messages",
+        "description": "Search messages the calling user can see.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search terms."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of matches to return.",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          "required": ["query"],
+          "additionalProperties": false
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "matches": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "permalink": { "type": "string" },
+                  "text": { "type": "string" },
+                  "ts": { "type": "string" }
+                }
+              }
+            }
+          },
+          "required": ["matches"],
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "example_read_channel_history",
+        "description": "Read recent messages from one channel.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "channel": { "type": "string" },
+            "limit": { "type": "integer" }
+          },
+          "required": ["channel"],
+          "additionalProperties": false
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "messages": { "type": "array" }
+          },
+          "required": ["messages"],
+          "additionalProperties": false
+        }
+      }
+    ]
+  }
+}

--- a/src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py
+++ b/src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py
@@ -1,0 +1,388 @@
+"""Exercise the GA-swap procedure on one sample action.
+
+``design/dedicated-integrations/ga-swap-procedure.md`` claims that a provider
+bundle can move an action from its REST/SDK adapter to the provider's official
+MCP server *without changing component identity or the saved-flow schema*.  This
+module is the executable form of that claim: one action is written twice -- once
+REST-backed, once pinned to an MCP server -- and the tests below hold the
+invariants the procedure promises, then prove the pinned half fails closed when
+the server drifts.
+
+The recorded ``tools/list`` is
+``fixtures/slack-mcp-tools-list.synthetic.json``: a hand-written, Slack-*shaped*
+fixture that is clearly labeled synthetic inside the file.  It is deliberately
+not evidence.  Moving a real Slack action to MCP still needs the dated
+authenticated capture named in ``decisions/substrate-slack.md``'s re-open
+trigger, which does not exist yet; that is why the sample action here belongs to
+a fictional ``example`` provider instead of to ``lfx-slack``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from lfx.base.mcp.pinned import pinned_spec_from_capabilities, tools_list_digest
+from lfx.base.mcp.preset import MCPPresetComponent
+from lfx.base.mcp.util import MCPServerInfo
+from lfx.custom.custom_component.component import Component
+from lfx.integrations.capabilities import IntegrationCapability
+from lfx.integrations.errors import IncompatibleToolError
+from lfx.io import IntInput, MessageTextInput, Output
+from lfx.schema.dataframe import DataFrame
+
+FIXTURE = Path(__file__).parent / "fixtures" / "slack-mcp-tools-list.synthetic.json"
+UPDATE_TOOLS_TARGET = "lfx.base.mcp.preset.update_tools"
+PINNED_URL = "https://mcp.example.com/mcp"
+
+MATCHES = [
+    {"permalink": "https://example.invalid/archives/C1/p1", "text": "the orders report is late", "ts": "1.1"},
+    {"permalink": "https://example.invalid/archives/C1/p2", "text": "orders are back to normal", "ts": "2.2"},
+]
+
+
+def _recording() -> dict[str, Any]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _tool_named(recording: dict[str, Any], name: str) -> dict[str, Any]:
+    for tool in recording["result"]["tools"]:
+        if tool["name"] == name:
+            return tool
+    msg = f"{name} is not in the recording"
+    raise AssertionError(msg)
+
+
+# --------------------------------------------------------------- the manifest
+# Everything above the substrate line is what the swap must leave alone.
+_SHARED_CAPABILITY_FIELDS: dict[str, Any] = {
+    "display_name": "Example: Search Messages",
+    "auth_profile_id": "example-user-oauth",
+    "identity": "user_delegated",
+    "required_scopes": ("search:read",),
+    "policy_keys": ("integrations.example.user.search",),
+    "maturity": "ga",
+    "deployment_contexts": ("hosted", "self_managed"),
+    "risk": "read",
+    "component_ref": "ExampleSearchMessages",
+}
+
+REST_CAPABILITY: dict[str, Any] = {
+    "id": "example.user.search",
+    **_SHARED_CAPABILITY_FIELDS,
+    "substrate": "rest",
+}
+
+
+def _pin_for(tool_name: str, recording: dict[str, Any]) -> dict[str, Any]:
+    tool = _tool_named(recording, tool_name)
+    server_info = recording["_initialize_result"]["serverInfo"]
+    return {
+        "server_url": PINNED_URL,
+        "input_schema": tool["inputSchema"],
+        "output_schema": tool["outputSchema"],
+        "tools_list_hash": tools_list_digest(recording["result"]["tools"]),
+        "server_name": server_info["name"],
+        "server_version": server_info["version"],
+    }
+
+
+def mcp_capabilities(recording: dict[str, Any] | None = None) -> list[IntegrationCapability]:
+    """The post-swap manifest: every tool the pinned server may expose is pinned."""
+    recording = recording or _recording()
+    search = IntegrationCapability(
+        **{
+            "id": "example.user.search",
+            **_SHARED_CAPABILITY_FIELDS,
+            "substrate": "mcp",
+            "mcp_tool": "example_search_messages",
+            "mcp_pin": _pin_for("example_search_messages", recording),
+        }
+    )
+    history = IntegrationCapability(
+        id="example.user.read_history",
+        display_name="Example: Read Channel History",
+        auth_profile_id="example-user-oauth",
+        identity="user_delegated",
+        required_scopes=("channels:history",),
+        policy_keys=("integrations.example.user.read_history",),
+        substrate="mcp",
+        maturity="ga",
+        deployment_contexts=("hosted", "self_managed"),
+        risk="read",
+        component_ref="ExampleReadChannelHistory",
+        mcp_tool="example_read_channel_history",
+        mcp_pin=_pin_for("example_read_channel_history", recording),
+    )
+    return [search, history]
+
+
+# ------------------------------------------------------------- the two halves
+_SAMPLE_INPUTS = [
+    MessageTextInput(name="query", display_name="Query", info="Search terms.", required=True, tool_mode=True),
+    IntInput(name="limit", display_name="Limit", info="Maximum number of matches.", value=20, advanced=True),
+]
+_SAMPLE_OUTPUTS = [Output(display_name="Matches", name="matches", method="search", types=["DataFrame"])]
+
+
+async def _fake_rest_search(query: str, limit: int) -> list[dict[str, Any]]:
+    """Stands in for the provider's Web API client in the pre-swap adapter."""
+    return [dict(match) for match in MATCHES[:limit] if query in match["text"]]
+
+
+class ExampleSearchMessagesRest(Component):
+    """Before the swap: same identity, REST adapter."""
+
+    display_name = "Example: Search Messages"
+    description = "Search messages the calling user can see."
+    icon = "Search"
+    name = "ExampleSearchMessages"
+    inputs = _SAMPLE_INPUTS
+    outputs = _SAMPLE_OUTPUTS
+
+    async def search(self) -> DataFrame:
+        rows = await _fake_rest_search(self.query, int(self.limit))
+        frame = DataFrame(rows)
+        self.status = frame
+        return frame
+
+
+class ExampleSearchMessagesPinned(MCPPresetComponent):
+    """After the swap: same identity, same inputs and output, pinned MCP adapter.
+
+    The node shape is preserved by *not* declaring ``preset_control_inputs``: a
+    single-action pinned component takes its tool from the pin and builds the
+    arguments from its own declared inputs, so no Tool dropdown or raw-JSON
+    argument box appears where the REST version had none.
+    """
+
+    display_name = "Example: Search Messages"
+    description = "Search messages the calling user can see."
+    icon = "Search"
+    name = "ExampleSearchMessages"
+    integration_provider_id = "example"
+    add_tool_output = False
+    inputs = _SAMPLE_INPUTS
+    outputs = _SAMPLE_OUTPUTS
+
+    capabilities: list[IntegrationCapability] | None = None
+
+    @property
+    def tool(self) -> str:
+        return "example_search_messages"
+
+    @property
+    def tool_arguments(self) -> dict[str, Any]:
+        arguments: dict[str, Any] = {"query": self.query}
+        if self.limit is not None:
+            arguments["limit"] = int(self.limit)
+        return arguments
+
+    def _pinned_spec(self):
+        return pinned_spec_from_capabilities(self.capabilities or mcp_capabilities())
+
+    def _mcp_server_config(self):
+        return "example-workspace-mcp", {"headers": {"Authorization": "Bearer token"}}
+
+    async def search(self) -> DataFrame:
+        return await self.run_tool()
+
+
+# ------------------------------------------------------------------- doubles
+def _tool_double(spec: dict[str, Any]):
+    async def coroutine(**kwargs):
+        payload = [match for match in MATCHES if kwargs.get("query", "") in match["text"]]
+        return SimpleNamespace(content=[SimpleNamespace(type="text", text=json.dumps(payload))])
+
+    return SimpleNamespace(
+        name=spec["name"],
+        description=spec.get("description", ""),
+        coroutine=coroutine,
+        metadata={
+            "server_name": "example-workspace-mcp",
+            "input_schema": spec["inputSchema"],
+            "output_schema": spec.get("outputSchema"),
+        },
+    )
+
+
+def _engine_for(recording: dict[str, Any]):
+    tools = [_tool_double(spec) for spec in recording["result"]["tools"]]
+    return AsyncMock(return_value=("Streamable_HTTP", tools, {tool.name: tool for tool in tools}))
+
+
+def _pinned_component(recording: dict[str, Any] | None = None) -> ExampleSearchMessagesPinned:
+    recording = recording or _recording()
+    component = ExampleSearchMessagesPinned()
+    component.query = "orders"
+    component.limit = 20
+    component.tool_execution_timeout = 0.0
+    component.verify_ssl = True
+    component.capabilities = mcp_capabilities()
+    server_info = recording["_initialize_result"]["serverInfo"]
+    component._streamable_http_client = SimpleNamespace(
+        server_info=MCPServerInfo(name=server_info["name"], version=server_info["version"])
+    )
+    return component
+
+
+def _rest_component() -> ExampleSearchMessagesRest:
+    component = ExampleSearchMessagesRest()
+    component.query = "orders"
+    component.limit = 20
+    return component
+
+
+# ------------------------------------------------------- the fixture is honest
+def test_the_recorded_tools_list_is_labeled_synthetic():
+    recording = _recording()
+    assert recording["_synthetic"] is True
+    assert "NOT A CAPTURE" in recording["_label"]
+    assert "mcp.slack.com" in recording["_warning"]
+
+
+# ------------------------------------------------- invariants of the procedure
+def test_component_identity_survives_the_swap():
+    assert ExampleSearchMessagesPinned.name == ExampleSearchMessagesRest.name
+    assert ExampleSearchMessagesPinned.display_name == ExampleSearchMessagesRest.display_name
+    assert ExampleSearchMessagesPinned.description == ExampleSearchMessagesRest.description
+    assert ExampleSearchMessagesPinned.icon == ExampleSearchMessagesRest.icon
+
+
+def test_saved_flow_schema_survives_the_swap():
+    """Field names, types, and requiredness are what a saved flow stores."""
+
+    def shape(component: type[Component]) -> list[tuple]:
+        return [
+            (item.name, type(item).__name__, item.display_name, getattr(item, "required", False))
+            for item in component.inputs
+        ]
+
+    def outputs(component: type[Component]) -> list[tuple]:
+        return [(item.name, item.display_name, item.method, tuple(item.types or ())) for item in component.outputs]
+
+    assert shape(ExampleSearchMessagesPinned) == shape(ExampleSearchMessagesRest)
+    assert outputs(ExampleSearchMessagesPinned) == outputs(ExampleSearchMessagesRest)
+    # The preset control inputs would have changed the node shape; a pinned
+    # single-action component must not declare them.
+    assert {item.name for item in ExampleSearchMessagesPinned.inputs} == {"query", "limit"}
+
+
+def test_only_the_substrate_fields_change_in_the_manifest():
+    after = mcp_capabilities()[0].model_dump()
+    before = IntegrationCapability(**REST_CAPABILITY).model_dump()
+    changed = {key for key in before if before[key] != after[key]}
+    assert changed == {"substrate", "mcp_tool", "mcp_pin"}
+    assert after["id"] == before["id"] == "example.user.search"
+    assert after["policy_keys"] == before["policy_keys"]
+    assert after["component_ref"] == before["component_ref"]
+    assert after["required_scopes"] == before["required_scopes"]
+
+
+def test_the_pin_reproduces_the_recorded_tools_list_digest():
+    recording = _recording()
+    spec = pinned_spec_from_capabilities(mcp_capabilities(recording))
+    assert spec.tools_list_hash == tools_list_digest(recording["result"]["tools"])
+    assert spec.digest() == spec.tools_list_hash
+    assert set(spec.names) == {tool["name"] for tool in recording["result"]["tools"]}
+
+
+# ---------------------------------------------------------- the swapped action
+async def test_both_halves_return_the_same_rows_for_one_saved_flow():
+    rest_rows = (await _rest_component().search()).to_dict(orient="records")
+    with patch(UPDATE_TOOLS_TARGET, new=_engine_for(_recording())):
+        pinned_rows = (await _pinned_component().search()).to_dict(orient="records")
+    assert pinned_rows == rest_rows == MATCHES
+
+
+async def test_the_swapped_action_connects_only_to_the_pinned_endpoint():
+    with patch(UPDATE_TOOLS_TARGET, new=_engine_for(_recording())) as engine:
+        await _pinned_component().search()
+    _, config = engine.await_args.args[:2]
+    assert config["url"] == PINNED_URL
+    assert config["allow_sse_fallback"] is False
+
+
+# ------------------------------------------------------------- drift, at GA
+def _with_added_tool(recording: dict[str, Any]) -> dict[str, Any]:
+    recording["result"]["tools"].append(
+        {
+            "name": "example_delete_message",
+            "description": "Delete a message.",
+            "inputSchema": {"type": "object", "properties": {"ts": {"type": "string"}}, "required": ["ts"]},
+        }
+    )
+    return recording
+
+
+def _with_renamed_tool(recording: dict[str, Any]) -> dict[str, Any]:
+    _tool_named(recording, "example_search_messages")["name"] = "example_search_messages_v2"
+    return recording
+
+
+def _with_removed_tool(recording: dict[str, Any]) -> dict[str, Any]:
+    recording["result"]["tools"] = [
+        tool for tool in recording["result"]["tools"] if tool["name"] != "example_read_channel_history"
+    ]
+    return recording
+
+
+def _with_widened_arguments(recording: dict[str, Any]) -> dict[str, Any]:
+    tool = _tool_named(recording, "example_search_messages")
+    tool["inputSchema"]["properties"]["cursor"] = {"type": "string"}
+    return recording
+
+
+def _with_drifted_results(recording: dict[str, Any]) -> dict[str, Any]:
+    tool = _tool_named(recording, "example_search_messages")
+    tool["outputSchema"]["properties"]["hits"] = tool["outputSchema"]["properties"].pop("matches")
+    tool["outputSchema"]["required"] = ["hits"]
+    return recording
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_key", "expected_value"),
+    [
+        (_with_added_tool, "added", ["example_delete_message"]),
+        (_with_removed_tool, "removed", ["example_read_channel_history"]),
+        (_with_renamed_tool, "renamed", ["example_search_messages -> example_search_messages_v2"]),
+        (_with_widened_arguments, "changed", ["example_search_messages: argument schema"]),
+        (_with_drifted_results, "changed", ["example_search_messages: result schema"]),
+    ],
+)
+async def test_the_pinned_action_fails_closed_when_the_server_drifts(mutate, expected_key, expected_value):
+    drifted = mutate(copy.deepcopy(_recording()))
+    component = _pinned_component()
+    with patch(UPDATE_TOOLS_TARGET, new=_engine_for(drifted)), pytest.raises(IncompatibleToolError) as excinfo:
+        await component.search()
+    assert excinfo.value.code == "incompatible-tool"
+    assert excinfo.value.details[expected_key] == expected_value
+    # The digest pin catches the same drift a second time, independently.
+    assert excinfo.value.details["server"]
+
+
+async def test_the_pinned_action_fails_closed_when_the_server_version_moves():
+    component = _pinned_component()
+    component._streamable_http_client = SimpleNamespace(
+        server_info=MCPServerInfo(name="example-workspace-mcp", version="2026.10.0")
+    )
+    with patch(UPDATE_TOOLS_TARGET, new=_engine_for(_recording())), pytest.raises(IncompatibleToolError) as excinfo:
+        await component.search()
+    assert excinfo.value.details["server"] == [
+        "server version 2026.10.0 does not match the pinned 2026.09.1",
+    ]
+
+
+async def test_the_pinned_action_rejects_arguments_outside_the_recorded_schema():
+    """The swap must not widen the action: the pinned schema is the contract."""
+    component = _pinned_component()
+    with patch(UPDATE_TOOLS_TARGET, new=_engine_for(_recording())):
+        tools, _ = await component._load_tools()
+        with pytest.raises(IncompatibleToolError) as excinfo:
+            await tools[0].coroutine(query="orders", cursor="page-2")
+    assert excinfo.value.details["unexpected"] == ["cursor"]

--- a/src/lfx/tests/unit/base/mcp/test_pinned.py
+++ b/src/lfx/tests/unit/base/mcp/test_pinned.py
@@ -101,6 +101,16 @@ def test_discovered_tool_reads_raw_schemas_from_structured_tool_metadata():
     assert view.output_schema == SEARCH_OUTPUT
 
 
+def test_discovered_tool_reads_a_raw_tools_list_entry():
+    """A pin author computes the digest straight from a recorded response."""
+    entry = {"name": "search_messages", "inputSchema": SEARCH_INPUT, "outputSchema": SEARCH_OUTPUT}
+    view = discovered_tool(entry)
+    assert view == DiscoveredTool(name="search_messages", input_schema=SEARCH_INPUT, output_schema=SEARCH_OUTPUT)
+    assert tools_list_digest([entry, {"name": "post_message", "inputSchema": POST_INPUT}]) == tools_list_digest(
+        _matching()
+    )
+
+
 def test_discovered_tool_without_schemas_is_empty_not_none():
     view = discovered_tool(SimpleNamespace(name="x"))
     assert view.input_schema == {}

--- a/src/lfx/tests/unit/mcp/test_pinned_transport.py
+++ b/src/lfx/tests/unit/mcp/test_pinned_transport.py
@@ -179,6 +179,15 @@ async def test_update_tools_keeps_the_raw_schemas_and_forwards_the_transport_pin
     assert client.connect_to_server.await_args.kwargs["allow_sse_fallback"] is False
 
 
+def test_a_pinned_transport_does_not_share_a_session_with_an_unpinned_caller(manager):
+    """Otherwise a pinned component could reuse a session an unpinned one opened over SSE."""
+    unpinned = manager._get_server_key(dict(CONNECTION_PARAMS), "streamable_http")
+    explicit = manager._get_server_key({**CONNECTION_PARAMS, "allow_sse_fallback": True}, "streamable_http")
+    pinned = manager._get_server_key({**CONNECTION_PARAMS, "allow_sse_fallback": False}, "streamable_http")
+    assert unpinned == explicit  # the default must not change any existing key
+    assert pinned != unpinned
+
+
 async def test_update_tools_defaults_to_allowing_the_sse_fallback():
     discovered = SimpleNamespace(
         name="search_messages",


### PR DESCRIPTION
**docs(integrations): write the GA-swap procedure, exercise it, and two engine follow-ups**

> **Reviewer note — this PR is not docs-only.** Besides the procedure, the fixture and the exercise, it carries three
> engine changes to shared MCP infrastructure: `discovered_tool()` learning to read a recorded `tools/list` entry
> (`pinned.py`), a `_get_server_key` suffix that keeps a pinned-transport caller off an unpinned SSE session
> (`util.py`), and the merge of PR 1's review fixes. Do not triage this by title. Each is covered by tests and called
> out under *Engine follow-ups* below.

## Summary

- Adds `design/dedicated-integrations/ga-swap-procedure.md`: the procedure a provider bundle follows to move one
  action from its SDK/REST adapter to the provider's official MCP server. It states the invariant it must keep
  (component identity and saved-flow schema do not change), the ten steps, the failure behavior and support answer,
  and the four deliberate boundaries (descriptions excluded from the digest, no tolerance for schema widening, the
  transport pinned with no SSE fallback, and the call-time argument rule — both call paths guarded, an undeclared
  argument is drift, an omitted required one is not).
- Exercises that procedure end to end in `src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py`: one sample action
  written twice (REST-backed and pinned), asserting identity, input/output shape, and manifest-diff invariants; the
  swapped action running and returning identical rows; and fail-closed behavior on six kinds of drift (tool added,
  removed, renamed, arguments widened, results drifted, server version moved).
- The recorded `tools/list` is `src/lfx/tests/unit/base/mcp/fixtures/slack-mcp-tools-list.synthetic.json` — Slack-
  *shaped*, **labeled synthetic inside the file**, with invented tool identifiers and schemas, and deliberately kept
  out of `design/dedicated-integrations/evidence/` because it is not evidence. A test asserts the labeling is
  present, so the file cannot quietly lose it.
- Two records amended for the release owner's 2026-09-04 decision, and no further:
  - `decisions/substrate-slack.md` gains a dated amendment saying that **what changed is INT-9's release, not
    Slack's substrate**. `substrate_decision.chosen` stays `["rest"]`, all seven actions stay on the Web API, the
    re-open trigger (a dated authenticated `tools/list` capture) is unchanged and still binding, and **INT-12 is
    unaffected**.
  - `estimate.md` restores INT-9 to 3 engineer-weeks in 1.13 (total 48.75 → 51.75, still inside the 45–55 range),
    rewrites the sensitivity note (the Slack adoption no longer carries the engine cost, only per-action migration),
    and re-labels the external lead-time row.
  - `README.md` gains the exit-criteria row, the file-tree line, and the `lfx owner` sign-off entry the checker
    requires for a new record.
- Why the sample action is fictional rather than Slack: step 1 of the procedure is a dated authenticated `tools/list`
  capture; it does not exist, and Slack MCP admits only directory-published or internal apps
  (`decisions/substrate-slack.md` fact 2), so it cannot be produced here. The procedure names the exact files an
  `lfx-slack` adoption will touch once the capture exists, and the two Slack-specific questions the capture must
  answer.
### Engine follow-ups

Two fell out of writing the exercise, and are carried here rather than by rebasing PR 1:
  - `tools_list_digest()` could not read a *recorded* `tools/list`, because `discovered_tool()` only understood live
    tool objects. A pin author computes the digest from the recording, so plain mappings are now accepted
    (`src/lfx/src/lfx/base/mcp/pinned.py`, with its own `BUNDLE_API.md` changelog line).
  - `_get_server_key` hashes `url|headers` only, so a pinned-transport caller could reuse a session — and a cached
    `sse` transport preference — that an *unpinned* caller had already established over SSE for the same endpoint and
    headers, quietly undoing the transport half of the pin. The key now carries a suffix when, and only when, the
    fallback is disabled, so every existing server key is byte-identical.

The third is the merge of PR 1's review round (the `Runnable`-property defect, the synchronous call path, the
missing-argument reclassification, and the build-time digest check). `ga-swap-procedure.md` was amended to match:
step 4 states that the pinned hash must cover exactly the pinned tools, step 8 tells an adopting bundle to drive at
least one drift case through the real engine and says which defect that would have caught, a fourth deliberate
boundary states the call-time argument rule, and the open item on the client-facing error mapping now records that
nothing is owed there because INT-6's branch is generic.

## Verification

| Command | Result |
|---|---|
| `pytest src/lfx/tests/unit/base/mcp/test_ga_swap_procedure.py -q -p no:randomly` | 14 passed |
| the 78 new tests across all five new files | 78 passed |
| `pytest src/lfx/tests/unit/base/mcp src/lfx/tests/unit/integrations src/lfx/tests/unit/mcp src/lfx/tests/unit/utils/test_flow_validation.py -q -p no:randomly` | 820 passed |
| `pytest src/backend/tests/unit/base/mcp/test_mcp_util.py src/backend/tests/unit/components/models_and_agents/test_mcp_component.py src/backend/tests/unit/api/v2/test_registration.py src/bundles/confluent/tests/test_context_engine.py src/bundles/ibm/tests/test_watsonx_data_mcp.py -q -p no:randomly` | 338 passed, 13 skipped |
| `pytest src/lfx/tests/unit -q -p no:randomly --timeout=300` (shared root env) | 8227 passed, 30 skipped, 5 xfailed, 2 xpassed, **17 failed** — all pre-existing environment artifacts of running the lfx suite from the root env (`docling` not installed; `helpers/test_flow.py` asserts `langflow` is *not* importable; `unit/extension` asserts an empty component cache while the root env has every bundle installed). None touch this diff; the isolated `src/lfx` env is green. |
| `python scripts/ci/check_capability_matrices.py` | Capability matrices are complete. |
| `python scripts/migrate/check_bundle_api_changelog.py --base feat/int-9-mcp-pinned-mode` | ok (6 new changelog lines) |
| `pre-commit run --from-ref origin/feat/int-5-oauth-broker --to-ref HEAD` (case-conflict, end-of-file, mixed-line-ending, trailing-whitespace, ruff, ruff-format, bundle-api-changelog, detect-secrets) | 8 passed, no file rewritten |

## Not exercised

- **A live end-to-end run of a pinned action against an official MCP server.** The ticket's QA bullet asks for a
  pinned Slack action running against the official server in a contract test; that needs the dated authenticated
  `tools/list` capture named in `decisions/substrate-slack.md`'s re-open trigger, plus a directory-published or
  internal Slack app with workspace-admin approval (fact 2). Neither exists. What ships instead is the same procedure
  run against a recorded, clearly-labeled synthetic fixture, plus a written adoption path for `lfx-slack`. Flagged
  for the release owner: this is the one QA bullet these two PRs do not close.
- **`matrices/slack.json` is deliberately untouched.** `substrate_decision.chosen` stays `["rest"]` and no action
  moves to `substrate: "mcp"`. Flipping a row would contradict the accepted Option B that INT-12 is building
  against, and would need an `mcp_tools_list` source citing a capture that does not exist;
  `check_capability_matrices.py` enforces both. So nothing in the tree runs on the MCP substrate yet — by design.
- **No MCP-drift row in `frontend-surfaces.md`.** That file is INT-8's; editing it here would collide. Recorded as an
  open item in `ga-swap-procedure.md`.
- **`connection-contract.md` open question 12.a.7 (`session_scope`).** Token rotation on a pinned server still
  orphans the MCP session. The new `_get_server_key` suffix isolates pinned from unpinned callers but does not
  address rotation-orphaned sessions; idle cleanup reclaims them. Documented, not fixed.
- **`check_capability_matrices.py --require-accepted` was not run.** It fails on blank owner Name/Date/PR sign-off
  cells across every design record, which is pre-existing on the base branch and unrelated to this ticket. This PR
  only adds `ga-swap-procedure.md` to the lfx owner's "Signs off on" cell. Separately, that checker is not wired into
  any workflow (`.github`, `.pre-commit-config.yaml`, `Makefile` all have no reference), so it is enforced only by
  hand — also pre-existing.
