### PR TITLE
fix(a11y): associate flow settings labels with their controls

### DIFF
--- a/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
+++ b/src/frontend/src/components/core/editFlowSettingsComponent/index.tsx
@@ -125,7 +125,6 @@ export const EditFlowSettings: React.FC<
               name="name"
               value={name ?? ""}
               placeholder={t("flow.namePlaceholder")}
-              id="name"
               maxLength={maxLength}
               minLength={minLength}
               required={true}
@@ -166,7 +165,6 @@ export const EditFlowSettings: React.FC<
           <Form.Control asChild>
             <Textarea
               name="description"
-              id="description"
               onChange={handleDescriptionChange}
               value={description!}
               placeholder={t("flow.descriptionPlaceholder")}
@@ -192,40 +190,40 @@ export const EditFlowSettings: React.FC<
         <Form.Message match="valueMissing" className="field-invalid">
           {t("flow.pleaseEnterDescription")}
         </Form.Message>
-        {/* Callers that only display the flow (no setLocked) would otherwise
-            render a focusable switch that cannot change anything. */}
-        {setLocked && (
-          <div className="mt-3">
-            <div className="flex items-center gap-2">
-              <div>
-                <div className="flex items-center gap-2">
-                  <Form.Label className="text-mmd font-medium">
-                    {t("flow.lockFlow")}
-                  </Form.Label>
+      </Form.Field>
+      {/* Callers that only display the flow (no setLocked) would otherwise
+          render a focusable switch that cannot change anything. */}
+      {setLocked && (
+        <div className="mt-3">
+          <div className="flex items-center gap-2">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-mmd font-medium">
+                  {t("flow.lockFlow")}
+                </span>
 
-                  <ForwardedIconComponent
-                    name={locked ? "Lock" : "Unlock"}
-                    className="text-muted-foreground !w-5 !h-5"
-                  />
-                </div>
-
-                <p className="text-xs text-muted-foreground/70 mt-1 font-normal">
-                  {t("flow.lockFlowDescription")}
-                </p>
+                <ForwardedIconComponent
+                  name={locked ? "Lock" : "Unlock"}
+                  className="text-muted-foreground !w-5 !h-5"
+                />
               </div>
 
-              <Switch
-                checked={!!locked}
-                onCheckedChange={(v) => setLocked(v)}
-                disabled={readOnly}
-                className="data-[state=checked]:bg-primary ml-auto"
-                data-testid="lock-flow-switch"
-                aria-label={t("flow.lockFlowAriaLabel")}
-              />
+              <p className="text-xs text-muted-foreground mt-1 font-normal">
+                {t("flow.lockFlowDescription")}
+              </p>
             </div>
+
+            <Switch
+              checked={!!locked}
+              onCheckedChange={(v) => setLocked(v)}
+              disabled={readOnly}
+              className="data-[state=checked]:bg-primary ml-auto"
+              data-testid="lock-flow-switch"
+              aria-label={t("flow.lockFlowAriaLabel")}
+            />
           </div>
-        )}
-      </Form.Field>
+        </div>
+      )}
     </>
   );
 };

--- a/src/frontend/tests/a11y/flow-settings.a11y.spec.ts
+++ b/src/frontend/tests/a11y/flow-settings.a11y.spec.ts
@@ -1,0 +1,50 @@
+import { expect, type LangflowPage, test } from "../fixtures";
+import { awaitBootstrapTest } from "../utils/await-bootstrap-test";
+import { TIMEOUTS } from "../utils/constants/timeouts";
+
+// The flow settings modal is reached from the flow card's actions menu on the
+// flows list, not from the canvas: FlowSettingsModal is mounted in
+// pages/MainPage/components/list.
+async function openFlowSettingsModal(page: LangflowPage) {
+  await awaitBootstrapTest(page, { skipModal: true });
+  await page.getByTestId("home-dropdown-menu").first().click();
+  await page.getByTestId("btn-edit-flow").click();
+  await expect(page.getByRole("dialog")).toBeVisible({
+    timeout: TIMEOUTS.standard,
+  });
+}
+
+test(
+  "flow settings modal accessibility",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await openFlowSettingsModal(page);
+    await page.runA11yScan("flow-settings-modal");
+  },
+);
+
+// Form.Field generates the id that Form.Label points at, and Form.Control
+// forwards it to the input. A hardcoded id on the input silently overrode it,
+// leaving every label in the modal pointing at an element that does not exist.
+// Asserting the accessible name would NOT catch this: the inputs carry a
+// placeholder, which the name computation falls back to even when the label
+// is orphaned. Assert the association itself.
+test(
+  "flow settings labels resolve to their controls",
+  { tag: ["@release", "@workspace"] },
+  async ({ page }) => {
+    await openFlowSettingsModal(page);
+
+    const orphanedLabels = await page.evaluate(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      if (!dialog) {
+        throw new Error("flow settings dialog not found");
+      }
+      return Array.from(dialog.querySelectorAll("label[for]"))
+        .map((label) => label.getAttribute("for") as string)
+        .filter((id) => !dialog.querySelector(`#${CSS.escape(id)}`));
+    });
+
+    expect(orphanedLabels).toEqual([]);
+  },
+);


### PR DESCRIPTION
Hardcoded ids on the name and description inputs overrode the ids Form.Field generates for Form.Label, orphaning every label in the modal. Move the lock block out of the description field and raise its description text to full opacity for WCAG AA contrast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the flow settings modal’s form structure and visual styling.
  * Corrected label associations to support more reliable accessibility behavior.

* **Tests**
  * Added accessibility coverage for the flow settings modal.
  * Added validation to ensure form labels correctly reference existing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->