### PR TITLE
ci(codeql): fire the pull_request scan on the branches PRs actually target

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,15 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'dev', 'main' ]
+    branches: [ 'release-*', 'main' ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ 'dev' ]
+    # Mirrors the Mend workflow's trigger (.github/workflows/mend.yml) and
+    # CONTRIBUTING.md, which routes PRs to the active release-X.Y.Z branch
+    # and never to main. `dev` last received a commit in July 2024 and is
+    # 5700+ commits behind main, so a filter of just 'dev' never matched a
+    # real PR's base branch and this pull_request trigger has not fired on
+    # an actual contribution since the branching model changed.
+    branches: [ 'release-*', 'main' ]
   schedule:
     - cron: '17 2 * * 1'
 


### PR DESCRIPTION
## What

`codeql.yml`'s `pull_request` trigger only fires for PRs whose base branch is `dev`:

```yaml
pull_request:
  # The branches below must be a subset of the branches above
  branches: [ 'dev' ]
```

`dev`'s last commit is from **2024-07-16** and it is **5,738 commits behind `main`** (`gh api repos/langflow-ai/langflow/compare/main...dev` → `"ahead_by":14,"behind_by":5738`). `CONTRIBUTING.md` routes every PR to the active `release-X.Y.Z` branch and explicitly says *"Do not target `main`"* — `dev` isn't even mentioned as an option.

I sampled ~40 recent open and merged PRs via `gh pr list --state open/merged --json baseRefName`; every one targets a `release-X.Y.Z` branch, `main`, or a `feat/*` branch — none target `dev`.

**Net effect:** CodeQL's pre-merge scan — the one that can actually block a vulnerable change before it merges — has not matched a real PR in this repo for two years plus. `push` (to the now-idle `dev`/`main`) and the weekly `schedule` cron keep the workflow visibly "green" in Actions history, which can read as "CodeQL is protecting PRs" when it isn't.

The sibling `.github/workflows/mend.yml` (Mend/dependency scanning) already gets this right:

```yaml
on:
  push:
    branches: ["release-*", "main"]
  pull_request:
    branches: ["release-*", "main"]
```

## Fix

Mirror `mend.yml`'s trigger on both `push` and `pull_request`, so CodeQL scans the branches PRs are actually opened against:

```yaml
on:
  push:
    branches: [ 'release-*', 'main' ]
  pull_request:
    branches: [ 'release-*', 'main' ]
```

Smallest possible change — trigger filters only, no changes to the analysis job itself (languages, permissions, timeout, `github/codeql-action` steps are all untouched).

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml', encoding='utf-8'))"` — re-parses cleanly after the edit, `on.pull_request.branches == on.push.branches == ['release-*', 'main']`.
- `release-*` glob syntax for the `branches` filter is the exact pattern already used (and presumably working) in `mend.yml` in this same repo, so this isn't a novel/untested pattern for the project's CI.
- Confirmed via `git log`/`gh api repos/.../commits?path=...` that this trigger hasn't been touched since the file was added in 2023, i.e. it predates the shift to the `release-X.Y.Z` branching model documented in `CONTRIBUTING.md` today.
- Did not touch `push`'s `dev` entry's removal lightly — kept the diff to swapping `dev`→`release-*` in both lists rather than only patching `pull_request`, since leaving `push` pointed at a 2-year-idle branch while `pull_request` no longer matches it would leave the same "looks covered, isn't" gap the fix is meant to close. Happy to keep `dev` in `push` too if there's a reason it should stay (e.g. an internal use I can't see from the public repo) — flagging that explicitly since I can't verify internal branch usage from outside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated security checks to run for pushes to the main branch and release branches.
  - Pull requests targeting the main branch or release branches are now included in these checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->