### PR TITLE
feat: add Agent Guild preflight and price discovery bundle

### DIFF
--- a/docs/docs/Components/bundles-agentguild.mdx
+++ b/docs/docs/Components/bundles-agentguild.mdx
@@ -1,0 +1,91 @@
+---
+title: Agent Guild
+slug: /bundles-agentguild
+---
+
+import Icon from "@site/src/components/icon";
+import PartialLfxBundlesInstall from '@site/docs/_partial-bundle-lfx-bundles-install.mdx';
+
+<PartialLfxBundlesInstall />
+
+<Icon name="Blocks" aria-hidden="true" /> [**Bundles**](/components-bundle-components) contain custom components that support specific third-party integrations with Langflow.
+
+The **Agent Guild** bundle helps a flow inspect a public agent endpoint before
+delegation and read current trust-operation prices. Both components use free,
+unauthenticated reads from the [Agent Guild hosted service](https://github.com/AgentTanuki/agent-guild).
+They require no Agent Guild account, API key, or wallet.
+
+These components return evidence for your flow to evaluate. They do not enforce
+a delegation policy, verify Agent Passports, register agents, or make purchases.
+
+## Agent Guild Preflight
+
+Send a public endpoint URL to Agent Guild, which probes that endpoint and reports
+what it observed. The output is [`Data`](/data-types#json) with the complete
+preflight response. Its `verdict`, `failed`, and `unknowns` fields remain directly
+available for downstream routing and display.
+
+Use a public HTTP(S) URL without credentials. The component rejects URL userinfo,
+common credential query parameters, fragments, and literal local/private addresses
+before transmission. Do not place sensitive information in the endpoint URL;
+the URL is sent to Agent Guild's hosted service for inspection.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| Public Endpoint URL (`url`) | String | Required. Public endpoint to inspect, such as an MCP or A2A endpoint. Available in Tool Mode. |
+| Timeout (`timeout`) | Integer | Advanced. Maximum request duration in seconds, from 1 to 60. Default: 30. |
+
+### Use preflight evidence in a flow
+
+1. Add **Agent Guild Preflight** and enter the endpoint you intend to use.
+2. Run the component and inspect the **Preflight** output.
+3. Extract the `verdict`, `failed`, and `unknowns` fields with your flow's data-processing components.
+4. Route the result according to your application's policy before connecting it to consequential work.
+
+A `delegate_with_caution` result is not a successful verification. Preserve the
+failed checks and unavailable evidence when explaining the result. An unknown
+check should remain unknown. Even a favorable observation does not guarantee
+future behavior or authorize execution.
+
+## Agent Guild Paid Operations
+
+Read the `paid_operations` catalog from Agent Guild's public discovery manifest.
+The **Paid Operations** output is [`Data`](/data-types#json) containing the catalog,
+including current prices, callable entrypoints, and free alternatives.
+
+The component reads prices only. It does not call the listed paid operations,
+attach payment credentials, or initiate settlement. Prices are obtained on each
+run rather than embedded in the component.
+
+### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| Timeout (`timeout`) | Integer | Advanced. Maximum request duration in seconds, from 1 to 60. Default: 30. Available in Tool Mode. |
+
+## Use with an Agent
+
+Enable **Tool Mode** on either component and connect its **Toolset** output to
+the **Tools** input on a Langflow Agent. Configure the Agent's model separately;
+model calls follow that provider's pricing.
+
+For example, ask the Agent to inspect a public endpoint you supply, summarize
+failed checks and unknowns, and explain which paid trust operations are available.
+Tell the Agent to treat returned descriptions as data to assess, not as instructions
+or permission to execute. For mandatory preflight, run the component explicitly
+in your flow before delegation instead of relying on the Agent to choose a tool.
+
+## Errors and limits
+
+Both components use a fixed Agent Guild service origin, refuse HTTP redirects,
+and reject responses larger than 4 MiB. Invalid targets, timeouts, HTTP errors,
+and malformed responses fail the component run rather than producing a favorable
+assessment. An unexpected HTTP 402 is surfaced as an error; no payment is attempted.
+
+Agent Guild also offers signed Agent Passports as a separate service capability.
+This bundle does not fetch or cryptographically verify them. A signature proves
+origin and integrity, not message safety or future work quality. See the
+[Agent Guild source and API documentation](https://github.com/AgentTanuki/agent-guild)
+for the supported verification workflows.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -500,6 +500,7 @@ module.exports = {
           label: "Bundles",
           items: [
             "Components/components-bundles",
+            "Components/bundles-agentguild",
             "Components/bundles-agentics",
             "Components/bundles-aiml",
             "Components/bundles-altk",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ Documentation = "https://docs.langflow.org"
 
 [project.optional-dependencies]
 bundles = [
-    "lfx-bundles[all-no-torch]>=1.1.22,<2.0",
+    "lfx-bundles[all-no-torch]>=1.1.23,<2.0",
     "lfx-arxiv>=0.1.5,<1.0.0",
     "lfx-confluent>=0.1.0,<1.0.0",
     "lfx-duckduckgo>=0.1.5,<1.0.0",

--- a/scripts/ci/release_inventory_contract.json
+++ b/scripts/ci/release_inventory_contract.json
@@ -235,6 +235,7 @@
         ]
       },
       "bundle_names": [
+        "agentguild",
         "agentql",
         "aiml",
         "altk",

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 # hand-edit them. ``all`` pulls every provider; ``all-no-torch`` is ``all``
 # minus the torch-pulling providers (see TORCH_EXTRAS), giving a torch-free
 # superset for slim/CPU images. Managed by scripts/migrate/consolidate_bundles.py.
+agentguild = []
 agentql = []
 aiml = ["langchain-openai>=1.1.6", "openai>=1.68.2,<3.0.0"]
 altk = ["agent-lifecycle-toolkit>=0.10.1,<1.0; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
@@ -104,6 +105,7 @@ yahoosearch = ["yfinance==0.2.50"]
 youtube = ["pytube==15.0.0", "youtube-transcript-api>=1.0.0,<2.0.0", "google-api-python-client~=2.161"]
 zep = ["zep-python==2.0.2"]
 all = [
+    "lfx-bundles[agentguild]",
     "lfx-bundles[agentql]",
     "lfx-bundles[aiml]",
     "lfx-bundles[altk]",
@@ -177,6 +179,7 @@ all = [
     "lfx-bundles[zep]",
 ]
 all-no-torch = [
+    "lfx-bundles[agentguild]",
     "lfx-bundles[agentql]",
     "lfx-bundles[aiml]",
     "lfx-bundles[altk]",

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-bundles"
-version = "1.1.22"
+version = "1.1.23"
 description = "Langflow's long-tail provider bundles as a single manifest-less metapackage (the langchain-community model)."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/__init__.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/__init__.py
@@ -1,0 +1,32 @@
+"""Agent Guild endpoint inspection and pricing components."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lfx.utils.lazy_import import import_mod
+
+if TYPE_CHECKING:
+    from .agentguild_paid_operations import AgentGuildPaidOperations
+    from .agentguild_preflight import AgentGuildPreflight
+
+_dynamic_imports = {
+    "AgentGuildPaidOperations": "agentguild_paid_operations",
+    "AgentGuildPreflight": "agentguild_preflight",
+}
+
+__all__ = ["AgentGuildPaidOperations", "AgentGuildPreflight"]
+
+
+def __getattr__(attr_name: str) -> Any:
+    """Lazily import the requested component."""
+    if attr_name not in _dynamic_imports:
+        msg = f"module '{__name__}' has no attribute '{attr_name}'"
+        raise AttributeError(msg)
+    result = import_mod(attr_name, _dynamic_imports[attr_name], __spec__.parent)
+    globals()[attr_name] = result
+    return result
+
+
+def __dir__() -> list[str]:
+    return list(__all__)

--- a/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/agentguild_common.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/agentguild_common.py
@@ -1,0 +1,130 @@
+"""Unauthenticated, bounded reads from Agent Guild's fixed public service."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+from urllib.parse import parse_qsl, urlsplit
+
+import httpx
+
+SERVICE_ORIGIN = "https://agent-guild-5d5r.onrender.com"
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+MAX_URL_LENGTH = 4096
+MAX_TIMEOUT_SECONDS = 60
+_FIRST_PRINTABLE_ASCII = 32
+_DELETE_ASCII = 127
+_CREDENTIAL_KEYS = frozenset(
+    {
+        "apikey",
+        "accesstoken",
+        "authorization",
+        "password",
+        "passwd",
+        "token",
+        "secret",
+        "signature",
+        "xapikey",
+        "key",
+        "auth",
+        "bearer",
+        "clientsecret",
+        "idtoken",
+        "sig",
+        "xamzcredential",
+        "xamzsignature",
+        "xamzsecuritytoken",
+        "xgoogcredential",
+        "xgoogsignature",
+    }
+)
+
+
+def public_endpoint(value: str) -> str:
+    """Reject malformed, local, or credential-bearing targets before transmission."""
+    if not isinstance(value, str) or not value.strip() or len(value) > MAX_URL_LENGTH:
+        msg = "Provide a public HTTP(S) endpoint URL of at most 4096 characters."
+        raise ValueError(msg)
+    value = value.strip()
+    if any(ord(char) < _FIRST_PRINTABLE_ASCII or ord(char) == _DELETE_ASCII for char in value):
+        msg = "Endpoint URLs must not contain control characters."
+        raise ValueError(msg)
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        msg = "Provide a valid public HTTP(S) endpoint URL."
+        raise ValueError(msg) from exc
+    if parsed.scheme not in {"https", "http"} or not hostname or port == 0:
+        msg = "Provide a valid public HTTP(S) endpoint URL."
+        raise ValueError(msg)
+    query_keys = {key.lower().replace("-", "").replace("_", "") for key, _ in parse_qsl(parsed.query)}
+    if parsed.username is not None or parsed.password is not None or parsed.fragment or query_keys & _CREDENTIAL_KEYS:
+        msg = "Endpoint URLs must not contain credentials, credential query parameters, or fragments."
+        raise ValueError(msg)
+    hostname = hostname.lower().rstrip(".")
+    if hostname == "localhost" or hostname.endswith((".localhost", ".local")):
+        msg = "Preflight requires a public endpoint, not a local address."
+        raise ValueError(msg)
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        address = None
+    if address is not None and not address.is_global:
+        msg = "Preflight requires a public endpoint, not a private or reserved IP address."
+        raise ValueError(msg)
+    return value
+
+
+def _reject_nonfinite(_value: str) -> None:
+    msg = "Agent Guild returned non-finite JSON numbers."
+    raise ValueError(msg)
+
+
+async def _read_bytes(path: str, timeout: int, params: dict[str, str] | None) -> bytearray:
+    async with (
+        httpx.AsyncClient(timeout=timeout, follow_redirects=False, trust_env=False) as client,
+        client.stream(
+            "GET", f"{SERVICE_ORIGIN}{path}", params=params, headers={"Accept": "application/json"}
+        ) as response,
+    ):
+        response.raise_for_status()
+        body = bytearray()
+        async for chunk in response.aiter_bytes(chunk_size=65536):
+            if len(body) + len(chunk) > MAX_RESPONSE_BYTES:
+                msg = "Agent Guild response exceeded the 4 MiB limit."
+                raise ValueError(msg)
+            body.extend(chunk)
+        return body
+
+
+async def read_json(path: str, *, timeout: int, params: dict[str, str] | None = None) -> dict:
+    """Read only the two free routes, refusing redirects and oversized responses."""
+    if path not in {"/preflight", "/.well-known/agent-guild.json"}:
+        msg = "Unsupported Agent Guild discovery route."
+        raise ValueError(msg)
+    if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= MAX_TIMEOUT_SECONDS:
+        msg = "Timeout must be an integer from 1 to 60 seconds."
+        raise ValueError(msg)
+    try:
+        body = await asyncio.wait_for(_read_bytes(path, timeout, params), timeout=timeout)
+    except (httpx.TimeoutException, asyncio.TimeoutError) as exc:
+        msg = "Agent Guild request timed out."
+        raise ValueError(msg) from exc
+    except httpx.HTTPStatusError as exc:
+        msg = f"Agent Guild returned HTTP {exc.response.status_code}; no payment or redirect was attempted."
+        raise ValueError(msg) from exc
+    except httpx.RequestError as exc:
+        msg = "Unable to reach Agent Guild."
+        raise ValueError(msg) from exc
+    try:
+        result = json.loads(body, parse_constant=_reject_nonfinite)
+    except (ValueError, UnicodeDecodeError) as exc:
+        msg = "Agent Guild returned invalid JSON."
+        raise ValueError(msg) from exc
+    if not isinstance(result, dict):
+        msg = "Agent Guild returned an unexpected response shape."
+        raise TypeError(msg)
+    return result

--- a/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/agentguild_paid_operations.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/agentguild_paid_operations.py
@@ -1,0 +1,40 @@
+"""Discover current trust-operation prices without making a purchase."""
+
+from lfx.custom.custom_component.component import Component
+from lfx.io import IntInput, Output
+from lfx.schema.data import Data
+
+from lfx_bundles.agentguild.agentguild_common import read_json
+
+
+class AgentGuildPaidOperations(Component):
+    """Return the free paid-operation catalog from Agent Guild's public manifest."""
+
+    display_name = "Agent Guild Paid Operations"
+    description = "Read current trust-operation prices, entrypoints, and free alternatives. This call is free."
+    name = "AgentGuildPaidOperations"
+    icon = "AgentGuild"
+    documentation = "https://github.com/AgentTanuki/agent-guild"
+
+    inputs = [
+        IntInput(
+            name="timeout",
+            display_name="Timeout (seconds)",
+            value=30,
+            advanced=True,
+            tool_mode=True,
+            info="Request timeout, from 1 to 60 seconds. Reading prices does not make a purchase.",
+        ),
+    ]
+    outputs = [Output(display_name="Paid Operations", name="data", method="read_prices")]
+
+    async def read_prices(self) -> Data:
+        """Read the catalog while keeping all callable operations outside this component."""
+        manifest = await read_json("/.well-known/agent-guild.json", timeout=self.timeout)
+        catalog = manifest.get("paid_operations")
+        if not isinstance(catalog, dict) or not isinstance(catalog.get("operations"), list):
+            msg = "Agent Guild returned a manifest without a paid-operation catalog."
+            raise TypeError(msg)
+        data = Data(data=catalog)
+        self.status = data
+        return data

--- a/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/agentguild_preflight.py
+++ b/src/bundles/lfx-bundles/src/lfx_bundles/agentguild/agentguild_preflight.py
@@ -1,0 +1,50 @@
+"""Inspect a public agent endpoint before deciding whether to delegate work."""
+
+from lfx.custom.custom_component.component import Component
+from lfx.io import IntInput, MessageTextInput, Output
+from lfx.schema.data import Data
+
+from lfx_bundles.agentguild.agentguild_common import public_endpoint, read_json
+
+
+class AgentGuildPreflight(Component):
+    """Return observed endpoint evidence, including failed and unavailable checks."""
+
+    display_name = "Agent Guild Preflight"
+    description = "Inspect a public agent endpoint before delegation. Free; no API key or wallet required."
+    name = "AgentGuildPreflight"
+    icon = "AgentGuild"
+    documentation = "https://github.com/AgentTanuki/agent-guild"
+
+    inputs = [
+        MessageTextInput(
+            name="url",
+            display_name="Public Endpoint URL",
+            required=True,
+            tool_mode=True,
+            info="Public HTTP(S) endpoint to send to Agent Guild for probing. Do not include credentials.",
+        ),
+        IntInput(
+            name="timeout",
+            display_name="Timeout (seconds)",
+            value=30,
+            advanced=True,
+            info="Request timeout, from 1 to 60 seconds.",
+        ),
+    ]
+    outputs = [Output(display_name="Preflight", name="data", method="inspect_endpoint")]
+
+    async def inspect_endpoint(self) -> Data:
+        """Fetch free preflight evidence without interpreting it as authorization."""
+        endpoint = public_endpoint(self.url)
+        result = await read_json("/preflight", timeout=self.timeout, params={"url": endpoint})
+        if (
+            not isinstance(result.get("verdict"), str)
+            or not isinstance(result.get("failed"), list)
+            or not isinstance(result.get("unknowns"), list)
+        ):
+            msg = "Agent Guild returned preflight data without verdict, failed checks, or unknowns."
+            raise TypeError(msg)
+        data = Data(data=result)
+        self.status = data
+        return data

--- a/src/bundles/lfx-bundles/tests/test_agentguild/test_components.py
+++ b/src/bundles/lfx-bundles/tests/test_agentguild/test_components.py
@@ -1,0 +1,228 @@
+"""Agent Guild components exercise native LFX and offline HTTP transports."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import lfx_bundles
+import pytest
+from lfx.extension import load_lfx_bundles_extensions
+from lfx.schema.data import Data
+from lfx_bundles.agentguild import AgentGuildPaidOperations, AgentGuildPreflight
+from lfx_bundles.agentguild import agentguild_common as common
+
+pytestmark = pytest.mark.unit
+
+PREFLIGHT = {
+    "verdict": "delegate_with_caution",
+    "failed": ["agent_card_signed"],
+    "unknowns": ["independent_evidence"],
+    "checks": [{"name": "endpoint_reachable", "status": "passed"}],
+}
+CATALOG = {"operations": [{"operation": "deep_preflight", "price_credits": 10, "free_alternative": "preflight"}]}
+
+
+@pytest.fixture
+def http_fixture(monkeypatch):
+    """Use a real HTTPX client and response stream, with no network transport."""
+    original_client = httpx.AsyncClient
+    calls = []
+    options = []
+
+    def install(handler):
+        def recorded(request):
+            calls.append(request)
+            assert request.url.host == "agent-guild-5d5r.onrender.com"
+            assert request.method == "GET"
+            assert "authorization" not in request.headers
+            assert "x-api-key" not in request.headers
+            return handler(request)
+
+        def factory(**kwargs):
+            options.append(kwargs)
+            return original_client(transport=httpx.MockTransport(recorded), **kwargs)
+
+        monkeypatch.setattr(common.httpx, "AsyncClient", factory)
+        return calls, options
+
+    return install
+
+
+class TestAgentGuildPreflight:
+    async def test_preflight_preserves_evidence_and_encodes_target(self, http_fixture):
+        calls, options = http_fixture(lambda _: httpx.Response(200, json=PREFLIGHT))
+        component = AgentGuildPreflight()
+        component.set(url="https://agent.example/a2a?mode=read&capability=research", timeout=12)
+        result = await component.inspect_endpoint()
+        assert isinstance(result, Data)
+        assert result.data == PREFLIGHT
+        assert calls[0].url.path == "/preflight"
+        assert calls[0].url.params["url"] == "https://agent.example/a2a?mode=read&capability=research"
+        assert len(calls) == 1
+        assert options == [{"timeout": 12, "follow_redirects": False, "trust_env": False}]
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "",
+            "   ",
+            "file:///etc/passwd",
+            "https://",
+            "https://agent.example:0/a2a",
+            "https://agent.example:bad/a2a",
+            "https://user:pass@agent.example/a2a",
+            "https://user@agent.example/a2a",
+            "https://agent.example/a2a?api_key=secret",
+            "https://agent.example/a2a?access_token=secret",
+            "https://agent.example/a2a?%61pi-key=secret",
+            "https://agent.example/a2a?X-Amz-Credential=secret",
+            "https://agent.example/a2a#secret",
+            "https://agent.example/\ncredential",
+            "http://127.0.0.1/a2a",
+            "http://[::1]/a2a",
+            "http://192.168.1.1/a2a",
+            "http://localhost/a2a",
+            "http://service.local/a2a",
+            "https://agent.example/" + "a" * 4096,
+        ],
+    )
+    async def test_invalid_or_credential_targets_fail_before_transmission(self, target, http_fixture):
+        calls, _ = http_fixture(lambda _: pytest.fail("Invalid target was transmitted"))
+        component = AgentGuildPreflight()
+        component.set(url=target)
+        with pytest.raises(ValueError, match=r"URL|public endpoint"):
+            await component.inspect_endpoint()
+        assert calls == []
+
+    @pytest.mark.parametrize("payload", [{}, {"verdict": "allow"}, {**PREFLIGHT, "unknowns": "missing"}])
+    async def test_incomplete_preflight_is_rejected(self, payload, http_fixture):
+        http_fixture(lambda _: httpx.Response(200, json=payload))
+        component = AgentGuildPreflight()
+        component.set(url="https://agent.example/a2a")
+        with pytest.raises(TypeError, match="without verdict"):
+            await component.inspect_endpoint()
+
+
+class TestAgentGuildPaidOperations:
+    async def test_prices_read_manifest_catalog_only(self, http_fixture):
+        calls, _ = http_fixture(lambda _: httpx.Response(200, json={"paid_operations": CATALOG, "other": "metadata"}))
+        result = await AgentGuildPaidOperations().read_prices()
+        assert result.data == CATALOG
+        assert len(calls) == 1
+        assert calls[0].url.path == "/.well-known/agent-guild.json"
+        assert not calls[0].url.query
+
+    @pytest.mark.parametrize("payload", [{}, {"paid_operations": []}, {"paid_operations": {"operations": "missing"}}])
+    async def test_incomplete_catalog_is_rejected(self, payload, http_fixture):
+        http_fixture(lambda _: httpx.Response(200, json=payload))
+        with pytest.raises(TypeError, match="without a paid-operation catalog"):
+            await AgentGuildPaidOperations().read_prices()
+
+
+class TestAgentGuildTransport:
+    @pytest.mark.parametrize("timeout", [0, -1, 61, True, 1.5, "30", None])
+    async def test_timeout_is_bounded_before_client_creation(self, timeout, http_fixture):
+        calls, options = http_fixture(lambda _: pytest.fail("Invalid timeout sent a request"))
+        with pytest.raises(ValueError, match="1 to 60"):
+            await common.read_json("/preflight", timeout=timeout)
+        assert calls == options == []
+
+    @pytest.mark.parametrize("status", [301, 302, 307, 308, 400, 402, 404, 500])
+    async def test_http_failures_never_follow_redirects_or_pay(self, status, http_fixture):
+        calls, _ = http_fixture(lambda _: httpx.Response(status, headers={"Location": "http://127.0.0.1/private"}))
+        with pytest.raises(ValueError, match=f"HTTP {status}"):
+            await common.read_json("/.well-known/agent-guild.json", timeout=30)
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize("body", [b"not json", b"[]", b'"string"', b'{"value":NaN}', b"\xff"])
+    async def test_malformed_json_is_not_evidence(self, body, http_fixture):
+        http_fixture(lambda _: httpx.Response(200, content=body))
+        with pytest.raises((ValueError, TypeError), match=r"JSON|response shape"):
+            await common.read_json("/preflight", timeout=30)
+
+    async def test_oversized_response_is_rejected(self, http_fixture):
+        http_fixture(lambda _: httpx.Response(200, content=b" " * (common.MAX_RESPONSE_BYTES + 1)))
+        with pytest.raises(ValueError, match="4 MiB"):
+            await common.read_json("/preflight", timeout=30)
+
+    async def test_transport_timeout_is_reported(self, http_fixture):
+        def timed_out(request):
+            msg = "fixture"
+            raise httpx.ReadTimeout(msg, request=request)
+
+        http_fixture(timed_out)
+        with pytest.raises(ValueError, match="timed out"):
+            await common.read_json("/preflight", timeout=30)
+
+    async def test_total_deadline_cancels_slow_stream(self, http_fixture):
+        closed = []
+
+        class SlowStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                while True:
+                    yield b" "
+                    await asyncio.sleep(0.05)
+
+            async def aclose(self):
+                closed.append(True)
+
+        http_fixture(lambda _: httpx.Response(200, stream=SlowStream()))
+        with pytest.raises(ValueError, match="timed out"):
+            await common.read_json("/preflight", timeout=1)
+        assert closed
+
+    async def test_only_free_routes_are_available(self, http_fixture):
+        calls, _ = http_fixture(lambda _: pytest.fail("A non-discovery route was called"))
+        with pytest.raises(ValueError, match="Unsupported"):
+            await common.read_json("/check", timeout=30)
+        assert calls == []
+
+
+class TestAgentGuildNativeIntegration:
+    @pytest.mark.parametrize(
+        ("component_class", "method", "arguments", "payload"),
+        [
+            (AgentGuildPreflight, "inspect_endpoint", {"url": "https://agent.example/a2a"}, PREFLIGHT),
+            (AgentGuildPaidOperations, "read_prices", {"timeout": 15}, {"paid_operations": CATALOG}),
+        ],
+    )
+    async def test_native_component_tool_execution(self, component_class, method, arguments, payload, http_fixture):
+        calls, _ = http_fixture(lambda _: httpx.Response(200, json=payload))
+        component = component_class()
+        tools = await component.to_toolkit()
+        assert len(tools) == 1
+        assert tools[0].name == method
+        assert set(tools[0].args) == set(arguments)
+        result = await tools[0].ainvoke(arguments)
+        serialized = json.dumps(result) if isinstance(result, dict) else str(result)
+        assert "operations" in serialized if method == "read_prices" else "independent_evidence" in serialized
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize("component_class", [AgentGuildPreflight, AgentGuildPaidOperations])
+    def test_native_editor_metadata(self, component_class):
+        component = component_class()
+        node = component.to_frontend_node()
+        assert node["data"]["node"]["icon"] == "AgentGuild"
+        assert node["data"]["node"]["display_name"].startswith("Agent Guild")
+
+    def test_official_bundle_discovery(
+        self,
+    ):
+        """Exercise the installed entry point while shadowing unrelated providers."""
+        root = Path(lfx_bundles.__file__).parent
+        claimed = {
+            path.name: ("installed", "unrelated-provider-fixture")
+            for path in root.iterdir()
+            if path.is_dir() and path.name != "agentguild"
+        }
+        results = load_lfx_bundles_extensions(claimed_bundles=claimed)
+        matching = [result for result in results if result.bundle == "agentguild"]
+        assert len(matching) == 1
+        assert matching[0].errors == []
+        assert {component.namespaced_id for component in matching[0].components} == {
+            "ext:agentguild:AgentGuildPreflight@official",
+            "ext:agentguild:AgentGuildPaidOperations@official",
+        }

--- a/src/frontend/src/icons/AgentGuild/AgentGuildIcon.jsx
+++ b/src/frontend/src/icons/AgentGuild/AgentGuildIcon.jsx
@@ -1,0 +1,32 @@
+const SvgAgentGuild = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 128 128"
+    aria-hidden="true"
+    {...props}
+  >
+    <rect width="128" height="128" rx="24" fill="#123b32" />
+    <path
+      d="M35 45 64 28 93 45v35L64 98 35 80Z"
+      fill="none"
+      stroke="#81dfb4"
+      strokeWidth="6"
+      strokeLinejoin="round"
+    />
+    <path
+      d="m35 45 29 18 29-18M64 63v35"
+      fill="none"
+      stroke="#81dfb4"
+      strokeWidth="5"
+    />
+    <g fill="#eefcf5">
+      <circle cx="35" cy="45" r="7" />
+      <circle cx="93" cy="45" r="7" />
+      <circle cx="64" cy="98" r="7" />
+    </g>
+  </svg>
+);
+
+export default SvgAgentGuild;

--- a/src/frontend/src/icons/AgentGuild/agent-guild.svg
+++ b/src/frontend/src/icons/AgentGuild/agent-guild.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">Agent Guild</title>
+  <rect width="128" height="128" rx="24" fill="#123b32"/>
+  <path d="M35 45 64 28 93 45v35L64 98 35 80Z" fill="none" stroke="#81dfb4" stroke-width="6" stroke-linejoin="round"/>
+  <path d="m35 45 29 18 29-18M64 63v35" fill="none" stroke="#81dfb4" stroke-width="5"/>
+  <g fill="#eefcf5"><circle cx="35" cy="45" r="7"/><circle cx="93" cy="45" r="7"/><circle cx="64" cy="98" r="7"/></g>
+</svg>

--- a/src/frontend/src/icons/AgentGuild/index.tsx
+++ b/src/frontend/src/icons/AgentGuild/index.tsx
@@ -1,0 +1,8 @@
+import type React from "react";
+import { forwardRef } from "react";
+import SvgAgentGuild from "./AgentGuildIcon";
+
+export const AgentGuildIcon = forwardRef<
+  SVGSVGElement,
+  React.SVGProps<SVGSVGElement>
+>((props, ref) => <SvgAgentGuild ref={ref} {...props} />);

--- a/src/frontend/src/icons/lazyIconImports.ts
+++ b/src/frontend/src/icons/lazyIconImports.ts
@@ -1,6 +1,10 @@
 // Export the lazy loading mapping for icons
 export const lazyIconsMapping = {
   AIML: () => import("@/icons/AIML").then((mod) => ({ default: mod.AIMLIcon })),
+  AgentGuild: () =>
+    import("@/icons/AgentGuild").then((mod) => ({
+      default: mod.AgentGuildIcon,
+    })),
   Agentics: () =>
     import("@/icons/Agentics").then((mod) => ({
       default: mod.AgenticsIcon,

--- a/src/frontend/src/utils/styleUtils.ts
+++ b/src/frontend/src/utils/styleUtils.ts
@@ -417,6 +417,7 @@ export const SIDEBAR_CATEGORIES = [
 
 export const SIDEBAR_BUNDLES = [
   { display_name: "AI/ML API", name: "aiml", icon: "AIML" },
+  { display_name: "Agent Guild", name: "agentguild", icon: "AgentGuild" },
   { display_name: "Agentics", name: "agentics", icon: "Agentics" },
   { display_name: "AgentQL", name: "agentql", icon: "AgentQL" },
   { display_name: "Code Agents", name: "codeagents", icon: "Bot" },

--- a/uv.lock
+++ b/uv.lock
@@ -9395,7 +9395,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-bundles"
-version = "1.1.22"
+version = "1.1.23"
 source = { editable = "src/bundles/lfx-bundles" }
 dependencies = [
     { name = "lfx" },

--- a/uv.lock
+++ b/uv.lock
@@ -9858,6 +9858,8 @@ requires-dist = [
     { name = "langchain-weaviate", marker = "extra == 'weaviate'", specifier = ">=0.0.6" },
     { name = "lfx", editable = "src/lfx" },
     { name = "lfx-azure", marker = "extra == 'azure'", editable = "src/bundles/azure" },
+    { name = "lfx-bundles", extras = ["agentguild"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
+    { name = "lfx-bundles", extras = ["agentguild"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["agentql"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["agentql"], marker = "extra == 'all-no-torch'", editable = "src/bundles/lfx-bundles" },
     { name = "lfx-bundles", extras = ["aiml"], marker = "extra == 'all'", editable = "src/bundles/lfx-bundles" },
@@ -10039,7 +10041,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.0.0,<2.0.0" },
     { name = "zep-python", marker = "extra == 'zep'", specifier = "==2.0.2" },
 ]
-provides-extras = ["agentql", "aiml", "altk", "apify", "assemblyai", "azure", "baidu", "bing", "chroma", "cleanlab", "clickhouse", "cloudflare", "codeagents", "cometapi", "composio", "confluence", "couchbase", "cuga", "deepseek", "elastic", "faiss", "funasr", "git", "glean", "google", "groq", "homeassistant", "huggingface", "icosacomputing", "jigsawstack", "langwatch", "litellm", "lmstudio", "maritalk", "mem0", "milvus", "mistral", "mongodb", "mrscraper", "needle", "notdiamond", "notion", "novita", "nvidia", "olivya", "ollama", "openrouter", "orcarouter", "perplexity", "pgvector", "pinecone", "plivo", "qdrant", "redis", "sambanova", "scrapegraph", "searchapi", "serpapi", "spider", "supabase", "tavily", "twelvelabs", "unstructured", "upstash", "vectara", "vertexai", "vlmrun", "weaviate", "wikipedia", "wolframalpha", "xai", "yahoosearch", "youtube", "zep", "all", "all-no-torch"]
+provides-extras = ["agentguild", "agentql", "aiml", "altk", "apify", "assemblyai", "azure", "baidu", "bing", "chroma", "cleanlab", "clickhouse", "cloudflare", "codeagents", "cometapi", "composio", "confluence", "couchbase", "cuga", "deepseek", "elastic", "faiss", "funasr", "git", "glean", "google", "groq", "homeassistant", "huggingface", "icosacomputing", "jigsawstack", "langwatch", "litellm", "lmstudio", "maritalk", "mem0", "milvus", "mistral", "mongodb", "mrscraper", "needle", "notdiamond", "notion", "novita", "nvidia", "olivya", "ollama", "openrouter", "orcarouter", "perplexity", "pgvector", "pinecone", "plivo", "qdrant", "redis", "sambanova", "scrapegraph", "searchapi", "serpapi", "spider", "supabase", "tavily", "twelvelabs", "unstructured", "upstash", "vectara", "vertexai", "vlmrun", "weaviate", "wikipedia", "wolframalpha", "xai", "yahoosearch", "youtube", "zep", "all", "all-no-torch"]
 
 [[package]]
 name = "lfx-cohere"


### PR DESCRIPTION
Adds an Agent Guild bundle so a Langflow flow can inspect a public agent endpoint before delegation and discover current trust-operation prices. `AgentGuildPreflight` returns the complete preflight response as `Data`, retaining the verdict, failed checks, and unknowns. `AgentGuildPaidOperations` returns the live price catalog. Both components support native Agent Tool Mode and require no Agent Guild account, API key, or wallet.

The components use two free reads at a fixed service origin. Supplied endpoint URLs are disclosed to Agent Guild for probing; the input rejects userinfo, common credential query parameters, fragments, and literal private/local addresses. Requests refuse redirects, limit responses to 4 MiB, and enforce a 1–60 second total timeout. Documentation explains data handling, uncertainty, downstream policy routing, and model costs. These components do not authorize delegation, verify passports, register agents, or make payments.

This follows the repository's invitation to contribute bundles and targets `release-1.13.0` per `CONTRIBUTING.md`. It uses the current `lfx-bundles` layout, existing HTTPX dependency, and bundle-local tests used by cross-bundle CI. The provider extra adds no third-party dependency. The release inventory includes `agentguild`; `lfx-bundles` advances from 1.1.27 to 1.1.28 with matching Langflow dependency floor and lock metadata.

The branch incorporates upstream `982ecd681ee54429649529d3dd2327f14f366c32`. The resulting contribution remains limited to the original 16 Agent Guild paths; unrelated upstream files and dependency resolutions are preserved. Component, test, documentation, and icon source are unchanged from the initial contribution.

Validation against the updated release source:

- 58 offline component/discovery checks passed, including native tool execution, official bundle discovery, URL rejection, HTTP failures, redirects, response size, malformed responses, and deadline cancellation. One existing all-extras network resolver test was deselected.
- 56 native release-inventory and release-plan tests passed. The release plan is ready for version 1.1.28.
- Ruff formatting/lint, offline lock validation, migration-name and component environment-write checks passed.
- Icon compilation and React rendering, MDX compilation, sidebar/icon registration, and Biome checks passed.

The isolated Python 3.12 environment was synchronized from the current lockfile for the native bundle, with test tools pinned to the same lock and imports verified against this checkout. No Agent Guild endpoint, model-provider, registration, or payment calls were made. Full Langflow UI, full repository tests, and Docusaurus site builds were not run. Draft for maintainer review; prepared by AgentTanuki with AI assistance.
