### PR TITLE
fix(graph): scope branch inactivation resets

### DIFF
--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -791,7 +791,7 @@ async def _generate_flow_events(
             vertex.add_build_time(timedelta)
             # Capture both inactivated and conditionally excluded vertices
             inactivated_vertices = list(graph.inactivated_vertices.union(graph.conditionally_excluded_vertices))
-            graph.reset_inactivated_vertices()
+            graph.reset_inactivated_vertices(vertex.id)
             graph.reset_activated_vertices()
 
             # Note: Do not reset conditionally_excluded_vertices each iteration

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -723,7 +723,7 @@ async def build_vertex(
         result_data_response.timedelta = timedelta
         vertex.add_build_time(timedelta)
         inactivated_vertices = list(graph.inactivated_vertices)
-        graph.reset_inactivated_vertices()
+        graph.reset_inactivated_vertices(vertex.id)
         graph.reset_activated_vertices()
 
         await chat_service.set_cache(flow_id_str, graph)

--- a/src/lfx/src/lfx/graph/checkpoint/builder.py
+++ b/src/lfx/src/lfx/graph/checkpoint/builder.py
@@ -65,6 +65,10 @@ def build_checkpoint(graph: Graph) -> GraphCheckpoint:
         vertices_layers=[list(layer) for layer in graph.vertices_layers],
         first_layer=list(graph._first_layer),  # noqa: SLF001
         inactivated_vertices={str(v) for v in graph.inactivated_vertices},
+        branch_inactivation_sources={
+            str(source): {str(vertex) for vertex in vertices}
+            for source, vertices in graph.branch_inactivation_sources.items()
+        },
         conditionally_excluded_vertices={str(v) for v in graph.conditionally_excluded_vertices},
         activated_vertices=list(graph.activated_vertices),
         vertex_results={vertex.id: _vertex_data(vertex) for vertex in graph.vertices},

--- a/src/lfx/src/lfx/graph/checkpoint/resume.py
+++ b/src/lfx/src/lfx/graph/checkpoint/resume.py
@@ -160,6 +160,10 @@ def restore_graph_from_checkpoint(checkpoint: GraphCheckpoint, *, store: Checkpo
     graph._call_order = list(checkpoint.call_order)  # noqa: SLF001
     # Without these, every vertex resumes ACTIVE and compute_resume_layer revives a ConditionalRouter-stopped branch.
     graph.inactivated_vertices = {str(v) for v in checkpoint.inactivated_vertices}
+    graph.branch_inactivation_sources = {
+        str(source): {str(vertex) for vertex in vertices}
+        for source, vertices in checkpoint.branch_inactivation_sources.items()
+    }
     graph.conditionally_excluded_vertices = {str(v) for v in checkpoint.conditionally_excluded_vertices}
     graph.human_input_decisions = dict(checkpoint.human_input_decisions)
     graph.activated_vertices = list(checkpoint.activated_vertices)

--- a/src/lfx/src/lfx/graph/checkpoint/schema.py
+++ b/src/lfx/src/lfx/graph/checkpoint/schema.py
@@ -50,6 +50,7 @@ class GraphCheckpoint(BaseModel):
     vertices_layers: list[list[str]] = Field(default_factory=list)
     first_layer: list[str] = Field(default_factory=list)
     inactivated_vertices: set[str] = Field(default_factory=set)
+    branch_inactivation_sources: dict[str, set[str]] = Field(default_factory=dict)
     conditionally_excluded_vertices: set[str] = Field(default_factory=set)
     activated_vertices: list[str] = Field(default_factory=list)
     vertex_results: dict[str, VertexCheckpointData] = Field(default_factory=dict)

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -195,6 +195,11 @@ class Graph:
         self.persist_messages: bool = True
         self._start_time = datetime.now(timezone.utc)
         self.inactivated_vertices: set = set()
+        # Branch stops are transient and must be released by the vertex that
+        # created them. The graph can execute sibling vertices concurrently, so
+        # a graph-wide reset when one sibling finishes would otherwise revive a
+        # branch stopped by another sibling that is still running.
+        self.branch_inactivation_sources: dict[str, set[str]] = {}
         self.activated_vertices: list[str] = []
         self.vertices_layers: list[list[str]] = []
         self.vertices_to_run: set[str] = set()
@@ -1378,12 +1383,25 @@ class Graph:
         self.in_degree_map = self.build_in_degree(edges)
         self.parent_child_map = self.build_parent_child_map(vertices)
 
-    def reset_inactivated_vertices(self) -> None:
-        """Resets the inactivated vertices in the graph."""
-        for vertex_id in self.inactivated_vertices.copy():
+    def reset_inactivated_vertices(self, source_vertex_id: str | None = None) -> None:
+        """Reset branch inactivations owned by a completed source vertex.
+
+        Passing no source preserves the graph-wide reset used when initializing
+        a run. Cached graphs written before source ownership was introduced also
+        fall back to that legacy behavior.
+        """
+        if source_vertex_id is None or not self.branch_inactivation_sources:
+            vertices_to_activate = self.inactivated_vertices.copy()
+            self.branch_inactivation_sources.clear()
+        else:
+            owned_vertices = self.branch_inactivation_sources.pop(source_vertex_id, set())
+            still_owned = (
+                set().union(*self.branch_inactivation_sources.values()) if self.branch_inactivation_sources else set()
+            )
+            vertices_to_activate = owned_vertices - still_owned
+
+        for vertex_id in vertices_to_activate:
             self.mark_vertex(vertex_id, "ACTIVE")
-        self.inactivated_vertices = set()
-        self.inactivated_vertices = set()
 
     def mark_all_vertices(self, state: str) -> None:
         """Marks all vertices in the graph."""
@@ -1470,6 +1488,26 @@ class Graph:
             output_name=output_name,
             protected_vertices=protected_vertices,
         )
+        branch_vertices = visited - {vertex_id}
+        if state == VertexStates.INACTIVE:
+            tracked_vertices = branch_vertices.intersection(self.inactivated_vertices)
+            if tracked_vertices:
+                self.branch_inactivation_sources.setdefault(vertex_id, set()).update(tracked_vertices)
+        elif state == VertexStates.ACTIVE:
+            owned_vertices = self.branch_inactivation_sources.get(vertex_id)
+            if owned_vertices is not None:
+                released_vertices = owned_vertices.intersection(branch_vertices)
+                owned_vertices.difference_update(released_vertices)
+                if not owned_vertices:
+                    self.branch_inactivation_sources.pop(vertex_id)
+
+                still_owned = (
+                    set().union(*self.branch_inactivation_sources.values())
+                    if self.branch_inactivation_sources
+                    else set()
+                )
+                for owned_vertex_id in released_vertices.intersection(still_owned):
+                    self.mark_vertex(owned_vertex_id, VertexStates.INACTIVE)
         new_predecessor_map, _ = self.build_adjacency_maps(self.edges)
         new_predecessor_map = {k: v for k, v in new_predecessor_map.items() if k in visited}
         if vertex_id in self.cycle_vertices:
@@ -1582,6 +1620,7 @@ class Graph:
             "raw_graph_data": self.raw_graph_data,
             "top_level_vertices": self.top_level_vertices,
             "inactivated_vertices": self.inactivated_vertices,
+            "branch_inactivation_sources": self.branch_inactivation_sources,
             "run_manager": self.run_manager.to_dict(),
             "_run_id": self._run_id,
             "in_degree_map": self.in_degree_map,
@@ -1724,6 +1763,7 @@ class Graph:
         # Graphs cached before source-flow provenance was introduced remain
         # loadable and simply have no additional trusted storage namespace.
         state.setdefault("source_flow_id", None)
+        state.setdefault("branch_inactivation_sources", {})
         run_manager = state["run_manager"]
         if isinstance(run_manager, RunnableVerticesManager):
             state["run_manager"] = run_manager
@@ -2191,7 +2231,7 @@ class Graph:
         if self.stop_vertex and self.stop_vertex in next_runnable_vertices:
             next_runnable_vertices = [self.stop_vertex]
         self.extend_run_queue(next_runnable_vertices)
-        self.reset_inactivated_vertices()
+        self.reset_inactivated_vertices(vertex_id)
         self.reset_activated_vertices()
 
         if chat_service is not None:

--- a/src/lfx/tests/unit/graph/checkpoint/test_resume.py
+++ b/src/lfx/tests/unit/graph/checkpoint/test_resume.py
@@ -99,12 +99,14 @@ async def test_resume_keeps_inactivated_branch_stopped():
     graph, _ = await _paused_checkpoint()
     # Simulate a ConditionalRouter having stopped the chat_output branch before the pause.
     graph.inactivated_vertices = {"chat_output"}
+    graph.branch_inactivation_sources = {"chat_input": {"chat_output"}}
     graph.get_vertex("chat_output").state = VertexStates.INACTIVE
     checkpoint = graph.build_checkpoint()
 
     resumed = Graph.resume_from_checkpoint(checkpoint)
     # The inactivated state survives resume and the dead branch is NOT queued to run again.
     assert resumed.inactivated_vertices == {"chat_output"}
+    assert resumed.branch_inactivation_sources == {"chat_input": {"chat_output"}}
     assert resumed.get_vertex("chat_output").state == VertexStates.INACTIVE
     assert "chat_output" not in resumed.resume_first_layer()
 

--- a/src/lfx/tests/unit/graph/checkpoint/test_schema.py
+++ b/src/lfx/tests/unit/graph/checkpoint/test_schema.py
@@ -36,6 +36,7 @@ def _checkpoint(**overrides) -> GraphCheckpoint:
         "vertices_layers": [["n1"], ["n2"]],
         "first_layer": ["n1"],
         "inactivated_vertices": {"n3"},
+        "branch_inactivation_sources": {"n1": {"n3"}},
         "activated_vertices": ["n2"],
         "vertex_results": {
             "n1": VertexCheckpointData(vertex_id="n1", built=True, results={"text": "hello"}),
@@ -62,6 +63,7 @@ def test_checkpoint_round_trips_via_json_with_sets_preserved():
     assert restored.vertices_being_run == {"n1"}
     assert restored.ran_at_least_once == {"n1"}
     assert restored.inactivated_vertices == {"n3"}
+    assert restored.branch_inactivation_sources == {"n1": {"n3"}}
     assert restored.run_queue == ["n2"]
     assert restored.call_order == ["n1"]
     assert restored.pause_context == {"reason": "human_input_required", "data": {"options": ["a", "b"]}}

--- a/src/lfx/tests/unit/graph/test_branch_inactivation.py
+++ b/src/lfx/tests/unit/graph/test_branch_inactivation.py
@@ -1,0 +1,94 @@
+from lfx.custom.custom_component.component import Component
+from lfx.graph.graph.base import Graph
+from lfx.graph.vertex.base import VertexStates
+from lfx.io import MessageTextInput, Output
+from lfx.schema.message import Message
+
+
+class Source(Component):
+    display_name = "Source"
+    name = "Source"
+    outputs = [Output(display_name="Done", name="done", method="run")]
+
+    def run(self) -> Message:
+        return Message(text="done")
+
+
+class Sink(Component):
+    display_name = "Sink"
+    name = "Sink"
+    inputs = [MessageTextInput(name="input_value", display_name="Input", required=False)]
+    outputs = [Output(display_name="Out", name="out", method="run")]
+
+    def run(self) -> Message:
+        return Message(text=str(self.input_value or ""))
+
+
+def _parallel_branches() -> Graph:
+    graph = Graph()
+    for component_id, component in (
+        ("stopper", Source(_id="stopper")),
+        ("sibling", Source(_id="sibling")),
+        ("victim", Sink(_id="victim")),
+        ("sibling_output", Sink(_id="sibling_output")),
+    ):
+        graph.add_component(component, component_id)
+    graph.add_component_edge("stopper", ("done", "input_value"), "victim")
+    graph.add_component_edge("sibling", ("done", "input_value"), "sibling_output")
+    graph.prepare()
+    return graph
+
+
+def test_completed_sibling_does_not_reset_another_sources_stopped_branch():
+    graph = _parallel_branches()
+
+    graph.mark_branch("stopper", VertexStates.INACTIVE, output_name="done")
+    graph.reset_inactivated_vertices("sibling")
+
+    assert graph.get_vertex("victim").state == VertexStates.INACTIVE
+    assert graph.inactivated_vertices == {"victim"}
+
+    graph.reset_inactivated_vertices("stopper")
+
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE
+    assert graph.inactivated_vertices == set()
+
+
+def test_start_releases_the_sources_branch_ownership():
+    graph = _parallel_branches()
+    graph.mark_branch("stopper", VertexStates.INACTIVE, output_name="done")
+
+    graph.mark_branch("stopper", VertexStates.ACTIVE, output_name="done")
+
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE
+    assert graph.inactivated_vertices == set()
+    assert graph.branch_inactivation_sources == {}
+
+
+def test_shared_descendant_stays_inactive_until_every_source_releases_it():
+    graph = Graph()
+    for component_id, component in (
+        ("first", Source(_id="first")),
+        ("second", Source(_id="second")),
+        ("first_branch", Sink(_id="first_branch")),
+        ("second_branch", Sink(_id="second_branch")),
+        ("merge", Sink(_id="merge")),
+        ("victim", Sink(_id="victim")),
+    ):
+        graph.add_component(component, component_id)
+    graph.add_component_edge("first", ("done", "input_value"), "first_branch")
+    graph.add_component_edge("second", ("done", "input_value"), "second_branch")
+    graph.add_component_edge("first_branch", ("out", "input_value"), "merge")
+    graph.add_component_edge("second_branch", ("out", "input_value"), "merge")
+    graph.add_component_edge("merge", ("out", "input_value"), "victim")
+    graph.prepare()
+
+    graph.mark_branch("first", VertexStates.INACTIVE, output_name="done")
+    graph.mark_branch("second", VertexStates.INACTIVE, output_name="done")
+    graph.reset_inactivated_vertices("first")
+
+    assert graph.get_vertex("victim").state == VertexStates.INACTIVE
+
+    graph.reset_inactivated_vertices("second")
+
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE


### PR DESCRIPTION
## Summary

- track transient branch inactivations by the source vertex that created them
- release only the completed vertex's branch state, preserving stops owned by concurrent siblings
- keep ownership across graph caching and HITL checkpoint round-trips
- cover unrelated sibling completion, explicit branch restart, shared descendants, and checkpoint restore

## Why

The streaming build drivers run sibling vertices concurrently, but each completed vertex previously called a graph-wide reset. If one component called Component.stop() and continued running, an unrelated sibling could finish first and reactivate that stopped branch.

The inactive vertex set remains the scheduling/UI source of truth. This change adds source ownership beside it so resets can be scoped without serializing graph execution. The no-argument reset remains available for legacy cached state and full resets.

## Validation

- 409 lfx graph tests passed (6 skipped, 1 xfailed; 3 unrelated catalog-policy tests deselected because the component catalog is not installed in the lfx-only environment)
- focused branch-inactivation and checkpoint tests passed
- Ruff formatting and lint checks passed
- git diff --check passed

Closes #14966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional branch handling so one completed branch no longer unintentionally reactivates another branch stopped by a different source.
  * Preserved branch activation state and ownership when pausing and resuming workflows from checkpoints.
  * Ensured shared downstream branches remain inactive until all relevant stopping conditions are released.

* **Tests**
  * Added coverage for branch activation behavior and checkpoint state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->