### PR TITLE
docs(services): name the actual parameter in KubernetesSecrets.upsert_secret's docstring

### DIFF
--- a/src/backend/base/langflow/services/variable/kubernetes_secrets.py
+++ b/src/backend/base/langflow/services/variable/kubernetes_secrets.py
@@ -54,7 +54,7 @@ class KubernetesSecretManager:
         If it exists, it will be updated with new data while preserving existing keys.
 
         :param secret_name: Name of the secret
-        :param new_data: Dictionary containing new key-value pairs for the secret
+        :param data: Dictionary containing new key-value pairs for the secret
         :return: Created or updated secret object
         """
         try:


### PR DESCRIPTION
`KubernetesSecrets.upsert_secret(self, secret_name, data)`'s docstring documents `:param new_data:` — the parameter is `data`. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `upsert_secret` method documentation to accurately describe its data parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->