### PR TITLE
docs: fix dead links in contributing-components.mdx

### DIFF
--- a/docs/docs/Contributing/contributing-components.mdx
+++ b/docs/docs/Contributing/contributing-components.mdx
@@ -19,11 +19,11 @@ Anyone can contribute an example component. For example, to create a new data co
 This example adds a data component, so add it to the `/data` directory.
 
 6. Add the component dependency to `src/lfx/src/lfx/components/data/__init__.py` as `from .DataFrameProcessor import DataFrameProcessor`.
-You can view the [/data/__init__.py](https://github.com/langflow-ai/langflow/blob/dev/src/lfx/src/lfx/components/data/__init__.py) in the Langflow repository.
+You can view the [/data/__init__.py](https://github.com/langflow-ai/langflow/blob/main/src/lfx/src/lfx/components/data/__init__.py) in the Langflow repository.
 
 7. Add any new dependencies to the [pyproject.toml](https://github.com/langflow-ai/langflow/blob/main/pyproject.toml#L20) file.
 
-8. Submit documentation for your component. For this example component, you would submit documentation to the [Data components page](https://github.com/langflow-ai/langflow/blob/main/docs/docs/Components/components-data.mdx).
+8. Submit documentation for your component. For this example component, you would submit documentation to the [Components reference](https://github.com/langflow-ai/langflow/blob/main/docs/docs/Components/concepts-components.mdx).
 
 9. Submit your changes as a pull request. The Langflow team will review, suggest changes, and add your component to Langflow.
 


### PR DESCRIPTION
## What's broken

`docs/docs/Contributing/contributing-components.mdx` has two dead links:

- Step 6 links to `https://github.com/langflow-ai/langflow/blob/dev/src/lfx/src/lfx/components/data/__init__.py` — the `dev` branch no longer exists (predates the `lfx` package), so the link 404s.
- Step 8 links to `https://github.com/langflow-ai/langflow/blob/main/docs/docs/Components/components-data.mdx` — this file was removed and no longer exists on `main`, so the link 404s.

## Proof

```
$ gh api repos/langflow-ai/langflow/contents/src/lfx/src/lfx/components/data/__init__.py?ref=dev
{"message":"Not Found", ...}

$ gh api repos/langflow-ai/langflow/contents/docs/docs/Components/components-data.mdx?ref=main
{"message":"Not Found", ...}
```

## What this PR changes

- Step 6 now points to the same file on `main`, which exists.
- Step 8 now points to `docs/docs/Components/concepts-components.mdx` (the current components reference page), which exists on `main`.

No other content in the file is changed.

Prepared with AI assistance; reviewed and verified by the author before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution instructions to link to the correct repository branch.
  * Corrected the documentation submission link to reference the Components reference page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->