### PR TITLE
fix: add discovery metadata to frontend testing skill

### DIFF
--- a/.agents/skills/frontend-testing/SKILL.md
+++ b/.agents/skills/frontend-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: frontend-testing
+description: Write, review, or debug Langflow frontend tests for React components, hooks, utilities, and Zustand stores.
+---
+
 # Frontend Testing Skill - Langflow
 
 ## When to Apply


### PR DESCRIPTION
The frontend-testing skill lacks the name and description metadata used for skill discovery. This adds that metadata while preserving the existing testing instructions unchanged.

Validation: the skill passes the skill metadata validator; the body below the new frontmatter is unchanged; `git diff --check` passes. No frontend tests were run because test code and application code are unchanged.

Targets `release-1.13.0` per the contribution guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added metadata describing the frontend testing skill and its scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->