### PR TITLE
fix(core): recognize API-keyless core providers

### DIFF
--- a/src/lfx/src/lfx/base/models/provider_registry.py
+++ b/src/lfx/src/lfx/base/models/provider_registry.py
@@ -528,9 +528,21 @@ def is_registered(provider: str) -> bool:
 
 
 def is_api_key_optional(provider: str) -> bool:
-    """True if *provider* is a registered provider that does not require an API key."""
+    """True if *provider* does not require an API key.
+
+    Extension providers declare this explicitly on their registry spec. Core
+    providers use the shared metadata table instead; providers such as Ollama
+    have no required secret because they authenticate through a base URL.
+    """
     spec = _registered.get(provider)
-    return spec is not None and not spec.api_key_required
+    if spec is not None:
+        return not spec.api_key_required
+
+    metadata = MODEL_PROVIDER_METADATA.get(provider)
+    if metadata is None:
+        return False
+
+    return not any(variable.get("required") and variable.get("is_secret") for variable in metadata.get("variables", []))
 
 
 def _resolve_callable(dotted: str) -> Callable:

--- a/src/lfx/tests/unit/base/models/test_provider_registry.py
+++ b/src/lfx/tests/unit/base/models/test_provider_registry.py
@@ -386,6 +386,15 @@ def test_api_key_required_by_default():
     assert provider_registry.is_api_key_optional("FakeCo") is False
 
 
+def test_core_provider_without_required_secret_is_api_key_optional():
+    """Core providers without an API-key variable must pass assistant setup."""
+    assert provider_registry.is_api_key_optional("Ollama") is True
+
+
+def test_core_provider_with_required_secret_is_not_api_key_optional():
+    assert provider_registry.is_api_key_optional("OpenAI") is False
+
+
 def test_live_provider_added_to_live_list_and_dispatches():
     register_provider(_fakeco_spec(live=True, live_discovery=_LIVE_DISCOVERY_PATH))
     assert "FakeCo" in LIVE_MODEL_PROVIDERS


### PR DESCRIPTION
## Summary

Fixes #14971.

Langflow's Assistant API rejected a configured Ollama provider as `Unknown provider` because `is_api_key_optional()` only checked extension providers. Ollama is a core provider with no required secret and authenticates through its base URL.

The registry now derives API-key optionality from core provider metadata while preserving explicit extension-provider configuration.

## Tests

- `python -m pytest src/lfx/tests/unit/base/models/test_provider_registry.py -q` (58 passed)
- `ruff check src/lfx/src/lfx/base/models/provider_registry.py src/lfx/tests/unit/base/models/test_provider_registry.py`
- `ruff format --check src/lfx/src/lfx/base/models/provider_registry.py src/lfx/tests/unit/base/models/test_provider_registry.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key requirement detection for both extension-registered and built-in providers.
  * Providers without a required API key, such as Ollama, are correctly identified.
  * Providers requiring an API key, such as OpenAI, are correctly identified.
  * Unknown providers default to requiring an API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->