### PR TITLE
fix: sync environment variables for existing users at startup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2211,7 +2211,7 @@
         "filename": "src/backend/tests/unit/services/variable/test_service.py",
         "hashed_secret": "30abc0a833efea23496b4d226fffa2f90c0855c0",
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 56,
         "is_secret": false
       }
     ],
@@ -2389,7 +2389,7 @@
         "filename": "src/backend/tests/unit/test_setup_superuser_flow.py",
         "hashed_secret": "6b7065a54fddbb64d6fbe6c4ce55cc668e8a3511",
         "is_verified": false,
-        "line_number": 348,
+        "line_number": 378,
         "is_secret": false
       }
     ],
@@ -7417,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T00:32:54Z"
+  "generated_at": "2026-09-08T14:29:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2211,7 +2211,7 @@
         "filename": "src/backend/tests/unit/services/variable/test_service.py",
         "hashed_secret": "30abc0a833efea23496b4d226fffa2f90c0855c0",
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 57,
         "is_secret": false
       }
     ],
@@ -2389,7 +2389,7 @@
         "filename": "src/backend/tests/unit/test_setup_superuser_flow.py",
         "hashed_secret": "6b7065a54fddbb64d6fbe6c4ce55cc668e8a3511",
         "is_verified": false,
-        "line_number": 378,
+        "line_number": 393,
         "is_secret": false
       }
     ],
@@ -7417,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-08T14:29:04Z"
+  "generated_at": "2026-09-08T15:45:42Z"
 }

--- a/docs/docs/Develop/configuration-global-variables.mdx
+++ b/docs/docs/Develop/configuration-global-variables.mdx
@@ -79,13 +79,19 @@ You can declare additional variables in `LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONM
 For example, `LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT=WATSONX_PROJECT_ID,WATSONX_API_KEY` creates global variables named `WATSONX_PROJECT_ID` and `WATSONX_API_KEY` in Langflow's database.
 Then, you can use these variables wherever they are needed in your component settings.
 
-With the default database variable store, Langflow imports configured environment variables for all existing users at startup, including SSO users.
-New users also receive these variables when their accounts are created.
-Variables imported by Langflow 1.12.1 or later follow environment value changes on subsequent startups until you edit them in Langflow.
-Creating or editing a variable yourself preserves your value over the environment, and unchanged environment values do not rewrite stored credentials.
+With the default database variable store (`LANGFLOW_VARIABLE_STORE=db`) and `LANGFLOW_STORE_ENVIRONMENT_VARIABLES=True`, server startup attempts to import configured environment variables for all existing users, including SSO users.
+A successful Gunicorn master import is inherited by its workers. Import failures are logged and do not block server startup; other users' imports continue after an individual user fails.
+Service initialization for commands such as `langflow migration --test` does not run this all-user import.
+Account creation and password sign-in also import variables for that user.
 
-Variables stored before this behavior was introduced keep their existing values because their timestamps cannot reliably distinguish environment imports from user edits.
-Update these legacy values in **Settings** > **Global Variables** when you need to rotate them.
+Imports use nonblank environment values with surrounding whitespace removed. Model-provider policy can exclude provider variables, and provider secret values equal to `dummy` (case-insensitive) are skipped.
+Environment-managed credentials follow subsequent environment value changes. Unchanged values do not rewrite stored credentials.
+Saving a value yourself, renaming the variable, or changing its type makes it user-owned; changing only **Apply to fields** retains environment management.
+
+After upgrading, a legacy credential is adopted for environment management only when its stored value already matches the environment.
+Matching legacy values can include an earlier user override that happens to equal the environment; future rotations update adopted values.
+Differing legacy values are preserved. Explicit user overrides saved after upgrading are never automatically adopted, even if their value matches the environment.
+To rotate a differing legacy value, its owner can update it in **Settings** > **Global Variables**.
 
 <Tabs>
 <TabItem value="local" label="Local" default>

--- a/docs/docs/Develop/configuration-global-variables.mdx
+++ b/docs/docs/Develop/configuration-global-variables.mdx
@@ -79,6 +79,14 @@ You can declare additional variables in `LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONM
 For example, `LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT=WATSONX_PROJECT_ID,WATSONX_API_KEY` creates global variables named `WATSONX_PROJECT_ID` and `WATSONX_API_KEY` in Langflow's database.
 Then, you can use these variables wherever they are needed in your component settings.
 
+With the default database variable store, Langflow imports configured environment variables for all existing users at startup, including SSO users.
+New users also receive these variables when their accounts are created.
+Variables imported by Langflow 1.12.1 or later follow environment value changes on subsequent startups until you edit them in Langflow.
+Creating or editing a variable yourself preserves your value over the environment, and unchanged environment values do not rewrite stored credentials.
+
+Variables stored before this behavior was introduced keep their existing values because their timestamps cannot reliably distinguish environment imports from user edits.
+Update these legacy values in **Settings** > **Global Variables** when you need to rotate them.
+
 <Tabs>
 <TabItem value="local" label="Local" default>
 

