### PR TITLE
docs: drop the companion-document links to files that were never committed

### DIFF
--- a/docs/features/durable-execution-hitl.md
+++ b/docs/features/durable-execution-hitl.md
@@ -4,7 +4,6 @@
 > Status: Draft
 > Owner: Engineering Team
 > Related PRs: #13633 (HITL v2); Epic LE-1437
-> Companion document: [`../../CZL/HITL_FEATURE_OVERVIEW.md`](../../CZL/HITL_FEATURE_OVERVIEW.md) — the engineering deep-dive (8-stage code walk-through), and [`../../CZL/HITL_STATUS.md`](../../CZL/HITL_STATUS.md) — the status/decision summary.
 
 ---
 


### PR DESCRIPTION
`docs/features/durable-execution-hitl.md` opens with a "Companion document" note linking `../../CZL/HITL_FEATURE_OVERVIEW.md` and `../../CZL/HITL_STATUS.md` — neither path exists in the repo (the CZL directory was never committed). The dead sentence is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a reference to the HITL engineering deep-dive and status summary from the durable execution documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->