### PR TITLE
fix: sync env variables for returning SSO users and stop sync from locking out future updates

### DIFF
--- a/src/backend/base/langflow/services/auth/service.py
+++ b/src/backend/base/langflow/services/auth/service.py
@@ -977,6 +977,13 @@ class AuthService(BaseAuthService):
             profile.sso_last_login_at = now
             profile.updated_at = now
             await update_user_last_login_at(user.id, db)
+            # Sync environment variables on every SSO sign-in, not just
+            # the first.  Without this call, a variable added to
+            # LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT after the user
+            # was created never shows up for them.
+            from langflow.services.deps import get_variable_service
+
+            await get_variable_service().initialize_user_variables(user.id, db)
             return user
 
         username = await self._unique_external_username(db, identity)

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -145,7 +145,20 @@ class DatabaseVariableService(VariableService, Service):
                                 f"Skipping update of user-modified variable {var_name} with environment value"
                             )
                         else:
-                            await self.update_variable(user_id, var_name, value, session=session)
+                            # Only write if the value actually changed; use
+                            # bump_updated_at=False so that an env-sync write
+                            # does not count as a user edit.  Without this,
+                            # the second sync sets updated_at > created_at
+                            # and every subsequent sync is skipped.
+                            existing_decrypted = auth_utils.decrypt_api_key(existing.value)
+                            if existing_decrypted != value:
+                                await self.update_variable(
+                                    user_id,
+                                    var_name,
+                                    value,
+                                    session=session,
+                                    bump_updated_at=False,
+                                )
                     else:
                         await self.create_variable(
                             user_id=user_id,
@@ -403,6 +416,8 @@ class DatabaseVariableService(VariableService, Service):
         name: str,
         value: str,
         session: AsyncSession,
+        *,
+        bump_updated_at: bool = True,
     ):
         stmt = select(Variable).where(Variable.user_id == user_id, Variable.name == name)
         variable = (await session.exec(stmt)).first()
@@ -423,7 +438,8 @@ class DatabaseVariableService(VariableService, Service):
             variable.value = auth_utils.encrypt_api_key(value, settings_service=self.settings_service)
         else:
             variable.value = value
-        variable.updated_at = datetime.now(timezone.utc)
+        if bump_updated_at:
+            variable.updated_at = datetime.now(timezone.utc)
         session.add(variable)
         await session.flush()
         await session.refresh(variable)

--- a/src/backend/tests/unit/services/auth/test_auth_service.py
+++ b/src/backend/tests/unit/services/auth/test_auth_service.py
@@ -2924,3 +2924,62 @@ async def test_get_current_user_mcp_auto_login_skip_missing_superuser_rejects(
         )
 
     assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+# =============================================================================
+# Regression: SSO returning users must receive newly added env variables (#14983)
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_returning_sso_user_gets_newly_added_env_variable(
+    auth_service: AuthService,
+    auth_settings: AuthSettings,
+    async_session,
+):
+    """A returning SSO user must see variables added to
+    LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT after their account was created.
+
+    Before the fix, _materialize_external_user only synced variables for new
+    users (inside _initialize_jit_user_defaults).  Returning users hit the
+    early-return branch and never called initialize_user_variables.
+    """
+    from langflow.services.auth.external import identity_from_claims
+    from langflow.services.deps import get_settings_service, get_variable_service
+
+    auth_settings.EXTERNAL_AUTH_ENABLED = True
+    auth_settings.EXTERNAL_AUTH_PROVIDER = "external"
+
+    identity = identity_from_claims(
+        {"sub": "sub-1", "email": "u1@example.com", "preferred_username": "u1"},
+        auth_settings,
+    )
+
+    # First sign-in — provisions the user.
+    with patch(
+        "langflow.services.deps.get_variable_service",
+        return_value=get_variable_service(),
+    ):
+        user = await auth_service._materialize_external_user(identity, async_session)
+        await async_session.flush()
+
+        # Operator adds a new variable to the environment and redeploys.
+        monkeypatch_values = {
+            "NEW_SERVICE_URL": "https://svc.internal",
+        }
+        with patch.dict("os.environ", monkeypatch_values, clear=False):
+            # Make sure the setting includes the new variable.
+            original = get_settings_service().settings.variables_to_get_from_environment
+            get_settings_service().settings.variables_to_get_from_environment = [
+                *original,
+                "NEW_SERVICE_URL",
+            ]
+            try:
+                # Second sign-in — must pick up the new variable.
+                await auth_service._materialize_external_user(identity, async_session)
+                await async_session.flush()
+            finally:
+                get_settings_service().settings.variables_to_get_from_environment = original
+
+    names = await get_variable_service().list_variables(user.id, async_session)
+    assert "NEW_SERVICE_URL" in names

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -952,3 +952,62 @@ async def test_get_all_never_returns_decrypted_credential_as_generic(service, se
     leaked = [v for v in results if v.value and v.value.startswith("gAAAAA")]
     assert leaked == []
     assert all(v.id != saved_id for v in results if v.value is not None)
+
+
+# =============================================================================
+# Regression: env value change must reach user after repeat sync (#14983)
+# =============================================================================
+
+
+async def test_env_value_change_reaches_user_after_repeat_sync(
+    service, session: AsyncSession, monkeypatch
+):
+    """After two syncs the stored updated_at becomes newer than created_at,
+    which makes the is_user_modified check always True — blocking every
+    subsequent environment update.
+
+    Bug 2 of #14983: the sync itself calls update_variable, which sets
+    updated_at = now.  After sync 2, updated_at > created_at is permanently
+    true, so sync 3+ are all skipped even when the env value changed.
+    """
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(
+        service.settings_service.settings,
+        "variables_to_get_from_environment",
+        ["OPENAI_API_KEY"],
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "v1")
+    await service.initialize_user_variables(user_id=user_id, session=session)
+    # sync 2 — must not lock out future updates
+    await service.initialize_user_variables(user_id=user_id, session=session)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "v2")
+    await service.initialize_user_variables(user_id=user_id, session=session)
+    value = await service.get_variable(user_id, "OPENAI_API_KEY", "", session=session)
+    assert value.get_secret_value() == "v2"
+
+
+async def test_env_sync_skips_write_when_value_unchanged(
+    service, session: AsyncSession, monkeypatch
+):
+    """When the environment value hasn't changed, the sync must not touch the
+    row at all (no unnecessary write, no updated_at bump)."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(
+        service.settings_service.settings,
+        "variables_to_get_from_environment",
+        ["OPENAI_API_KEY"],
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "same-value")
+    await service.initialize_user_variables(user_id=user_id, session=session)
+    var_after_create = await service.get_variable_object(user_id, "OPENAI_API_KEY", session)
+    created_ts = var_after_create.updated_at
+
+    # Second sync with the same value — should be a no-op.
+    await service.initialize_user_variables(user_id=user_id, session=session)
+    var_after_second = await service.get_variable_object(user_id, "OPENAI_API_KEY", session)
+    assert var_after_second.updated_at == created_ts

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -959,9 +959,7 @@ async def test_get_all_never_returns_decrypted_credential_as_generic(service, se
 # =============================================================================
 
 
-async def test_env_value_change_reaches_user_after_repeat_sync(
-    service, session: AsyncSession, monkeypatch
-):
+async def test_env_value_change_reaches_user_after_repeat_sync(service, session: AsyncSession, monkeypatch):
     """After two syncs the stored updated_at becomes newer than created_at,
     which makes the is_user_modified check always True — blocking every
     subsequent environment update.