--- a/src/backend/base/langflow/alembic/versions/d7e9f1a3b5c8_add_variable_environment_origin.py
+++ b/src/backend/base/langflow/alembic/versions/d7e9f1a3b5c8_add_variable_environment_origin.py
@@ -1,0 +1,37 @@
+"""Track environment-managed variable values.
+
+Revision ID: d7e9f1a3b5c8
+Revises: c6d8e0f2a4b7
+Create Date: 2026-09-08
+
+Phase: EXPAND
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from langflow.utils import migration
+
+revision: str = "d7e9f1a3b5c8"  # pragma: allowlist secret
+down_revision: str | None = "c6d8e0f2a4b7"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Leave existing rows unknown so adoption can compare their decrypted values."""
+    conn = op.get_bind()
+    if migration.table_exists("variable", conn) and not migration.column_exists(
+        "variable", "is_environment_managed", conn
+    ):
+        with op.batch_alter_table("variable", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("is_environment_managed", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove origin tracking without changing stored variable values."""
+    conn = op.get_bind()
+    if migration.table_exists("variable", conn) and migration.column_exists("variable", "is_environment_managed", conn):
+        with op.batch_alter_table("variable", schema=None) as batch_op:
+            batch_op.drop_column("is_environment_managed")

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -196,7 +196,12 @@ def get_lifespan(*, fix_migration=False, version=None):
     async def lifespan(_app: FastAPI):
         from lfx.interface.components import component_cache, get_and_cache_all_types_dict
 
-        from langflow.preload import PreloadStep, get_owned_temp_dirs, is_step_complete
+        from langflow.preload import (
+            PreloadStep,
+            get_owned_temp_dirs,
+            initialize_environment_variables,
+            is_step_complete,
+        )
 
         configure()
 
@@ -259,6 +264,7 @@ def get_lifespan(*, fix_migration=False, version=None):
             # Even when preload state is inherited via fork, initialize_services() must run
             # so each worker rebuilds its own connection pool (idempotent otherwise).
             await initialize_services(fix_migration=fix_migration)
+            await initialize_environment_variables()
             await logger.adebug(f"Services initialized in {asyncio.get_event_loop().time() - start_time:.2f}s")
 
             # Surface env-driven pgVector so operators can confirm the deployment

--- a/src/backend/base/langflow/preload.py
+++ b/src/backend/base/langflow/preload.py
@@ -57,6 +57,7 @@ class PreloadStep(Enum):
     """Ordered preload phases; completion flags must advance via ``mark_step_complete`` only."""
 
     PROFILE_PICTURES = "profile_pictures"
+    ENVIRONMENT_VARIABLES = "environment_variables"
     BUNDLES = "bundles"
     TYPES_CACHED = "types_cached"
     STARTER_PROJECTS = "starter_projects"
@@ -66,6 +67,7 @@ class PreloadStep(Enum):
 
 _STEP_ATTR: Final[dict[PreloadStep, str]] = {
     PreloadStep.PROFILE_PICTURES: "profile_pictures_copied",
+    PreloadStep.ENVIRONMENT_VARIABLES: "environment_variables_initialized",
     PreloadStep.BUNDLES: "bundles_loaded",
     PreloadStep.TYPES_CACHED: "types_cached",
     PreloadStep.STARTER_PROJECTS: "starter_projects_created",
@@ -76,6 +78,7 @@ _STEP_ATTR: Final[dict[PreloadStep, str]] = {
 # Explicit prerequisite DAG matching ``_run_master_preload`` ordering (comments + pipeline).
 _STEP_PREREQUISITES: Final[dict[PreloadStep, tuple[PreloadStep, ...]]] = {
     PreloadStep.PROFILE_PICTURES: (),
+    PreloadStep.ENVIRONMENT_VARIABLES: (),
     PreloadStep.BUNDLES: (),
     PreloadStep.TYPES_CACHED: (PreloadStep.BUNDLES,),
     PreloadStep.STARTER_PROJECTS: (PreloadStep.TYPES_CACHED,),
@@ -108,6 +111,7 @@ class _PreloadState:
     bundles_components_paths: list[str] = field(default_factory=list)
     # Per-step completion flags to prevent silent data loss
     profile_pictures_copied: bool = False
+    environment_variables_initialized: bool = False
     bundles_loaded: bool = False
     types_cached: bool = False
     starter_projects_created: bool = False
@@ -135,6 +139,7 @@ class _PreloadState:
         self.temp_dirs = []
         self.bundles_components_paths = []
         self.profile_pictures_copied = False
+        self.environment_variables_initialized = False
         self.bundles_loaded = False
         self.types_cached = False
         self.starter_projects_created = False
@@ -152,6 +157,24 @@ async def _best_effort(step: PreloadStep, log_suffix: str, awaitable: Awaitable[
         mark_step_complete(step)
     except Exception:  # noqa: BLE001
         await logger.aexception(f"[preload] {log_suffix}")
+
+
+async def initialize_environment_variables() -> None:
+    """Run the server-only sweep unless inherited from a successful master preload."""
+    if is_step_complete(PreloadStep.ENVIRONMENT_VARIABLES):
+        await logger.adebug("Skipping environment variables: already initialized during server startup")
+        return
+
+    async def _initialize() -> None:
+        from langflow.services.deps import get_variable_service
+
+        await get_variable_service().initialize_all_user_variables()
+
+    await _best_effort(
+        PreloadStep.ENVIRONMENT_VARIABLES,
+        "environment variable import failed; server startup will continue",
+        _initialize(),
+    )
 
 
 def is_preloaded() -> bool:
@@ -219,6 +242,7 @@ async def _run_master_preload() -> None:
     # would leave an open connection pool in the master process, and that pool
     # would be inherited (fork-unsafe) by every worker.
     try:
+        await initialize_environment_variables()
         await logger.adebug("[preload] copying profile pictures")
         await _best_effort(
             PreloadStep.PROFILE_PICTURES,

--- a/src/backend/base/langflow/services/database/models/variable/model.py
+++ b/src/backend/base/langflow/services/database/models/variable/model.py
@@ -39,6 +39,11 @@ class Variable(VariableBase, table=True):  # type: ignore[call-arg]
         sa_column=Column(DateTime(timezone=True), nullable=True),
         description="Last update time of the variable",
     )
+    is_environment_managed: bool | None = Field(
+        default=None,
+        nullable=True,
+        description="True for environment imports, False for user overrides, None for legacy rows",
+    )
     default_fields: list[str] | None = Field(sa_column=Column(JSON))
     # foreign key to user table
     user_id: UUID = Field(description="User ID associated with this variable", foreign_key="user.id")

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -751,6 +751,12 @@ async def initialize_services(*, fix_migration: bool = False, skip_superuser_set
         except sqlalchemy_exc.IntegrityError as exc:
             await logger.awarning(f"Error assigning orphaned flows to the superuser: {exc!s}")
 
+    # This path runs during both master preload and ordinary worker startup.
+    # Existing SSO users do not pass through the password-login initializer.
+    from langflow.services.deps import get_variable_service
+
+    await get_variable_service().initialize_all_user_variables()
+
     async with session_scope() as session:
         await clean_transactions(settings_service, session)
         await clean_vertex_builds(settings_service, session)

--- a/src/backend/base/langflow/services/utils.py
+++ b/src/backend/base/langflow/services/utils.py
@@ -751,12 +751,6 @@ async def initialize_services(*, fix_migration: bool = False, skip_superuser_set
         except sqlalchemy_exc.IntegrityError as exc:
             await logger.awarning(f"Error assigning orphaned flows to the superuser: {exc!s}")
 
-    # This path runs during both master preload and ordinary worker startup.
-    # Existing SSO users do not pass through the password-login initializer.
-    from langflow.services.deps import get_variable_service
-
-    await get_variable_service().initialize_all_user_variables()
-
     async with session_scope() as session:
         await clean_transactions(settings_service, session)
         await clean_vertex_builds(settings_service, session)

--- a/src/backend/base/langflow/services/variable/base.py
+++ b/src/backend/base/langflow/services/variable/base.py
@@ -13,6 +13,9 @@ class VariableService(Service):
 
     name = "variable_service"
 
+    async def initialize_all_user_variables(self) -> None:
+        """Sync environment defaults at startup; external stores opt out by default."""
+
     async def get_default_field_bindings(
         self,
         user_id: UUID | str,

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -54,10 +54,25 @@ class DatabaseVariableService(VariableService, Service):
         ):
             return
 
+        from lfx.base.models.unified_models import get_model_provider_metadata
+
         from langflow.services.database.models.user.model import User
         from langflow.services.deps import session_scope
 
+        secret_names = {
+            variable["variable_key"]
+            for provider in get_model_provider_metadata().values()
+            for variable in provider.get("variables", [])
+            if variable.get("is_secret") and variable.get("variable_key")
+        }
+        if not any(
+            (value := os.environ.get(name, "").strip()) and not (name in secret_names and value.lower() == "dummy")
+            for name in settings.variables_to_get_from_environment
+        ):
+            return
+
         last_user_id: UUID | None = None
+        failed_users = 0
         while True:
             async with session_scope() as session:
                 query = select(User.id).order_by(User.id).limit(100)
@@ -65,11 +80,20 @@ class DatabaseVariableService(VariableService, Service):
                     query = query.where(User.id > last_user_id)
                 user_ids = (await session.exec(query)).all()
             if not user_ids:
-                return
+                break
             for user_id in user_ids:
-                async with session_scope() as session:
-                    await self.initialize_user_variables(user_id, session)
+                try:
+                    async with session_scope() as session:
+                        await self.initialize_user_variables(user_id, session)
+                except Exception:  # noqa: BLE001
+                    failed_users += 1
+                    await logger.aexception("Environment variable import failed for user %s; continuing", user_id)
             last_user_id = user_ids[-1]
+        if failed_users:
+            # Let the startup gate remain incomplete so workers can retry a
+            # partial master sweep, after all other users have been processed.
+            msg = f"Environment variable import failed for {failed_users} users"
+            raise RuntimeError(msg)
 
     async def get_default_field_bindings(
         self,
@@ -163,15 +187,16 @@ class DatabaseVariableService(VariableService, Service):
 
                 try:
                     if existing:
-                        # Only new environment imports have this marker. Legacy
-                        # rows (NULL or later updated_at) cannot be distinguished
-                        # from user-created/edited values and must be preserved.
-                        if existing.created_at is None or existing.updated_at != existing.created_at:
-                            await logger.adebug(
-                                f"Preserving user-owned or legacy variable {var_name} during environment import"
-                            )
-                        elif existing.type == CREDENTIAL_TYPE:
+                        if existing.type != CREDENTIAL_TYPE or existing.is_environment_managed is False:
+                            continue
+                        if existing.is_environment_managed is None:
+                            await self._adopt_environment_variable(existing, value, session)
+                        elif existing.created_at is not None and existing.updated_at == existing.created_at:
                             await self._update_environment_variable(existing, value, session)
+                        else:
+                            # Older workers cannot write the origin flag. A
+                            # changed timestamp still protects their user edits.
+                            await logger.adebug("Preserving variable %s modified by an older worker", var_name)
                     else:
                         variable = await self.create_variable(
                             user_id=user_id,
@@ -182,8 +207,9 @@ class DatabaseVariableService(VariableService, Service):
                             type_=CREDENTIAL_TYPE,
                             session=session,
                         )
-                        # Equality marks an environment-managed row without a
-                        # schema change. User writes still set updated_at=now.
+                        variable.is_environment_managed = True
+                        # Keep the timestamp marker to detect edits by older
+                        # workers during a rolling upgrade.
                         variable.updated_at = variable.created_at
                         session.add(variable)
                         await session.flush()
@@ -197,6 +223,28 @@ class DatabaseVariableService(VariableService, Service):
                         )
                         break
 
+    async def _adopt_environment_variable(self, variable: Variable, value: str, session: AsyncSession) -> None:
+        """Adopt an unknown legacy credential only while it matches the environment."""
+        if auth_utils.decrypt_api_key(variable.value) != value:
+            return
+        created_at = variable.created_at or datetime.now(timezone.utc)
+        statement = (
+            update(Variable)
+            .where(
+                Variable.id == variable.id,
+                Variable.user_id == variable.user_id,
+                Variable.name == variable.name,
+                Variable.type == CREDENTIAL_TYPE,
+                col(Variable.is_environment_managed).is_(None),
+                Variable.updated_at == variable.updated_at,
+                Variable.value == variable.value,
+            )
+            .values(is_environment_managed=True, created_at=created_at, updated_at=created_at)
+            .execution_options(synchronize_session=False)
+        )
+        await session.exec(statement)
+        await session.refresh(variable)
+
     async def _update_environment_variable(self, variable: Variable, value: str, session: AsyncSession) -> None:
         """Rotate a managed credential only if no concurrent edit changed the row."""
         if auth_utils.decrypt_api_key(variable.value) == value:
@@ -208,6 +256,7 @@ class DatabaseVariableService(VariableService, Service):
                 Variable.user_id == variable.user_id,
                 Variable.name == variable.name,
                 Variable.type == CREDENTIAL_TYPE,
+                col(Variable.is_environment_managed).is_(True),
                 Variable.created_at == variable.created_at,
                 Variable.updated_at == variable.updated_at,
                 Variable.value == variable.value,
@@ -502,6 +551,7 @@ class DatabaseVariableService(VariableService, Service):
         else:
             variable.value = value
         variable.updated_at = datetime.now(timezone.utc)
+        variable.is_environment_managed = False
         session.add(variable)
         await session.flush()
         await session.refresh(variable)
@@ -549,7 +599,16 @@ class DatabaseVariableService(VariableService, Service):
                 variable.value = auth_utils.encrypt_api_key(variable.value, settings_service=self.settings_service)
             # GENERIC_TYPE variables are stored as plain text
 
-        db_variable.updated_at = datetime.now(timezone.utc)
+        claims_value = (
+            variable.value is not None
+            or (variable.name is not None and variable.name != db_variable.name)
+            or (variable.type is not None and variable.type != db_variable.type)
+        )
+        if claims_value:
+            db_variable.is_environment_managed = False
+        # Apply-to-fields edits must retain the marker on managed credentials.
+        if claims_value or db_variable.is_environment_managed is not True:
+            db_variable.updated_at = datetime.now(timezone.utc)
         variable_data = variable.model_dump(exclude_unset=True)
         for key, value in variable_data.items():
             setattr(db_variable, key, value)
@@ -606,7 +665,9 @@ class DatabaseVariableService(VariableService, Service):
             value=encrypted_value,
             default_fields=list(default_fields),
         )
-        variable = Variable.model_validate(variable_base, from_attributes=True, update={"user_id": user_id})
+        variable = Variable.model_validate(
+            variable_base, from_attributes=True, update={"user_id": user_id, "is_environment_managed": False}
+        )
         session.add(variable)
         await session.flush()
         await session.refresh(variable)

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -9,7 +9,7 @@ from lfx.log.logger import logger
 from lfx.services.authorization.base import ResourceVisibilityScope
 from lfx.services.settings.constants import AGENTIC_VARIABLES
 from lfx.services.variable import VariableNotFoundError
-from sqlmodel import col, select
+from sqlmodel import col, select, update
 
 from langflow.services.auth import utils as auth_utils
 from langflow.services.base import Service
@@ -42,6 +42,35 @@ class DatabaseVariableService(VariableService, Service):
     def __init__(self, settings_service: SettingsService):
         self.settings_service = settings_service
 
+    async def initialize_all_user_variables(self) -> None:
+        """Import environment defaults for existing users independently of their login method.
+
+        Page through user IDs and commit each user's imports separately to bound
+        memory usage and transaction duration during startup.
+        """
+        settings = self.settings_service.settings
+        if not settings.store_environment_variables or not any(
+            os.environ.get(name, "").strip() for name in settings.variables_to_get_from_environment
+        ):
+            return
+
+        from langflow.services.database.models.user.model import User
+        from langflow.services.deps import session_scope
+
+        last_user_id: UUID | None = None
+        while True:
+            async with session_scope() as session:
+                query = select(User.id).order_by(User.id).limit(100)
+                if last_user_id is not None:
+                    query = query.where(User.id > last_user_id)
+                user_ids = (await session.exec(query)).all()
+            if not user_ids:
+                return
+            for user_id in user_ids:
+                async with session_scope() as session:
+                    await self.initialize_user_variables(user_id, session)
+            last_user_id = user_ids[-1]
+
     async def get_default_field_bindings(
         self,
         user_id: UUID | str,
@@ -71,7 +100,9 @@ class DatabaseVariableService(VariableService, Service):
             var_to_provider = {}
             provider_variables = {}
             metadata = get_model_provider_metadata()
-            principal = await session.get(User, UUID(str(user_id)))
+            # Serialize imports for the same user across PostgreSQL workers so
+            # concurrent startup/login imports cannot create duplicate rows.
+            principal = await session.get(User, UUID(str(user_id)), with_for_update=True)
             for provider, meta in metadata.items():
                 for var in meta.get("variables", []):
                     var_key = var.get("variable_key")
@@ -132,22 +163,17 @@ class DatabaseVariableService(VariableService, Service):
 
                 try:
                     if existing:
-                        # Check if the variable has been user-modified (updated_at != created_at)
-                        # If so, don't overwrite with environment variable
-                        is_user_modified = (
-                            existing.updated_at is not None
-                            and existing.created_at is not None
-                            and existing.updated_at > existing.created_at
-                        )
-
-                        if is_user_modified:
+                        # Only new environment imports have this marker. Legacy
+                        # rows (NULL or later updated_at) cannot be distinguished
+                        # from user-created/edited values and must be preserved.
+                        if existing.created_at is None or existing.updated_at != existing.created_at:
                             await logger.adebug(
-                                f"Skipping update of user-modified variable {var_name} with environment value"
+                                f"Preserving user-owned or legacy variable {var_name} during environment import"
                             )
-                        else:
-                            await self.update_variable(user_id, var_name, value, session=session)
+                        elif existing.type == CREDENTIAL_TYPE:
+                            await self._update_environment_variable(existing, value, session)
                     else:
-                        await self.create_variable(
+                        variable = await self.create_variable(
                             user_id=user_id,
                             name=var_name,
                             value=value,
@@ -156,6 +182,11 @@ class DatabaseVariableService(VariableService, Service):
                             type_=CREDENTIAL_TYPE,
                             session=session,
                         )
+                        # Equality marks an environment-managed row without a
+                        # schema change. User writes still set updated_at=now.
+                        variable.updated_at = variable.created_at
+                        session.add(variable)
+                        await session.flush()
                     await logger.adebug(f"Processed {var_name} variable from environment.")
                 except Exception as e:  # noqa: BLE001
                     await logger.aexception(f"Error processing {var_name} variable: {e!s}")
@@ -165,6 +196,27 @@ class DatabaseVariableService(VariableService, Service):
                             f"Session rolled back after error processing {var_name}. Stopping variable initialization."
                         )
                         break
+
+    async def _update_environment_variable(self, variable: Variable, value: str, session: AsyncSession) -> None:
+        """Rotate a managed credential only if no concurrent edit changed the row."""
+        if auth_utils.decrypt_api_key(variable.value) == value:
+            return
+        statement = (
+            update(Variable)
+            .where(
+                Variable.id == variable.id,
+                Variable.user_id == variable.user_id,
+                Variable.name == variable.name,
+                Variable.type == CREDENTIAL_TYPE,
+                Variable.created_at == variable.created_at,
+                Variable.updated_at == variable.updated_at,
+                Variable.value == variable.value,
+            )
+            .values(value=auth_utils.encrypt_api_key(value, settings_service=self.settings_service))
+            .execution_options(synchronize_session=False)
+        )
+        await session.exec(statement)
+        await session.refresh(variable)
 
     async def get_variable_object(
         self,

--- a/src/backend/tests/unit/alembic/test_variable_environment_origin_migration.py
+++ b/src/backend/tests/unit/alembic/test_variable_environment_origin_migration.py
@@ -1,0 +1,56 @@
+"""Contract tests for nullable environment-variable origin tracking."""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION_PATH = (
+    Path(__file__).parents[3] / "base/langflow/alembic/versions/d7e9f1a3b5c8_add_variable_environment_origin.py"
+)
+
+
+def test_variable_origin_migration_preserves_values_and_old_inserts(monkeypatch):
+    """Upgrade/downgrade is repeatable and old workers can omit the nullable column."""
+    spec = importlib.util.spec_from_file_location("variable_environment_origin", _MIGRATION_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as connection:
+        old_variable = sa.Table(
+            "variable",
+            sa.MetaData(),
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("value", sa.String(), nullable=False),
+        )
+        old_variable.create(connection)
+        connection.execute(old_variable.insert().values(id=1, value="legacy-ciphertext"))
+        monkeypatch.setattr(migration, "op", Operations(MigrationContext.configure(connection)))
+        migration.upgrade()
+        migration.upgrade()
+        connection.execute(old_variable.insert().values(id=2, value="old-worker-ciphertext"))
+        variable = sa.Table("variable", sa.MetaData(), autoload_with=connection)
+        rows = connection.execute(sa.select(variable).order_by(variable.c.id)).mappings().all()
+        assert [row["value"] for row in rows] == ["legacy-ciphertext", "old-worker-ciphertext"]
+        assert [row["is_environment_managed"] for row in rows] == [None, None]
+        assert variable.c.is_environment_managed.nullable
+        connection.execute(variable.update().where(variable.c.id == 1).values(is_environment_managed=True))
+        connection.execute(variable.update().where(variable.c.id == 2).values(is_environment_managed=False))
+        assert connection.execute(
+            sa.select(variable.c.is_environment_managed).order_by(variable.c.id)
+        ).scalars().all() == [
+            True,
+            False,
+        ]
+        migration.downgrade()
+        migration.downgrade()
+        assert "is_environment_managed" not in {c["name"] for c in sa.inspect(connection).get_columns("variable")}
+        assert connection.execute(sa.select(old_variable.c.value).order_by(old_variable.c.id)).scalars().all() == [
+            "legacy-ciphertext",
+            "old-worker-ciphertext",
+        ]
+    engine.dispose()

--- a/src/backend/tests/unit/base/test_preload.py
+++ b/src/backend/tests/unit/base/test_preload.py
@@ -15,6 +15,7 @@ from langflow.preload import (
     PreloadStep,
     _run_master_preload,
     get_owned_temp_dirs,
+    initialize_environment_variables,
     is_master,
     is_preloaded,
     mark_step_complete,
@@ -31,6 +32,7 @@ def reset_preload_state():
         "temp_dirs": _STATE.temp_dirs.copy(),
         "bundles_components_paths": _STATE.bundles_components_paths.copy(),
         "profile_pictures_copied": _STATE.profile_pictures_copied,
+        "environment_variables_initialized": _STATE.environment_variables_initialized,
         "bundles_loaded": _STATE.bundles_loaded,
         "types_cached": _STATE.types_cached,
         "starter_projects_created": _STATE.starter_projects_created,
@@ -69,6 +71,7 @@ class _PreloadFixture:
     create_or_update_starter_projects: AsyncMock
     load_flows_from_directory: AsyncMock
     initialize_agentic_global_variables: AsyncMock
+    initialize_all_user_variables: AsyncMock
     logger: AsyncMock
 
 
@@ -102,6 +105,7 @@ def _preload_env(
     dispose_side_effect=None,
     copy_profile_pictures=None,
     initialize_agentic_global_variables=None,
+    initialize_all_user_variables=None,
     cache_service=None,
     all_types_dict=None,
 ):
@@ -121,6 +125,7 @@ def _preload_env(
     create_starter = AsyncMock()
     load_flows = AsyncMock()
     init_agentic = initialize_agentic_global_variables or AsyncMock()
+    init_environment = initialize_all_user_variables or AsyncMock()
     logger_mock = AsyncMock()
 
     with ExitStack() as stack:
@@ -136,6 +141,12 @@ def _preload_env(
         )
         stack.enter_context(patch("langflow.services.deps.get_db_service", return_value=db_service))
         stack.enter_context(patch("langflow.services.deps.get_service", return_value=cache_service))
+        stack.enter_context(
+            patch(
+                "langflow.services.deps.get_variable_service",
+                return_value=MagicMock(initialize_all_user_variables=init_environment),
+            )
+        )
         stack.enter_context(
             patch("langflow.services.deps.session_scope", return_value=_async_cm(AsyncMock())),
         )
@@ -173,6 +184,7 @@ def _preload_env(
             create_or_update_starter_projects=create_starter,
             load_flows_from_directory=load_flows,
             initialize_agentic_global_variables=init_agentic,
+            initialize_all_user_variables=init_environment,
             logger=logger_mock,
         )
 
@@ -273,6 +285,7 @@ def test_reset_clears_all_fields():
     _STATE.temp_dirs = [MagicMock()]
     _STATE.bundles_components_paths = ["/a"]
     _STATE.profile_pictures_copied = True
+    _STATE.environment_variables_initialized = True
     _STATE.bundles_loaded = True
     _STATE.types_cached = True
     _STATE.starter_projects_created = True
@@ -286,6 +299,7 @@ def test_reset_clears_all_fields():
     assert _STATE.temp_dirs == []
     assert _STATE.bundles_components_paths == []
     assert _STATE.profile_pictures_copied is False
+    assert _STATE.environment_variables_initialized is False
     assert _STATE.bundles_loaded is False
     assert _STATE.types_cached is False
     assert _STATE.starter_projects_created is False
@@ -449,6 +463,36 @@ async def test_run_master_preload_sets_completion_flags_on_success():
     assert _STATE.types_cached is True
     assert _STATE.starter_projects_created is True
     assert _STATE.flows_loaded is True
+
+
+async def test_environment_sweep_is_inherited_by_workers():
+    """Workers skip a sweep already completed by the preload master."""
+    with _preload_env() as fx:
+        await _run_master_preload()
+        await initialize_environment_variables()
+        await initialize_environment_variables()
+    fx.initialize_all_user_variables.assert_awaited_once()
+    assert _STATE.environment_variables_initialized is True
+
+
+async def test_environment_sweep_failure_continues_startup_and_retries():
+    """A failed master sweep leaves the worker fallback available without blocking boot."""
+    sweep = AsyncMock(side_effect=[RuntimeError("sweep failed"), None])
+    with _preload_env(initialize_all_user_variables=sweep) as fx:
+        await _run_master_preload()
+        assert _STATE.environment_variables_initialized is False
+        fx.load_flows_from_directory.assert_awaited_once()
+        fx.db_engine.dispose.assert_awaited_once()
+        await initialize_environment_variables()
+    assert sweep.await_count == 2
+    assert _STATE.environment_variables_initialized is True
+
+
+async def test_environment_sweep_service_lookup_failure_is_best_effort():
+    """Failure constructing the variable service must not prevent server readiness."""
+    with patch("langflow.services.deps.get_variable_service", side_effect=RuntimeError("unavailable")):
+        await initialize_environment_variables()
+    assert _STATE.environment_variables_initialized is False
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -1,4 +1,5 @@
 import secrets
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -6,7 +7,7 @@ from uuid import uuid4
 import pytest
 from cryptography.fernet import Fernet
 from langflow.services.auth.service import AuthService
-from langflow.services.auth.utils import ensure_fernet_key
+from langflow.services.auth.utils import encrypt_api_key, ensure_fernet_key
 from langflow.services.database.models.user.model import User
 from langflow.services.database.models.variable.model import Variable, VariableUpdate
 from langflow.services.deps import get_settings_service
@@ -94,16 +95,117 @@ async def test_environment_sync_unchanged_value_does_not_write(service, session,
     assert (variable.value, variable.updated_at) == original
 
 
-async def test_environment_sync_preserves_user_created_variable(service, session, monkeypatch):
+@pytest.mark.parametrize("environment_value", ["user-key", "environment-key"])
+async def test_environment_sync_preserves_user_created_variable(service, session, monkeypatch, environment_value):
     """A user-created variable is an override even before its first edit."""
     user_id = uuid4()
     monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
     monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
-    monkeypatch.setenv("OPENAI_API_KEY", "environment-key")
+    monkeypatch.setenv("OPENAI_API_KEY", environment_value)
     await service.create_variable(user_id, "OPENAI_API_KEY", "user-key", session=session)
+    await service.initialize_user_variables(user_id, session)
+    monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
     await service.initialize_user_variables(user_id, session)
     stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
     assert stored.get_secret_value() == "user-key"
+
+
+async def test_environment_sync_metadata_edit_keeps_rotation(service, session, monkeypatch):
+    """Changing field bindings must not freeze an imported credential."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "original-key")
+    await service.initialize_user_variables(user_id, session)
+    variable = await service.get_variable_object(user_id, "OPENAI_API_KEY", session)
+    await service.update_variable_fields(
+        user_id, variable.id, VariableUpdate(id=variable.id, default_fields=["API Key"]), session
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
+    await service.initialize_user_variables(user_id, session)
+    stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+    assert stored.get_secret_value() == "rotated-key"
+    assert variable.default_fields == ["API Key"]
+
+
+@pytest.mark.parametrize("legacy_state", ["never_updated", "previously_updated", "missing_created_at"])
+async def test_environment_sync_adopts_matching_legacy_value(service, session, monkeypatch, legacy_state):
+    """A matching legacy credential becomes eligible for the next rotation."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "legacy-key")
+    variable = Variable(
+        user_id=user_id, name="OPENAI_API_KEY", type=CREDENTIAL_TYPE, value=encrypt_api_key("legacy-key")
+    )
+    session.add(variable)
+    await session.flush()
+    if legacy_state == "previously_updated":
+        variable.updated_at = variable.created_at + timedelta(seconds=1)
+    elif legacy_state == "missing_created_at":
+        variable.created_at = None
+    await session.flush()
+    ciphertext = variable.value
+    await service.initialize_user_variables(user_id, session)
+    assert variable.value == ciphertext
+    assert variable.is_environment_managed is True
+    monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
+    await service.initialize_user_variables(user_id, session)
+    stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+    assert stored.get_secret_value() == "rotated-key"
+
+
+async def test_environment_sync_preserves_edits_by_older_workers(service, session, monkeypatch):
+    """The timestamp guard protects writes from workers unaware of the origin flag."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "original-key")
+    await service.initialize_user_variables(user_id, session)
+    variable = await service.get_variable_object(user_id, "OPENAI_API_KEY", session)
+    variable.value = encrypt_api_key("user-key")
+    variable.updated_at = variable.created_at + timedelta(seconds=1)
+    await session.flush()
+    assert variable.is_environment_managed is True
+    for value in ["user-key", "rotated-key"]:
+        monkeypatch.setenv("OPENAI_API_KEY", value)
+        await service.initialize_user_variables(user_id, session)
+        stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+        assert stored.get_secret_value() == "user-key"
+
+
+async def test_all_user_initialization_continues_after_commit_failure(service, session, monkeypatch):
+    """One user's transaction failure must not discard later users' imports."""
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "environment-key")
+    users = [User(username=f"sweep-user-{index}", password="unused") for index in range(2)]  # noqa: S106  # pragma: allowlist secret
+    session.add_all(users)
+    await session.commit()
+    user_ids = sorted(user.id for user in users)
+    scopes = 0
+
+    @asynccontextmanager
+    async def failing_commit_scope():
+        nonlocal scopes
+        scopes += 1
+        async with AsyncSession(session.bind, expire_on_commit=False) as scoped:
+            try:
+                yield scoped
+                if scopes == 2:  # First user's commit, after the page query.
+                    msg = "simulated commit failure"
+                    raise RuntimeError(msg)
+                await scoped.commit()
+            except Exception:
+                await scoped.rollback()
+                raise
+
+    monkeypatch.setattr("langflow.services.deps.session_scope", failing_commit_scope)
+    with pytest.raises(RuntimeError):
+        await service.initialize_all_user_variables()
+    assert await service.list_variables(user_ids[0], session) == []
+    value = await service.get_variable(user_ids[1], "OPENAI_API_KEY", "", session)
+    assert value.get_secret_value() == "environment-key"
 
 
 @pytest.mark.parametrize("legacy_state", ["never_updated", "previously_updated", "missing_created_at"])
@@ -114,6 +216,7 @@ async def test_environment_sync_preserves_ambiguous_legacy_rows(service, session
     monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
     monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
     variable = await service.create_variable(user_id, "OPENAI_API_KEY", "legacy-key", session=session)
+    variable.is_environment_managed = None
     if legacy_state == "previously_updated":
         variable.updated_at = variable.created_at + timedelta(seconds=1)
     elif legacy_state == "missing_created_at":
@@ -141,6 +244,8 @@ async def test_environment_sync_preserves_user_edits(service, session, monkeypat
         await service.update_variable_fields(
             user_id, variable.id, VariableUpdate(id=variable.id, value="original-key"), session
         )
+    await service.initialize_user_variables(user_id, session)
+    assert variable.is_environment_managed is False
     monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
 
     await service.initialize_user_variables(user_id, session)
@@ -149,16 +254,21 @@ async def test_environment_sync_preserves_user_edits(service, session, monkeypat
     assert stored.get_secret_value() == "original-key"
 
 
-async def test_environment_sync_preserves_interleaved_user_edit(service, session, monkeypatch):
+@pytest.mark.parametrize("operation", ["_update_environment_variable", "_adopt_environment_variable"])
+async def test_environment_sync_preserves_interleaved_user_edit(service, session, monkeypatch, operation):
     """A user edit committed after the import reads a row must win the race."""
     user_id = uuid4()
     monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
     monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
     monkeypatch.setenv("OPENAI_API_KEY", "original-key")
     await service.initialize_user_variables(user_id, session)
+    if operation == "_adopt_environment_variable":
+        variable = await service.get_variable_object(user_id, "OPENAI_API_KEY", session)
+        variable.is_environment_managed = None
     await session.commit()
-    monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
-    update_environment = service._update_environment_variable
+    if operation == "_update_environment_variable":
+        monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
+    update_environment = getattr(service, operation)
 
     async def edit_before_import(variable, value, import_session):
         async with AsyncSession(session.bind, expire_on_commit=False) as editor:
@@ -166,7 +276,7 @@ async def test_environment_sync_preserves_interleaved_user_edit(service, session
             await editor.commit()
         await update_environment(variable, value, import_session)
 
-    monkeypatch.setattr(service, "_update_environment_variable", edit_before_import)
+    monkeypatch.setattr(service, operation, edit_before_import)
 
     await service.initialize_user_variables(user_id, session)
 
@@ -174,12 +284,13 @@ async def test_environment_sync_preserves_interleaved_user_edit(service, session
     assert stored.get_secret_value() == "user-key"
 
 
-@pytest.mark.parametrize("mode", ["disabled", "missing_value"])
+@pytest.mark.parametrize("mode", ["disabled", "missing_value", "placeholder"])
 async def test_all_user_initialization_skips_without_environment_imports(service, monkeypatch, mode):
     """Disabled or unconfigured imports must not query every user at startup."""
     monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", mode != "disabled")
     monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
-    monkeypatch.setenv("OPENAI_API_KEY", " " if mode == "missing_value" else "environment-key")
+    value = " " if mode == "missing_value" else "dummy" if mode == "placeholder" else "environment-key"
+    monkeypatch.setenv("OPENAI_API_KEY", value)
     with patch("langflow.services.deps.session_scope") as session_scope:
         await service.initialize_all_user_variables()
     session_scope.assert_not_called()

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -1,5 +1,5 @@
 import secrets
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -41,6 +41,7 @@ async def session():
         await conn.run_sync(SQLModel.metadata.create_all)
     async with AsyncSession(engine, expire_on_commit=False) as session:
         yield session
+    await engine.dispose()
 
 
 async def test_initialize_user_variables__create_and_update(service, session: AsyncSession):
@@ -50,7 +51,8 @@ async def test_initialize_user_variables__create_and_update(service, session: As
     bad_vars = {"VAR1": "value1", "VAR2": "value2", "VAR3": "value3"}
     env_vars = {**good_vars, **bad_vars}
 
-    await service.create_variable(user_id, "OPENAI_API_KEY", "outdate", session=session)
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "outdate"}, clear=True):  # pragma: allowlist secret
+        await service.initialize_user_variables(user_id=user_id, session=session)
     env_vars["OPENAI_API_KEY"] = "updated_value"
 
     with patch.dict("os.environ", env_vars, clear=True):
@@ -64,6 +66,123 @@ async def test_initialize_user_variables__create_and_update(service, session: As
 
     assert all(i in variables for i in good_vars)
     assert all(i not in variables for i in bad_vars)
+
+
+async def test_environment_sync_repeated_rotation(service, session, monkeypatch):
+    """Repeated imports must continue rotating environment-managed credentials."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    for value in ["first-key", "first-key", "second-key", "third-key"]:
+        monkeypatch.setenv("OPENAI_API_KEY", value)
+        await service.initialize_user_variables(user_id, session)
+        stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+        assert stored.get_secret_value() == value
+
+
+async def test_environment_sync_unchanged_value_does_not_write(service, session, monkeypatch):
+    """An unchanged import preserves both ciphertext and the modification marker."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "same-key")
+    await service.initialize_user_variables(user_id, session)
+    variable = await service.get_variable_object(user_id, "OPENAI_API_KEY", session)
+    original = (variable.value, variable.updated_at)
+    await service.initialize_user_variables(user_id, session)
+    await session.refresh(variable)
+    assert (variable.value, variable.updated_at) == original
+
+
+async def test_environment_sync_preserves_user_created_variable(service, session, monkeypatch):
+    """A user-created variable is an override even before its first edit."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "environment-key")
+    await service.create_variable(user_id, "OPENAI_API_KEY", "user-key", session=session)
+    await service.initialize_user_variables(user_id, session)
+    stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+    assert stored.get_secret_value() == "user-key"
+
+
+@pytest.mark.parametrize("legacy_state", ["never_updated", "previously_updated", "missing_created_at"])
+async def test_environment_sync_preserves_ambiguous_legacy_rows(service, session, monkeypatch, legacy_state):
+    """Old timestamps cannot safely establish whether the user owns the value."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
+    variable = await service.create_variable(user_id, "OPENAI_API_KEY", "legacy-key", session=session)
+    if legacy_state == "previously_updated":
+        variable.updated_at = variable.created_at + timedelta(seconds=1)
+    elif legacy_state == "missing_created_at":
+        variable.created_at = None
+    await session.flush()
+
+    await service.initialize_user_variables(user_id, session)
+
+    stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+    assert stored.get_secret_value() == "legacy-key"
+
+
+@pytest.mark.parametrize("edit_method", ["update_variable", "update_variable_fields"])
+async def test_environment_sync_preserves_user_edits(service, session, monkeypatch, edit_method):
+    """Explicitly saving an imported value transfers control to the user."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "original-key")
+    await service.initialize_user_variables(user_id, session)
+    variable = await service.get_variable_object(user_id, "OPENAI_API_KEY", session)
+    if edit_method == "update_variable":
+        await service.update_variable(user_id, variable.name, "original-key", session)
+    else:
+        await service.update_variable_fields(
+            user_id, variable.id, VariableUpdate(id=variable.id, value="original-key"), session
+        )
+    monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
+
+    await service.initialize_user_variables(user_id, session)
+
+    stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+    assert stored.get_secret_value() == "original-key"
+
+
+async def test_environment_sync_preserves_interleaved_user_edit(service, session, monkeypatch):
+    """A user edit committed after the import reads a row must win the race."""
+    user_id = uuid4()
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", True)
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", "original-key")
+    await service.initialize_user_variables(user_id, session)
+    await session.commit()
+    monkeypatch.setenv("OPENAI_API_KEY", "rotated-key")
+    update_environment = service._update_environment_variable
+
+    async def edit_before_import(variable, value, import_session):
+        async with AsyncSession(session.bind, expire_on_commit=False) as editor:
+            await service.update_variable(user_id, variable.name, "user-key", editor)
+            await editor.commit()
+        await update_environment(variable, value, import_session)
+
+    monkeypatch.setattr(service, "_update_environment_variable", edit_before_import)
+
+    await service.initialize_user_variables(user_id, session)
+
+    stored = await service.get_variable(user_id, "OPENAI_API_KEY", "", session)
+    assert stored.get_secret_value() == "user-key"
+
+
+@pytest.mark.parametrize("mode", ["disabled", "missing_value"])
+async def test_all_user_initialization_skips_without_environment_imports(service, monkeypatch, mode):
+    """Disabled or unconfigured imports must not query every user at startup."""
+    monkeypatch.setattr(service.settings_service.settings, "store_environment_variables", mode != "disabled")
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", ["OPENAI_API_KEY"])
+    monkeypatch.setenv("OPENAI_API_KEY", " " if mode == "missing_value" else "environment-key")
+    with patch("langflow.services.deps.session_scope") as session_scope:
+        await service.initialize_all_user_variables()
+    session_scope.assert_not_called()
 
 
 @pytest.mark.parametrize("var_name", ["WATSONX_APIKEY", "WATSONX_PROJECT_ID"])

--- a/src/backend/tests/unit/test_lifespan_startup_cleanup.py
+++ b/src/backend/tests/unit/test_lifespan_startup_cleanup.py
@@ -14,7 +14,7 @@ asserts the cleanup path no longer raises.
 Issue: https://github.com/langflow-ai/langflow/issues/13634
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import langflow.main as main_module
 import pytest
@@ -55,3 +55,33 @@ async def test_startup_failure_does_not_mask_error_with_unbound_temp_dirs(monkey
     cleanup_failures = [context for context, _ in telemetry_calls if context == "lifespan_cleanup"]
     assert cleanup_failures == [], f"shutdown cleanup raised during startup failure: {telemetry_calls}"
     assert ("lifespan_cleanup", "UnboundLocalError") not in telemetry_calls
+
+
+async def test_environment_import_failure_does_not_abort_worker_startup(monkeypatch):
+    """The real worker lifespan continues past a failed environment sweep."""
+    from langflow.preload import _STATE
+
+    monkeypatch.setattr(_STATE, "environment_variables_initialized", False)
+    sweep = AsyncMock(side_effect=RuntimeError("environment import failed"))
+    variable_service = AsyncMock(initialize_all_user_variables=sweep)
+    monkeypatch.setattr("langflow.services.deps.get_variable_service", lambda: variable_service)
+    monkeypatch.setattr(main_module, "initialize_services", AsyncMock())
+    reached_next_step = RuntimeError("reached next startup step")
+
+    async def stop_after_services(message, *_args, **_kwargs):
+        if message.startswith("Services initialized in"):
+            raise reached_next_step
+
+    logger = AsyncMock()
+    logger.exception = MagicMock()
+    logger.adebug.side_effect = stop_after_services
+    monkeypatch.setattr(main_module, "logger", logger)
+    monkeypatch.setattr(main_module, "log_exception_to_telemetry", AsyncMock())
+    monkeypatch.setattr(main_module, "teardown_services", AsyncMock())
+    monkeypatch.setattr(main_module, "cleanup_mcp_sessions", AsyncMock())
+    with pytest.raises(RuntimeError, match="reached next startup step") as exc:
+        async with main_module.get_lifespan()(object()):
+            pass
+    assert exc.value is reached_next_step
+    sweep.assert_awaited_once()
+    assert _STATE.environment_variables_initialized is False

--- a/src/backend/tests/unit/test_setup_superuser_flow.py
+++ b/src/backend/tests/unit/test_setup_superuser_flow.py
@@ -17,6 +17,36 @@ from sqlmodel import select
 _MOCK_AUTO_LOGIN_LOCK_TIMEOUT_MSG = "mock lock timeout"
 
 
+async def test_service_startup_imports_environment_for_existing_users(initialized_services, monkeypatch):  # noqa: ARG001
+    """Startup must import newly configured variables for SSO and password users."""
+    from langflow.services.database.models.auth import SSOUserProfile
+    from langflow.services.deps import get_variable_service
+    from langflow.services.utils import initialize_services
+
+    async with session_scope() as session:
+        # Cross the startup sweep's page boundary, including an existing SSO account.
+        users = [
+            User(username=f"existing-user-{index}", password="unused")  # noqa: S106  # pragma: allowlist secret
+            for index in range(101)
+        ]
+        session.add_all(users)
+        await session.flush()
+        user_ids = [user.id for user in users]
+        session.add(SSOUserProfile(user_id=user_ids[0], sso_provider="external", sso_user_id="existing-subject"))
+
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "store_environment_variables", True)
+    monkeypatch.setattr(settings, "variables_to_get_from_environment", ["NEW_SERVICE_URL"])
+    for env_value in ["https://service.example.com", "https://rotated.example.com"]:
+        monkeypatch.setenv("NEW_SERVICE_URL", env_value)
+        await initialize_services(skip_superuser_setup=True)
+
+        async with session_scope() as session:
+            for user_id in user_ids:
+                value = await get_variable_service().get_variable(user_id, "NEW_SERVICE_URL", "", session)
+                assert value.get_secret_value() == env_value
+
+
 @pytest.fixture
 async def initialized_services(monkeypatch, tmp_path):
     """Lightweight fixture: initializes DB + services WITHOUT starting the full app.

--- a/src/backend/tests/unit/test_setup_superuser_flow.py
+++ b/src/backend/tests/unit/test_setup_superuser_flow.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 
 import filelock
 import pytest
@@ -15,36 +16,6 @@ from pydantic import SecretStr
 from sqlmodel import select
 
 _MOCK_AUTO_LOGIN_LOCK_TIMEOUT_MSG = "mock lock timeout"
-
-
-async def test_service_startup_imports_environment_for_existing_users(initialized_services, monkeypatch):  # noqa: ARG001
-    """Startup must import newly configured variables for SSO and password users."""
-    from langflow.services.database.models.auth import SSOUserProfile
-    from langflow.services.deps import get_variable_service
-    from langflow.services.utils import initialize_services
-
-    async with session_scope() as session:
-        # Cross the startup sweep's page boundary, including an existing SSO account.
-        users = [
-            User(username=f"existing-user-{index}", password="unused")  # noqa: S106  # pragma: allowlist secret
-            for index in range(101)
-        ]
-        session.add_all(users)
-        await session.flush()
-        user_ids = [user.id for user in users]
-        session.add(SSOUserProfile(user_id=user_ids[0], sso_provider="external", sso_user_id="existing-subject"))
-
-    settings = get_settings_service().settings
-    monkeypatch.setattr(settings, "store_environment_variables", True)
-    monkeypatch.setattr(settings, "variables_to_get_from_environment", ["NEW_SERVICE_URL"])
-    for env_value in ["https://service.example.com", "https://rotated.example.com"]:
-        monkeypatch.setenv("NEW_SERVICE_URL", env_value)
-        await initialize_services(skip_superuser_setup=True)
-
-        async with session_scope() as session:
-            for user_id in user_ids:
-                value = await get_variable_service().get_variable(user_id, "NEW_SERVICE_URL", "", session)
-                assert value.get_secret_value() == env_value
 
 
 @pytest.fixture
@@ -72,6 +43,50 @@ async def initialized_services(monkeypatch, tmp_path):
     yield
 
     await teardown_services()
+
+
+async def test_server_startup_imports_environment_for_existing_users(initialized_services, monkeypatch):  # noqa: ARG001
+    """Startup must import newly configured variables for SSO and password users."""
+    from langflow.preload import _STATE, initialize_environment_variables
+    from langflow.services.database.models.auth import SSOUserProfile
+    from langflow.services.deps import get_variable_service
+    from langflow.services.utils import initialize_services
+
+    async with session_scope() as session:
+        # Cross the startup sweep's page boundary, including an existing SSO account.
+        users = [
+            User(username=f"existing-user-{index}", password="unused")  # noqa: S106  # pragma: allowlist secret
+            for index in range(101)
+        ]
+        session.add_all(users)
+        await session.flush()
+        user_ids = [user.id for user in users]
+        session.add(SSOUserProfile(user_id=user_ids[0], sso_provider="external", sso_user_id="existing-subject"))
+
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "store_environment_variables", True)
+    monkeypatch.setattr(settings, "variables_to_get_from_environment", ["NEW_SERVICE_URL"])
+    for env_value in ["https://service.example.com", "https://rotated.example.com"]:
+        monkeypatch.setenv("NEW_SERVICE_URL", env_value)
+        await initialize_services(skip_superuser_setup=True)
+        monkeypatch.setattr(_STATE, "environment_variables_initialized", False)
+        await initialize_environment_variables()
+
+        async with session_scope() as session:
+            for user_id in user_ids:
+                value = await get_variable_service().get_variable(user_id, "NEW_SERVICE_URL", "", session)
+                assert value.get_secret_value() == env_value
+
+
+async def test_cli_service_initialization_does_not_sweep_users(initialized_services, monkeypatch):  # noqa: ARG001
+    """Shared service initialization used by migration commands must not run the sweep."""
+    from langflow.services.deps import get_variable_service
+    from langflow.services.utils import initialize_services
+
+    sweep = AsyncMock()
+    monkeypatch.setattr(get_variable_service(), "initialize_all_user_variables", sweep)
+    await initialize_services(skip_superuser_setup=True)
+    sweep.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #14983.

Synchronize configured environment variables for existing users during server startup, including SSO users. A successful preload master sweep is inherited by workers. Individual user transaction failures are logged while later users continue; sweep failures cannot prevent server readiness. CLI service initialization does not sweep users.

Repeated environment rotations preserve user overrides and skip unchanged ciphertext. Changing only Apply to fields keeps a credential environment-managed. Conditional database updates protect concurrent edits, and the timestamp guard also protects user edits made by older workers during a rolling upgrade.

Add a nullable `is_environment_managed` column through an EXPAND migration to distinguish legacy rows, environment imports, and explicit user overrides. Legacy credentials are adopted only when their current value matches the environment; differing values remain untouched. Matching legacy values may include earlier user overrides. Explicit overrides saved after upgrading are never adopted automatically.

Validation:

- 369 tests passed, 34 optional tests skipped across variable, authentication, startup/preload, and Alembic suites; Ruff and pre-commit checks pass.
- PostgreSQL 16 probes pass for migration upgrade/downgrade and old-worker inserts, repeated rotations, legacy adoption, metadata edits, explicit overrides, and concurrent rotation/adoption races.
- Regression coverage includes a failed user commit followed by successful imports, worker startup continuing after failure, preload inheritance/retry, CLI exclusion, and startup additions/rotations across 101 existing users.

```bash
uv run pytest src/backend/tests/unit/services/variable src/backend/tests/unit/services/auth/test_auth_service.py src/backend/tests/unit/base/test_preload.py src/backend/tests/unit/test_setup_superuser_flow.py src/backend/tests/unit/test_lifespan_startup_cleanup.py src/backend/tests/unit/alembic
```

Related: #14985 targets `release-1.13.0`; this PR targets `release-1.12.1` and performs the all-user sync at startup.
