### PR TITLE
fix(variables): import environment globals for every user at startup

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -49,6 +49,7 @@ from langflow.services.database.models.folder.constants import (
     LEGACY_FOLDER_NAMES,
 )
 from langflow.services.database.models.folder.model import Folder, FolderCreate, FolderRead
+from langflow.services.database.models.user.model import User
 from langflow.services.deps import (
     get_settings_service,
     get_storage_service,
@@ -1513,6 +1514,30 @@ async def initialize_auto_login_default_superuser() -> None:
             await initialize_agentic_user_variables(super_user.id, async_session)
         _ = await get_or_create_default_folder(async_session, super_user.id)
     await logger.adebug("Super user initialized")
+
+
+async def initialize_env_variables_for_all_users(session: AsyncSession) -> None:
+    """Import ``LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT`` for every existing user.
+
+    The login handler imports these only for the user that just signed in. That never happens
+    again for a user of an external identity provider: their credential is resolved on every
+    request and the returning-user path does no provisioning, so a variable added to the list
+    would reach newly provisioned users only.
+
+    The process environment cannot change without a restart, which makes startup the point where
+    every user can be brought up to date at once, whatever they authenticate with. Failures are
+    per user so one bad row cannot stop the rest.
+    """
+    if not get_settings_service().settings.store_environment_variables:
+        return
+
+    user_ids = (await session.exec(select(User.id))).all()
+    variable_service = get_variable_service()
+    for user_id in user_ids:
+        try:
+            await variable_service.initialize_user_variables(user_id, session)
+        except Exception:  # noqa: BLE001
+            await logger.aexception(f"Failed to import environment variables for user {user_id}")
 
 
 async def get_or_create_default_folder(session: AsyncSession, user_id: UUID) -> FolderRead:

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -1535,7 +1535,10 @@ async def initialize_env_variables_for_all_users(session: AsyncSession) -> None:
     variable_service = get_variable_service()
     for user_id in user_ids:
         try:
-            await variable_service.initialize_user_variables(user_id, session)
+            # The importer catches flush errors itself. A savepoint also restores the
+            # session after those errors without discarding earlier users' imports.
+            async with session.begin_nested():
+                await variable_service.initialize_user_variables(user_id, session)
         except Exception:  # noqa: BLE001
             await logger.aexception(f"Failed to import environment variables for user {user_id}")
 

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -451,6 +451,18 @@ def get_lifespan(*, fix_migration=False, version=None):
                             "Starter projects may not be created or updated."
                         )
 
+            # Gate: Import environment-sourced global variables for every user
+            if is_step_complete(PreloadStep.ENV_GLOBALS):
+                await logger.adebug("Skipping environment global variables: master already completed it during preload")
+            else:
+                from langflow.initial_setup.setup import initialize_env_variables_for_all_users
+
+                try:
+                    async with session_scope() as session:
+                        await initialize_env_variables_for_all_users(session)
+                except Exception as e:  # noqa: BLE001
+                    await logger.awarning(f"Failed to import environment global variables: {e}")
+
             # Gate: Initialize agentic global variables (when agentic_experience enabled)
             if get_settings_service().settings.agentic_experience:
                 if is_step_complete(PreloadStep.AGENTIC_GLOBALS):

--- a/src/backend/base/langflow/preload.py
+++ b/src/backend/base/langflow/preload.py
@@ -60,6 +60,7 @@ class PreloadStep(Enum):
     BUNDLES = "bundles"
     TYPES_CACHED = "types_cached"
     STARTER_PROJECTS = "starter_projects"
+    ENV_GLOBALS = "env_globals"
     AGENTIC_GLOBALS = "agentic_globals"
     FLOWS = "flows"
 
@@ -69,6 +70,7 @@ _STEP_ATTR: Final[dict[PreloadStep, str]] = {
     PreloadStep.BUNDLES: "bundles_loaded",
     PreloadStep.TYPES_CACHED: "types_cached",
     PreloadStep.STARTER_PROJECTS: "starter_projects_created",
+    PreloadStep.ENV_GLOBALS: "env_globals_imported",
     PreloadStep.AGENTIC_GLOBALS: "agentic_globals_initialized",
     PreloadStep.FLOWS: "flows_loaded",
 }