@@ -989,11 +987,10 @@ async def test_env_value_change_reaches_user_after_repeat_sync(
     assert value.get_secret_value() == "v2"
 
 
-async def test_env_sync_skips_write_when_value_unchanged(
-    service, session: AsyncSession, monkeypatch
-):
+async def test_env_sync_skips_write_when_value_unchanged(service, session: AsyncSession, monkeypatch):
     """When the environment value hasn't changed, the sync must not touch the
-    row at all (no unnecessary write, no updated_at bump)."""
+    row at all (no unnecessary write, no updated_at bump).
+    """
     user_id = uuid4()
     monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #14983

## Problem

`LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT` only reached a user's `variable` rows once, at account creation. Two separate bugs caused this.

Bug 1: with `LANGFLOW_EXTERNAL_AUTH_ENABLED`, every request materializes the external user in `_materialize_external_user`. Users that already exist hit the early-return branch and never run the variable sync, so a variable added to the environment after signup never shows up for them. New users get the sync because the JIT provisioning path calls it.

Bug 2: the sync writes through `update_variable`, which sets `updated_at = now`. The sync guard treats `updated_at > created_at` as "the user edited this, leave it alone". So the second sync flags an environment-created row as user-modified, and every later sync skips it. Rotating a key in the environment stops reaching users after that, for SSO and password login alike.

## Changes

- Run `initialize_user_variables` for returning users in `_materialize_external_user`, not only in the JIT path.
- Skip the write when the decrypted stored value already matches the environment value.
- Add a `bump_updated_at` flag to `update_variable`, defaulting to true, and pass false from the sync path. API and UI updates keep the old behavior.

The sync stays idempotent and never marks an environment row as user-modified. A real UI edit still bumps the timestamp and wins over the environment.

## Verification

Three regression tests cover the issue scenarios and failed before this change:

- `test_returning_sso_user_gets_newly_added_env_variable`
- `test_env_value_change_reaches_user_after_repeat_sync`
- `test_env_sync_skips_write_when_value_unchanged`

Run them with:

```
uv run pytest src/backend/tests/unit/services/variable/test_service.py src/backend/tests/unit/services/auth/test_auth_service.py -k "env_value_change_reaches_user_after_repeat_sync or env_sync_skips_write_when_value_unchanged or returning_sso_user_gets_newly_added_env_variable"
```

## Notes

I kept the sync where the external user is materialized instead of adding a startup sweep for all users. The environment only changes on restart, so the per-request cost is now bounded: equal values skip the write, and this path already runs for every external-auth request. Happy to move it to a startup hook if that fits the release flow better.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Returning SSO users now receive environment-based variables added after their account was created.
  - Updated environment variable values are synchronized correctly during sign-in.
  - Unchanged environment values no longer trigger unnecessary updates.

- **Tests**
  - Added coverage for variable synchronization when values change, remain unchanged, or are newly configured for existing SSO users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->