@@ -79,6 +81,8 @@ _STEP_PREREQUISITES: Final[dict[PreloadStep, tuple[PreloadStep, ...]]] = {
     PreloadStep.BUNDLES: (),
     PreloadStep.TYPES_CACHED: (PreloadStep.BUNDLES,),
     PreloadStep.STARTER_PROJECTS: (PreloadStep.TYPES_CACHED,),
+    # Reads only the process environment and the user table, so nothing has to run first.
+    PreloadStep.ENV_GLOBALS: (),
     PreloadStep.AGENTIC_GLOBALS: (PreloadStep.TYPES_CACHED,),
     # MCP config may succeed even when globals failed (separate try/except in preload).
     PreloadStep.FLOWS: (PreloadStep.TYPES_CACHED,),
@@ -111,6 +115,7 @@ class _PreloadState:
     bundles_loaded: bool = False
     types_cached: bool = False
     starter_projects_created: bool = False
+    env_globals_imported: bool = False
     agentic_globals_initialized: bool = False
     flows_loaded: bool = False
 
@@ -197,6 +202,7 @@ async def _run_master_preload() -> None:
     from langflow.initial_setup.setup import (
         copy_profile_pictures,
         create_or_update_starter_projects,
+        initialize_env_variables_for_all_users,
         load_flows_from_directory,
     )
     from langflow.main import load_bundles_with_error_handling
@@ -245,6 +251,18 @@ async def _run_master_preload() -> None:
                 "starter projects init failed",
                 create_or_update_starter_projects(all_types_dict),
             )
+
+        await logger.adebug("[preload] importing environment global variables")
+
+        async def _run_env_globals() -> None:
+            async with session_scope() as session:
+                await initialize_env_variables_for_all_users(session)
+
+        await _best_effort(
+            PreloadStep.ENV_GLOBALS,
+            "environment global variables import failed",
+            _run_env_globals(),
+        )
 
         if settings_service.settings.agentic_experience:
             from langflow.api.utils.mcp.agentic_mcp import initialize_agentic_global_variables

--- a/src/backend/base/langflow/preload.py
+++ b/src/backend/base/langflow/preload.py
@@ -143,6 +143,7 @@ class _PreloadState:
         self.bundles_loaded = False
         self.types_cached = False
         self.starter_projects_created = False
+        self.env_globals_imported = False
         self.agentic_globals_initialized = False
         self.flows_loaded = False
 

--- a/src/backend/base/langflow/services/variable/service.py
+++ b/src/backend/base/langflow/services/variable/service.py
@@ -144,8 +144,11 @@ class DatabaseVariableService(VariableService, Service):
                             await logger.adebug(
                                 f"Skipping update of user-modified variable {var_name} with environment value"
                             )
-                        else:
-                            await self.update_variable(user_id, var_name, value, session=session)
+                        elif self._stored_value(existing) != value:
+                            # bump_updated_at=False keeps this import from looking like a user
+                            # edit to the check above: stamping updated_at here would freeze the
+                            # row against every later environment change.
+                            await self.update_variable(user_id, var_name, value, session=session, bump_updated_at=False)
                     else:
                         await self.create_variable(
                             user_id=user_id,
@@ -165,6 +168,21 @@ class DatabaseVariableService(VariableService, Service):
                             f"Session rolled back after error processing {var_name}. Stopping variable initialization."
                         )
                         break
+
+    @staticmethod
+    def _stored_value(variable: Variable) -> str | None:
+        """Return the plaintext behind a stored variable, or None when it cannot be read.
+
+        An unreadable value (encrypted with a retired LANGFLOW_SECRET_KEY) compares unequal to
+        the environment value, so the environment import refreshes it rather than leaving a row
+        nothing can decrypt.
+        """
+        if variable.type != CREDENTIAL_TYPE:
+            return variable.value
+        try:
+            return auth_utils.decrypt_api_key(variable.value)
+        except Exception:  # noqa: BLE001
+            return None
 
     async def get_variable_object(
         self,
@@ -403,6 +421,8 @@ class DatabaseVariableService(VariableService, Service):
         name: str,
         value: str,
         session: AsyncSession,
+        *,
+        bump_updated_at: bool = True,
     ):
         stmt = select(Variable).where(Variable.user_id == user_id, Variable.name == name)
         variable = (await session.exec(stmt)).first()
@@ -423,7 +443,8 @@ class DatabaseVariableService(VariableService, Service):
             variable.value = auth_utils.encrypt_api_key(value, settings_service=self.settings_service)
         else:
             variable.value = value
-        variable.updated_at = datetime.now(timezone.utc)
+        if bump_updated_at:
+            variable.updated_at = datetime.now(timezone.utc)
         session.add(variable)
         await session.flush()
         await session.refresh(variable)

--- a/src/backend/tests/unit/base/test_preload.py
+++ b/src/backend/tests/unit/base/test_preload.py
@@ -34,6 +34,7 @@ def reset_preload_state():
         "bundles_loaded": _STATE.bundles_loaded,
         "types_cached": _STATE.types_cached,
         "starter_projects_created": _STATE.starter_projects_created,
+        "env_globals_imported": _STATE.env_globals_imported,
         "agentic_globals_initialized": _STATE.agentic_globals_initialized,
         "flows_loaded": _STATE.flows_loaded,
     }
@@ -68,6 +69,7 @@ class _PreloadFixture:
     get_and_cache_all_types_dict: AsyncMock
     create_or_update_starter_projects: AsyncMock
     load_flows_from_directory: AsyncMock
+    initialize_env_variables_for_all_users: AsyncMock
     initialize_agentic_global_variables: AsyncMock
     logger: AsyncMock
 
@@ -101,6 +103,7 @@ def _preload_env(
     agentic_experience=False,
     dispose_side_effect=None,
     copy_profile_pictures=None,
+    initialize_env_variables_for_all_users=None,
     initialize_agentic_global_variables=None,
     cache_service=None,
     all_types_dict=None,
@@ -120,6 +123,7 @@ def _preload_env(
     get_and_cache = AsyncMock()
     create_starter = AsyncMock()
     load_flows = AsyncMock()
+    init_env = initialize_env_variables_for_all_users or AsyncMock()
     init_agentic = initialize_agentic_global_variables or AsyncMock()
     logger_mock = AsyncMock()
 
@@ -146,6 +150,7 @@ def _preload_env(
         stack.enter_context(
             patch("langflow.initial_setup.setup.load_flows_from_directory", load_flows),
         )
+        stack.enter_context(patch("langflow.initial_setup.setup.initialize_env_variables_for_all_users", init_env))
         stack.enter_context(patch("langflow.main.load_bundles_with_error_handling", load_bundles))
         stack.enter_context(
             patch("lfx.interface.components.get_and_cache_all_types_dict", get_and_cache),
@@ -172,6 +177,7 @@ def _preload_env(
             get_and_cache_all_types_dict=get_and_cache,
             create_or_update_starter_projects=create_starter,
             load_flows_from_directory=load_flows,
+            initialize_env_variables_for_all_users=init_env,
             initialize_agentic_global_variables=init_agentic,
             logger=logger_mock,
         )
@@ -276,6 +282,7 @@ def test_reset_clears_all_fields():
     _STATE.bundles_loaded = True
     _STATE.types_cached = True
     _STATE.starter_projects_created = True
+    _STATE.env_globals_imported = True
     _STATE.agentic_globals_initialized = True
     _STATE.flows_loaded = True
 
@@ -289,6 +296,7 @@ def test_reset_clears_all_fields():
     assert _STATE.bundles_loaded is False
     assert _STATE.types_cached is False
     assert _STATE.starter_projects_created is False
+    assert _STATE.env_globals_imported is False
     assert _STATE.agentic_globals_initialized is False
     assert _STATE.flows_loaded is False
 
@@ -441,14 +449,29 @@ async def test_run_master_preload_best_effort_step_failure_continues():
 @pytest.mark.asyncio
 async def test_run_master_preload_sets_completion_flags_on_success():
     """Every successful step must set its matching completion flag."""
-    with _preload_env(all_types_dict={"fake": "types_dict"}):
+    with _preload_env(all_types_dict={"fake": "types_dict"}) as fx:
         await _run_master_preload()
 
     assert _STATE.profile_pictures_copied is True
     assert _STATE.bundles_loaded is True
     assert _STATE.types_cached is True
     assert _STATE.starter_projects_created is True
+    fx.initialize_env_variables_for_all_users.assert_awaited_once()
+    assert _STATE.env_globals_imported is True
     assert _STATE.flows_loaded is True
+
+
+@pytest.mark.asyncio
+async def test_run_master_preload_env_globals_failure_allows_worker_retry():
+    """Failed environment imports leave the step incomplete while preload continues."""
+    failing_import = AsyncMock(side_effect=RuntimeError("Environment import failed"))
+    with _preload_env(initialize_env_variables_for_all_users=failing_import) as fx:
+        await _run_master_preload()
+
+    failing_import.assert_awaited_once()
+    assert _STATE.env_globals_imported is False
+    fx.load_flows_from_directory.assert_awaited_once()
+    fx.db_engine.dispose.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/unit/initial_setup/test_setup_functions.py
+++ b/src/backend/tests/unit/initial_setup/test_setup_functions.py
@@ -13,7 +13,7 @@ from langflow.initial_setup.setup import (
 )
 from langflow.services.database.models.folder.constants import DEFAULT_FOLDER_NAME
 from langflow.services.database.models.folder.model import Folder, FolderRead
-from sqlmodel import select
+from sqlmodel import col, select
 
 
 @pytest.mark.usefixtures("client")
@@ -451,3 +451,59 @@ async def test_initialize_env_variables_for_all_users_reaches_existing_users(asy
     for user in users:
         names = await variable_service.list_variables(user.id, async_session)
         assert "NEW_SERVICE_URL" in names, f"{user.username} did not receive the new variable; has {names}"
+
+
+@pytest.mark.parametrize("operation", ["INSERT", "UPDATE"])
+async def test_initialize_env_variables_for_all_users_isolates_flush_failure(
+    async_session, monkeypatch, operation
+) -> None:
+    """A failed flush rolls back only that user, including their earlier imports."""
+    from langflow.initial_setup.setup import initialize_env_variables_for_all_users
+    from langflow.services.database.models.user.model import User
+    from langflow.services.database.models.variable.model import Variable
+    from langflow.services.deps import get_settings_service, get_variable_service
+    from sqlalchemy import text
+
+    users = [User(username=f"import-user-{index}", password=secrets.token_urlsafe(8)) for index in range(3)]
+    async_session.add_all(users)
+    await async_session.commit()
+
+    # Match the importer's iteration order so the failure has successful users on both sides.
+    user_ids = (await async_session.exec(select(User.id))).all()
+    failed_user_id = user_ids[1]
+    names = ["FIRST_SERVICE_URL", "SECOND_SERVICE_URL"]
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "store_environment_variables", True)
+    monkeypatch.setattr(settings, "variables_to_get_from_environment", names)
+    variable_service = get_variable_service()
+
+    if operation == "UPDATE":
+        for user_id in user_ids:
+            for name in names:
+                await variable_service.create_variable(user_id, name, "old-value", session=async_session)
+        await async_session.commit()
+
+    # Trigger a real database failure inside the service, which catches flush exceptions itself.
+    await async_session.execute(
+        text(
+            f"CREATE TRIGGER reject_env_import BEFORE {operation} ON variable "
+            f"WHEN NEW.user_id = '{failed_user_id.hex}' AND NEW.name = 'SECOND_SERVICE_URL' "
+            "BEGIN SELECT RAISE(ABORT, 'test import failure'); END"
+        )
+    )
+    await async_session.commit()
+    for name in names:
+        monkeypatch.setenv(name, "new-value")
+
+    await initialize_env_variables_for_all_users(async_session)
+    assert async_session.is_active
+    await async_session.commit()
+
+    variables = (await async_session.exec(select(Variable).where(col(Variable.name).in_(names)))).all()
+    expected_owners = set(user_ids) if operation == "UPDATE" else set(user_ids) - {failed_user_id}
+    assert {(variable.user_id, variable.name) for variable in variables} == {
+        (user_id, name) for user_id in expected_owners for name in names
+    }
+    for variable in variables:
+        value = await variable_service.get_variable(variable.user_id, variable.name, "", session=async_session)
+        assert value.get_secret_value() == ("old-value" if variable.user_id == failed_user_id else "new-value")

--- a/src/backend/tests/unit/initial_setup/test_setup_functions.py
+++ b/src/backend/tests/unit/initial_setup/test_setup_functions.py
@@ -1,4 +1,5 @@
 import asyncio
+import secrets
 from copy import deepcopy
 from uuid import uuid4
 
@@ -422,3 +423,31 @@ def test_update_components_syncs_metadata_for_skipped_language_model():
     assert node["template"]["code"]["value"] == "new source"
     assert node["template"]["model"]["value"] == "persisted-model"
     assert node["metadata"] == {"code_hash": "new-hash", "module": "new.module"}
+
+
+async def test_initialize_env_variables_for_all_users_reaches_existing_users(async_session, monkeypatch) -> None:
+    """Users who already exist must pick up a newly added environment variable.
+
+    The login handler only imports these for the user that just signed in, which never happens
+    again for a user of an external identity provider: their credential is resolved on every
+    request and the returning-user path does no provisioning.
+    """
+    from langflow.initial_setup.setup import initialize_env_variables_for_all_users
+    from langflow.services.database.models.user.model import User
+    from langflow.services.deps import get_settings_service, get_variable_service
+
+    users = [
+        User(username=f"existing-user-{index}", password=secrets.token_urlsafe(8), is_active=True) for index in range(2)
+    ]
+    async_session.add_all(users)
+    await async_session.flush()
+
+    monkeypatch.setenv("NEW_SERVICE_URL", "https://service.internal")
+    monkeypatch.setattr(get_settings_service().settings, "variables_to_get_from_environment", ["NEW_SERVICE_URL"])
+
+    await initialize_env_variables_for_all_users(async_session)
+
+    variable_service = get_variable_service()
+    for user in users:
+        names = await variable_service.list_variables(user.id, async_session)
+        assert "NEW_SERVICE_URL" in names, f"{user.username} did not receive the new variable; has {names}"

--- a/src/backend/tests/unit/services/variable/test_service.py
+++ b/src/backend/tests/unit/services/variable/test_service.py
@@ -102,6 +102,46 @@ async def test_initialize_user_variables__preserves_existing_default_fields(
     assert variable.default_fields == default_fields
 
 
+async def test_initialize_user_variables__applies_changed_environment_value(
+    service, session: AsyncSession, monkeypatch
+):
+    """A rotated environment value reaches the user no matter how often the import has run.
+
+    The import used to stamp ``updated_at`` on its own writes, so from the third run onwards the
+    row looked user-modified and every later environment change was skipped.
+    """
+    user_id = uuid4()
+    var_name = "OPENAI_API_KEY"
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", [var_name])
+
+    monkeypatch.setenv(var_name, "first-value")
+    await service.initialize_user_variables(user_id=user_id, session=session)
+    await service.initialize_user_variables(user_id=user_id, session=session)
+
+    monkeypatch.setenv(var_name, "second-value")
+    await service.initialize_user_variables(user_id=user_id, session=session)
+
+    value = await service.get_variable(user_id, var_name, "", session=session)
+    assert value.get_secret_value() == "second-value"
+
+
+async def test_initialize_user_variables__keeps_user_edited_value(service, session: AsyncSession, monkeypatch):
+    """An explicit edit still wins over the environment."""
+    user_id = uuid4()
+    var_name = "OPENAI_API_KEY"
+    monkeypatch.setattr(service.settings_service.settings, "variables_to_get_from_environment", [var_name])
+
+    monkeypatch.setenv(var_name, "from-environment")
+    await service.initialize_user_variables(user_id=user_id, session=session)
+    await service.update_variable(user_id, var_name, "edited-in-the-ui", session=session)
+
+    monkeypatch.setenv(var_name, "rotated-in-the-environment")
+    await service.initialize_user_variables(user_id=user_id, session=session)
+
+    value = await service.get_variable(user_id, var_name, "", session=session)
+    assert value.get_secret_value() == "edited-in-the-ui"
+
+
 async def test_initialize_user_variables__not_found_variable(service, session: AsyncSession):
     with patch("langflow.services.variable.service.DatabaseVariableService.create_variable") as m:
         m.side_effect = Exception()


### PR DESCRIPTION
Fixes #14983

## Problem

Two gaps in the `LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT` import.

1. **External IdP users only get it once.** There is no `/login` for them — the credential is resolved per request in `_materialize_external_user`, and the returning-user branch returns without provisioning. Only the JIT branch imports, so a newly added variable reaches newly created users and nobody else.
2. **The user-edit guard poisons itself.** The import writes through `update_variable`, which stamps `updated_at`; `create_variable` leaves it null. From the third import on, the row reads as user-modified and is skipped — freezing it against every later environment change, on SSO and password login alike.

## Fix

**Import for every user at startup.** The environment cannot change without a restart, so startup covers all users regardless of auth method. `initialize_env_variables_for_all_users()` mirrors `initialize_agentic_global_variables()` and runs from the same two hooks — master preload via a new `PreloadStep.ENV_GLOBALS`, worker lifespan via the usual `is_step_complete` gate. Failures are per user.

`_materialize_external_user` is left alone on purpose: it runs on every request, so importing there would add a query per variable to every API call.

**Don't let the import look like a user edit.** `update_variable` gains a keyword-only `bump_updated_at: bool = True`; the import passes `False` and skips the write when the stored value already matches. `variable/base.py` and `variable/kubernetes.py` are unchanged — a keyword-only param with a default is a safe override widening.

## Tests

- rotated environment value reaches the user after repeated imports
- a UI edit still wins over the environment
- the startup import reaches users who already exist

`89 passed` (services/variable, initial_setup, base/test_preload). `ruff check` and `ruff format` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment-configured variables are now initialized for all existing users during application startup.
  - Changed environment values are automatically applied to previously imported variables.
  - User-edited variable values remain unchanged when environment values are updated.

- **Bug Fixes**
  - Environment variable imports now correctly refresh unreadable stored credentials.
  - Automatic imports no longer alter variable modification timestamps unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->