### PR TITLE
fix(composio): stop Gmail tool-calls from being forced to fabricate an empty attachment

### DIFF
--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -13,7 +13,12 @@ import pytest
 composio = pytest.importorskip("composio", reason="composio extra not installed in this env")
 pytest.importorskip("composio_langchain", reason="composio extra not installed in this env")
 
-from lfx.base.composio.safe_provider import SafeLangchainProvider, _sanitize_schema  # noqa: E402
+from lfx.base.composio.safe_provider import (  # noqa: E402
+    SafeLangchainProvider,
+    _harden_schema,
+    _relax_attachment_requirements,
+    _sanitize_schema,
+)
 
 
 class TestSanitizeSchema:
@@ -170,6 +175,163 @@ class TestSafeLangchainProviderRegression:
         model = pydantic_model_from_param_schema(schema)
         # Defaulted type is "string", which maps to ``str`` in Composio's type table.
         assert "payload" in model.model_fields
+
+
+class TestRelaxAttachmentRequirements:
+    """Reproduces the GMAIL_CREATE_EMAIL_DRAFT / GMAIL_SEND_EMAIL bug report.
+
+    Composio's raw schema for these actions marks "attachment" required even
+    though a real send/draft never needs one, you just omit it. Left alone,
+    an LLM building a tool call fabricates an empty placeholder
+    ({"name": "", "data": ""}) to satisfy the schema, which the real Gmail
+    API then rejects: "Tool input validation error".
+    """
+
+    def test_gmail_create_email_draft_shaped_schema(self):
+        # Modeled on the real GMAIL_CREATE_EMAIL_DRAFT input_parameters shape
+        # from the bug report: recipient/subject/body genuinely required,
+        # attachment required only because of the upstream schema defect.
+        schema = {
+            "type": "object",
+            "properties": {
+                "user_id": {"type": "string"},
+                "recipient_email": {"type": "string"},
+                "subject": {"type": "string"},
+                "body": {"type": "string"},
+                "is_html": {"type": "boolean"},
+                "attachment": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "data": {"type": "string"}},
+                },
+            },
+            "required": ["user_id", "recipient_email", "attachment"],
+        }
+        _relax_attachment_requirements(schema)
+        assert schema["required"] == ["user_id", "recipient_email"]
+        # The property itself is untouched — only its false "required" status is dropped.
+        assert "attachment" in schema["properties"]
+
+    def test_pydantic_model_no_longer_requires_attachment(self):
+        """End-to-end: after hardening, the built Pydantic model accepts a call with no attachment."""
+        from composio.utils.shared import pydantic_model_from_param_schema
+
+        schema = {
+            "title": "GmailCreateEmailDraft",
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string", "title": "Subject"},
+                "attachment": {"type": "string", "title": "Attachment"},
+            },
+            "required": ["subject", "attachment"],
+        }
+        _harden_schema(schema)
+        model = pydantic_model_from_param_schema(schema)
+        # subject is still mandatory; attachment must now be optional.
+        assert model.model_fields["subject"].is_required() is True
+        assert model.model_fields["attachment"].is_required() is False
+        # Confirms the model can actually be built with attachment omitted —
+        # the exact call shape an LLM should now be free to make.
+        instance = model(subject="test")
+        assert instance.subject == "test"
+
+    def test_wrap_tool_calls_harden_schema_on_input_parameters(self):
+        """``wrap_tool`` must route through ``_harden_schema``, not just ``_sanitize_schema``.
+
+        Avoids constructing a full ``composio.types.Tool`` (its nested
+        ``ItemDeprecated``/``ItemToolkit`` shape is version-coupled and brittle
+        to pin in a test); a lightweight stand-in with the one attribute
+        ``wrap_tool`` reads (``input_parameters``) is enough to prove the
+        dispatch is wired to the attachment-relaxing patch, not just the
+        original type-defaulting one.
+        """
+
+        class _FakeTool:
+            input_parameters = {
+                "type": "object",
+                "properties": {"subject": {"type": "string"}, "attachment": {"type": "string"}},
+                "required": ["subject", "attachment"],
+            }
+
+        provider = SafeLangchainProvider()
+        fake_tool = _FakeTool()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(SafeLangchainProvider.__bases__[0], "wrap_tool", lambda self, tool, execute_tool: tool)  # noqa: ARG005
+            result = provider.wrap_tool(tool=fake_tool, execute_tool=lambda **_kwargs: None)
+        assert result.input_parameters["required"] == ["subject"]
+
+    def test_wrap_tool_strips_blank_attachment_before_the_real_execute_call(self):
+        """End-to-end reproduction of the follow-up bug: schema-optional isn't enough.
+
+        Making "attachment" optional in the schema stops an LLM from being
+        *forced* to supply it, but doesn't stop one from submitting the exact
+        {"name": "", "data": ""} placeholder anyway "to be safe" — that now
+        passes local validation (the field is optional) and would reach the
+        real Gmail API, which rejects it there instead: "the email tool
+        rejected its attachment parameter, although no attachment was
+        requested". This drives the real ``wrap_tool``/``safe_execute_tool``
+        path with exactly that placeholder and asserts it never reaches the
+        underlying ``execute_tool`` call.
+        """
+        received_args: dict = {}
+
+        def fake_execute_tool(slug: str, arguments: dict) -> dict:
+            received_args["slug"] = slug
+            received_args["arguments"] = arguments
+            return {"successful": True, "data": {}}
+
+        def fake_base_wrap_tool(self, tool, execute_tool):  # noqa: ARG001
+            # Stand-in for composio_langchain's real wrap_tool: it eventually
+            # calls execute_tool with whatever kwargs the LLM's tool call
+            # produced. Drive it with the bug report's exact payload.
+            execute_tool(
+                "GMAIL_CREATE_EMAIL_DRAFT",
+                {"subject": "test", "attachment": {"name": "", "data": ""}},
+            )
+            return tool
+
+        class _FakeTool:
+            input_parameters = {
+                "type": "object",
+                "properties": {"subject": {"type": "string"}, "attachment": {"type": "string"}},
+                "required": ["subject", "attachment"],
+            }
+
+        provider = SafeLangchainProvider()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(SafeLangchainProvider.__bases__[0], "wrap_tool", fake_base_wrap_tool)
+            provider.wrap_tool(tool=_FakeTool(), execute_tool=fake_execute_tool)
+
+        assert received_args["slug"] == "GMAIL_CREATE_EMAIL_DRAFT"
+        assert received_args["arguments"] == {"subject": "test"}
+
+    def test_wrap_tool_preserves_a_real_attachment_through_execute_call(self):
+        """Negative case: a genuine attachment must still reach the real call."""
+        received_args: dict = {}
+
+        def fake_execute_tool(_slug: str, arguments: dict) -> dict:
+            received_args["arguments"] = arguments
+            return {"successful": True, "data": {}}
+
+        def fake_base_wrap_tool(self, tool, execute_tool):  # noqa: ARG001
+            execute_tool(
+                "GMAIL_CREATE_EMAIL_DRAFT",
+                {"subject": "test", "attachment": {"name": "invoice.pdf", "data": "base64=="}},
+            )
+            return tool
+
+        class _FakeTool:
+            input_parameters = {
+                "type": "object",
+                "properties": {"subject": {"type": "string"}, "attachment": {"type": "string"}},
+                "required": ["subject", "attachment"],
+            }
+
+        provider = SafeLangchainProvider()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(SafeLangchainProvider.__bases__[0], "wrap_tool", fake_base_wrap_tool)
+            provider.wrap_tool(tool=_FakeTool(), execute_tool=fake_execute_tool)
+
+        assert received_args["arguments"]["attachment"] == {"name": "invoice.pdf", "data": "base64=="}
 
 
 class TestNoOpOnAlreadyTypedSchemas:

--- a/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
+++ b/src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
@@ -10,6 +10,15 @@ those raw subscripts succeed.
 
 import pytest
 
+# The bundle-guarded CI job discovers which tests to run by grepping for
+# ``pytest.importorskip("lfx_bundles"``, not by module name (see
+# .github/workflows/python_test.yml). Without this exact guard first, this
+# file is invisible to that job's file list — it still imports successfully
+# in the ordinary backend job, but there `composio` isn't installed, so
+# every test below importorskips and the suite reports green having run
+# nothing. This guard is what makes the file discoverable by the job that
+# actually has `composio` installed.
+pytest.importorskip("lfx_bundles", reason="bundles extra not installed in this env")
 composio = pytest.importorskip("composio", reason="composio extra not installed in this env")
 pytest.importorskip("composio_langchain", reason="composio extra not installed in this env")
 
@@ -18,6 +27,7 @@ from lfx.base.composio.safe_provider import (  # noqa: E402
     _harden_schema,
     _relax_attachment_requirements,
     _sanitize_schema,
+    _slug_needs_attachment_relaxation,
 )
 
 
@@ -224,7 +234,7 @@ class TestRelaxAttachmentRequirements:
             },
             "required": ["subject", "attachment"],
         }
-        _harden_schema(schema)
+        _harden_schema(schema, relax_attachment=True)
         model = pydantic_model_from_param_schema(schema)
         # subject is still mandatory; attachment must now be optional.
         assert model.model_fields["subject"].is_required() is True
@@ -246,6 +256,7 @@ class TestRelaxAttachmentRequirements:
         """
 
         class _FakeTool:
+            slug = "GMAIL_CREATE_EMAIL_DRAFT"
             input_parameters = {
                 "type": "object",
                 "properties": {"subject": {"type": "string"}, "attachment": {"type": "string"}},
@@ -290,6 +301,7 @@ class TestRelaxAttachmentRequirements:
             return tool
 
         class _FakeTool:
+            slug = "GMAIL_CREATE_EMAIL_DRAFT"
             input_parameters = {
                 "type": "object",
                 "properties": {"subject": {"type": "string"}, "attachment": {"type": "string"}},
@@ -320,6 +332,7 @@ class TestRelaxAttachmentRequirements:
             return tool
 
         class _FakeTool:
+            slug = "GMAIL_CREATE_EMAIL_DRAFT"
             input_parameters = {
                 "type": "object",
                 "properties": {"subject": {"type": "string"}, "attachment": {"type": "string"}},
@@ -332,6 +345,86 @@ class TestRelaxAttachmentRequirements:
             provider.wrap_tool(tool=_FakeTool(), execute_tool=fake_execute_tool)
 
         assert received_args["arguments"]["attachment"] == {"name": "invoice.pdf", "data": "base64=="}
+
+    def test_wrap_tool_does_not_relax_attachment_for_an_unrelated_toolkit(self):
+        """The core regression guard for I2: scoping must actually hold.
+
+        A toolkit where "attachment" is a real, meaningful requirement (e.g.
+        an action whose entire purpose is attaching a file) must keep it in
+        ``required`` and must NOT have a blank attachment silently stripped
+        before the real call. Relaxing it there would convert a legitimate
+        local validation error into a confusing API-side rejection instead.
+        """
+        received_args: dict = {}
+
+        def fake_execute_tool(slug: str, arguments: dict) -> dict:
+            received_args["slug"] = slug
+            received_args["arguments"] = arguments
+            return {"successful": True, "data": {}}
+
+        def fake_base_wrap_tool(self, tool, execute_tool):  # noqa: ARG001
+            execute_tool(
+                "JIRA_ATTACH_FILE_TO_ISSUE",
+                {"issue_key": "PROJ-1", "attachment": {"name": "", "data": ""}},
+            )
+            return tool
+
+        class _FakeUnrelatedTool:
+            slug = "JIRA_ATTACH_FILE_TO_ISSUE"
+            input_parameters = {
+                "type": "object",
+                "properties": {"issue_key": {"type": "string"}, "attachment": {"type": "string"}},
+                "required": ["issue_key", "attachment"],
+            }
+
+        provider = SafeLangchainProvider()
+        fake_tool = _FakeUnrelatedTool()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(SafeLangchainProvider.__bases__[0], "wrap_tool", fake_base_wrap_tool)
+            result = provider.wrap_tool(tool=fake_tool, execute_tool=fake_execute_tool)
+
+        # Schema: "attachment" stays required — this toolkit's real contract.
+        assert result.input_parameters["required"] == ["issue_key", "attachment"]
+        # Execution: the blank attachment is NOT stripped — reaches the call
+        # verbatim, so Jira's own API can reject it with a real error instead
+        # of the call silently going out without the file the user asked for.
+        assert received_args["arguments"] == {
+            "issue_key": "PROJ-1",
+            "attachment": {"name": "", "data": ""},
+        }
+
+
+class TestSlugNeedsAttachmentRelaxation:
+    """The allowlist gate itself, independent of wrap_tool."""
+
+    def _get_fn(self):
+        return _slug_needs_attachment_relaxation
+
+    def test_gmail_slugs_match(self):
+        assert self._get_fn()("GMAIL_CREATE_EMAIL_DRAFT") is True
+        assert self._get_fn()("GMAIL_SEND_EMAIL") is True
+
+    def test_outlook_slugs_match(self):
+        assert self._get_fn()("OUTLOOK_OUTLOOK_SEND_EMAIL") is True
+
+    def test_unrelated_toolkits_do_not_match(self):
+        for slug in (
+            "JIRA_ATTACH_FILE_TO_ISSUE",
+            "FRESHDESK_CREATE_TICKET",
+            "PANDADOC_CREATE_DOCUMENT",
+            "DROPBOX_UPLOAD_FILE",
+            "ONEDRIVE_UPLOAD_FILE",
+            "MISSIVE_CREATE_DRAFT",
+            "FLEXISIGN_SEND_DOCUMENT",
+            "JOTFORM_SUBMIT_FORM",
+        ):
+            assert self._get_fn()(slug) is False
+
+    def test_case_sensitive_prefix_match_only(self):
+        # A slug that merely contains "gmail" lowercase, or elsewhere in the
+        # string, must not match — this is a prefix check, not a substring one.
+        assert self._get_fn()("gmail_create_email_draft") is False
+        assert self._get_fn()("SOME_GMAIL_RELATED_ACTION") is False
 
 
 class TestNoOpOnAlreadyTypedSchemas:

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -344,4 +344,3 @@ def _patch_identifier_substitution_once() -> None:
 _patch_file_helper_once()
 _patch_pydantic_builder_once()
 _patch_identifier_substitution_once()
-

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -13,16 +13,33 @@ both the FileHelper file-substitution helpers and the pydantic schema builder
 so the agent path, the direct ``execute_action`` path, and the legacy
 ``tools.get`` path all see a schema with a ``"type"`` for every node.
 
-We also relax the ``attachment`` field specifically: Composio's raw schemas
-for Gmail/Outlook send/draft actions mark the attachment object (or its
-sub-fields) as ``required``, even though a real attachment is optional, you
-simply omit it to send an email without one. Left alone, an LLM building a
-tool call sees "attachment" in ``required`` and has to invent an empty
-placeholder (e.g. ``{"name": "", "data": ""}``) to satisfy the schema, which
-then reaches the real Gmail/Outlook API and fails validation there instead.
-Langflow's own node-execution path (``ComposioBaseComponent``) already treats
-this field as optional; ``_relax_attachment_requirements`` mirrors that for
-the raw tool-calling schema.
+We also relax the ``attachment`` field, but only for the specific toolkits
+where this is a known issue: Composio's raw schema for
+``GMAIL_CREATE_EMAIL_DRAFT`` marks the attachment object (or its sub-fields)
+as ``required``, even though a real attachment is optional there, you simply
+omit it to send an email without one. Left alone, an LLM building a tool call
+sees "attachment" in ``required`` and has to invent an empty placeholder
+(e.g. ``{"name": "", "data": ""}``) to satisfy the schema, which then reaches
+the real Gmail API and fails validation there instead. Langflow's own
+node-execution path (``ComposioBaseComponent``) already treats this field as
+optional for that action; ``_relax_attachment_requirements`` mirrors that for
+the raw tool-calling schema. Outlook is included in the same allowlist as a
+precaution, its send/draft actions share the same general schema shape
+(composio_langchain's own reserved-keyword handling elsewhere in this file
+already special-cases Outlook's ``from`` field), but this has only been
+directly confirmed against Gmail, not independently verified for Outlook.
+
+This relaxation is deliberately NOT applied globally. Langflow ships dozens
+of Composio toolkits, and several (jira, freshdesk, pandadoc, dropbox,
+onedrive, missive, flexisign, jotform, ...) have actions whose entire purpose
+is attaching a file, where ``attachment`` in ``required`` is the real
+contract, not a schema defect. Relaxing it there would silently convert a
+clear local validation error ("you forgot the attachment") into an opaque
+API-side rejection instead. So the relaxation is gated by slug prefix
+(``_RELAX_ATTACHMENT_SLUG_PREFIXES``) and only ever applied at the one patch
+point that has the tool's identity available (``wrap_tool``, which sees
+``tool.slug``); the three process-wide monkeypatches below have no such
+context; and stay on ``_sanitize_schema`` alone.
 """
 
 from __future__ import annotations
@@ -149,10 +166,29 @@ def _relax_attachment_requirements(schema: Any) -> None:
                 _relax_attachment_requirements(sub)
 
 
-def _harden_schema(schema: Any) -> None:
-    """Apply every schema patch (missing-``type`` + false-required-attachment) in one pass."""
+# Toolkits confirmed (Gmail) or suspected (Outlook, same schema family) to
+# over-require "attachment". NOT a general rule: most toolkits with an
+# attachment-like field require it for real (see module docstring), so this
+# list is the deliberate boundary, not a starting point to expand casually.
+_RELAX_ATTACHMENT_SLUG_PREFIXES = ("GMAIL_", "OUTLOOK_")
+
+
+def _slug_needs_attachment_relaxation(slug: str) -> bool:
+    """True only for toolkits where Composio's schema is known to over-require "attachment"."""
+    return slug.startswith(_RELAX_ATTACHMENT_SLUG_PREFIXES)
+
+
+def _harden_schema(schema: Any, *, relax_attachment: bool = False) -> None:
+    """Apply schema patches: always fix missing ``type`` keys.
+
+    ``relax_attachment`` must stay opt-in, defaulting to ``False``. It's only
+    correct for the toolkits ``_slug_needs_attachment_relaxation`` allows;
+    passing it ``True`` for anything else would silently mask a real
+    validation error on a toolkit where the field is genuinely required.
+    """
     _sanitize_schema(schema)
-    _relax_attachment_requirements(schema)
+    if relax_attachment:
+        _relax_attachment_requirements(schema)
 
 
 def _is_blank_attachment(value: Any) -> bool:
@@ -197,10 +233,13 @@ if _COMPOSIO_AVAILABLE:
         """LangchainProvider that patches tool schemas before delegating."""
 
         def wrap_tool(self, tool: Tool, execute_tool: Callable[..., Any]) -> StructuredTool:
-            _harden_schema(tool.input_parameters)
+            relax_attachment = _slug_needs_attachment_relaxation(tool.slug)
+            _harden_schema(tool.input_parameters, relax_attachment=relax_attachment)
 
             def safe_execute_tool(slug: str, arguments: dict) -> dict:
-                return execute_tool(slug, _strip_blank_attachment(arguments))
+                if relax_attachment:
+                    arguments = _strip_blank_attachment(arguments)
+                return execute_tool(slug, arguments)
 
             return super().wrap_tool(tool=tool, execute_tool=safe_execute_tool)
 
@@ -250,12 +289,15 @@ def _patch_file_helper_once() -> None:
     # keywords (composio/core/models/_files.py:236-240, :309-312), but pinning
     # the wrapper to a stricter signature would silently break if a future
     # release switches to positionals.
+    # No tool identity is available here (only the raw schema), so these stay
+    # on _sanitize_schema alone — never _harden_schema — since there is no
+    # slug to check against _slug_needs_attachment_relaxation.
     def safe_uploads(self, *args, **kwargs):
-        _harden_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
+        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
         return original_uploads(self, *args, **kwargs)
 
     def safe_downloads(self, *args, **kwargs):
-        _harden_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
+        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
         return original_downloads(self, *args, **kwargs)
 
     FileHelper._substitute_file_uploads_recursively = safe_uploads  # noqa: SLF001
@@ -282,8 +324,9 @@ def _patch_pydantic_builder_once() -> None:
 
     original_builder = _composio_shared.pydantic_model_from_param_schema
 
+    # No tool identity here either — same reasoning as safe_uploads/safe_downloads.
     def safe_builder(*args, **kwargs):
-        _harden_schema(_extract_schema_arg(args, kwargs, positional_index=0, keyword="param_schema"))
+        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=0, keyword="param_schema"))
         return original_builder(*args, **kwargs)
 
     _composio_shared.pydantic_model_from_param_schema = safe_builder

--- a/src/lfx/src/lfx/base/composio/safe_provider.py
+++ b/src/lfx/src/lfx/base/composio/safe_provider.py
@@ -12,6 +12,17 @@ We sanitize ``tool.input_parameters`` in-place at wrap time, and also patch
 both the FileHelper file-substitution helpers and the pydantic schema builder
 so the agent path, the direct ``execute_action`` path, and the legacy
 ``tools.get`` path all see a schema with a ``"type"`` for every node.
+
+We also relax the ``attachment`` field specifically: Composio's raw schemas
+for Gmail/Outlook send/draft actions mark the attachment object (or its
+sub-fields) as ``required``, even though a real attachment is optional, you
+simply omit it to send an email without one. Left alone, an LLM building a
+tool call sees "attachment" in ``required`` and has to invent an empty
+placeholder (e.g. ``{"name": "", "data": ""}``) to satisfy the schema, which
+then reaches the real Gmail/Outlook API and fails validation there instead.
+Langflow's own node-execution path (``ComposioBaseComponent``) already treats
+this field as optional; ``_relax_attachment_requirements`` mirrors that for
+the raw tool-calling schema.
 """
 
 from __future__ import annotations
@@ -99,14 +110,99 @@ def _sanitize_schema(schema: Any) -> None:
                 _sanitize_schema(sub)
 
 
+def _is_attachment_field(name: Any) -> bool:
+    """True for "attachment" itself or any dotted sub-field ("attachment.name")."""
+    return isinstance(name, str) and (name.lower() == "attachment" or name.lower().startswith("attachment."))
+
+
+def _relax_attachment_requirements(schema: Any) -> None:
+    """Recursively drop attachment-related entries from every ``required`` list.
+
+    See the module docstring: Composio's raw schema requires the attachment
+    field on actions where it's actually optional, which forces an LLM to
+    fabricate an empty placeholder to pass validation. This mutates ``schema``
+    in place, walking the same JSON-schema shapes ``_sanitize_schema`` does,
+    since a "required" list can appear at any nesting level (a top-level
+    action schema, a $defs entry, a union arm, etc.).
+    """
+    if not isinstance(schema, dict):
+        return
+
+    required = schema.get("required")
+    if isinstance(required, list):
+        schema["required"] = [name for name in required if not _is_attachment_field(name)]
+
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        for sub in properties.values():
+            _relax_attachment_requirements(sub)
+    items = schema.get("items")
+    if isinstance(items, dict):
+        _relax_attachment_requirements(items)
+    for union_key in ("anyOf", "oneOf", "allOf"):
+        for sub in schema.get(union_key, []) or []:
+            _relax_attachment_requirements(sub)
+    for defs_key in ("$defs", "definitions"):
+        defs = schema.get(defs_key)
+        if isinstance(defs, dict):
+            for sub in defs.values():
+                _relax_attachment_requirements(sub)
+
+
+def _harden_schema(schema: Any) -> None:
+    """Apply every schema patch (missing-``type`` + false-required-attachment) in one pass."""
+    _sanitize_schema(schema)
+    _relax_attachment_requirements(schema)
+
+
+def _is_blank_attachment(value: Any) -> bool:
+    """True for an attachment value with nothing real in it.
+
+    Covers the exact placeholder an LLM fabricates when it decides to submit
+    an "attachment" it was never actually asked for: ``{"name": "", "data":
+    ""}`` (every sub-field blank), or a bare empty string. A real attachment
+    always carries at least one non-empty field.
+    """
+    if value in (None, ""):
+        return True
+    if isinstance(value, dict):
+        return not any(v not in (None, "") for v in value.values())
+    return False
+
+
+def _strip_blank_attachment(arguments: Any) -> Any:
+    """Drop an ``attachment`` argument an LLM filled with only blank values.
+
+    ``_relax_attachment_requirements`` stops the schema from *forcing* an LLM
+    to supply attachment, but it can't stop a model from submitting one
+    anyway "to be safe" — that empty placeholder then passes local schema
+    validation (since the field is optional now) and reaches the real
+    Gmail/Outlook API, which rejects it there instead. This is the
+    execution-time half of the same fix: strip it right before the real call
+    goes out, exactly like ``ComposioBaseComponent.execute_action`` already
+    does for the direct node-execution path.
+    """
+    if not isinstance(arguments, dict) or "attachment" not in arguments:
+        return arguments
+    if not _is_blank_attachment(arguments["attachment"]):
+        return arguments
+    arguments = dict(arguments)
+    del arguments["attachment"]
+    return arguments
+
+
 if _COMPOSIO_AVAILABLE:
 
     class SafeLangchainProvider(LangchainProvider, name="langchain"):
         """LangchainProvider that patches tool schemas before delegating."""
 
         def wrap_tool(self, tool: Tool, execute_tool: Callable[..., Any]) -> StructuredTool:
-            _sanitize_schema(tool.input_parameters)
-            return super().wrap_tool(tool=tool, execute_tool=execute_tool)
+            _harden_schema(tool.input_parameters)
+
+            def safe_execute_tool(slug: str, arguments: dict) -> dict:
+                return execute_tool(slug, _strip_blank_attachment(arguments))
+
+            return super().wrap_tool(tool=tool, execute_tool=safe_execute_tool)
 
 
 def _extract_schema_arg(args: tuple, kwargs: dict, positional_index: int, keyword: str) -> Any:
@@ -155,11 +251,11 @@ def _patch_file_helper_once() -> None:
     # the wrapper to a stricter signature would silently break if a future
     # release switches to positionals.
     def safe_uploads(self, *args, **kwargs):
-        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
+        _harden_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
         return original_uploads(self, *args, **kwargs)
 
     def safe_downloads(self, *args, **kwargs):
-        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
+        _harden_schema(_extract_schema_arg(args, kwargs, positional_index=1, keyword="schema"))
         return original_downloads(self, *args, **kwargs)
 
     FileHelper._substitute_file_uploads_recursively = safe_uploads  # noqa: SLF001
@@ -187,7 +283,7 @@ def _patch_pydantic_builder_once() -> None:
     original_builder = _composio_shared.pydantic_model_from_param_schema
 
     def safe_builder(*args, **kwargs):
-        _sanitize_schema(_extract_schema_arg(args, kwargs, positional_index=0, keyword="param_schema"))
+        _harden_schema(_extract_schema_arg(args, kwargs, positional_index=0, keyword="param_schema"))
         return original_builder(*args, **kwargs)
 
     _composio_shared.pydantic_model_from_param_schema = safe_builder
@@ -248,3 +344,4 @@ def _patch_identifier_substitution_once() -> None:
 _patch_file_helper_once()
 _patch_pydantic_builder_once()
 _patch_identifier_substitution_once()
+

--- a/src/lfx/tests/unit/test_safe_provider.py
+++ b/src/lfx/tests/unit/test_safe_provider.py
@@ -206,14 +206,25 @@ class TestRelaxAttachmentRequirements:
 
 
 class TestHardenSchema:
-    """_harden_schema applies both the type-defaulting and attachment-relaxing patches."""
+    """_harden_schema always fixes types; attachment-relaxing is opt-in only."""
 
     def _get_fn(self):
         from lfx.base.composio.safe_provider import _harden_schema
 
         return _harden_schema
 
-    def test_applies_both_patches(self):
+    def test_relax_attachment_true_applies_both_patches(self):
+        schema = {
+            "properties": {"attachment": {}, "subject": {"type": "string"}},
+            "required": ["attachment", "subject"],
+        }
+        self._get_fn()(schema, relax_attachment=True)
+        assert schema["type"] == "object"
+        assert schema["properties"]["attachment"]["type"] == "string"
+        assert schema["required"] == ["subject"]
+
+    def test_default_does_not_relax_attachment(self):
+        """The default must stay False — most toolkits need attachment to stay required."""
         schema = {
             "properties": {"attachment": {}, "subject": {"type": "string"}},
             "required": ["attachment", "subject"],
@@ -221,7 +232,51 @@ class TestHardenSchema:
         self._get_fn()(schema)
         assert schema["type"] == "object"
         assert schema["properties"]["attachment"]["type"] == "string"
-        assert schema["required"] == ["subject"]
+        # Type got fixed, but "attachment" is still required — untouched.
+        assert schema["required"] == ["attachment", "subject"]
+
+    def test_relax_attachment_false_explicit_same_as_default(self):
+        schema = {"required": ["attachment"]}
+        self._get_fn()(schema, relax_attachment=False)
+        assert schema["required"] == ["attachment"]
+
+
+# ---------------------------------------------------------------------------
+# _slug_needs_attachment_relaxation
+# ---------------------------------------------------------------------------
+
+
+class TestSlugNeedsAttachmentRelaxation:
+    """The allowlist gate that scopes attachment relaxation to known-affected toolkits.
+
+    This is the regression guard for treating one Gmail action's schema
+    defect as a codebase-wide rule: only Gmail/Outlook slugs should ever
+    reach _relax_attachment_requirements or _strip_blank_attachment. Every
+    other toolkit (jira, dropbox, pandadoc, ...) must keep its own
+    "attachment" field's real required/optional status untouched.
+    """
+
+    def _get_fn(self):
+        from lfx.base.composio.safe_provider import _slug_needs_attachment_relaxation
+
+        return _slug_needs_attachment_relaxation
+
+    def test_gmail_slug_matches(self):
+        assert self._get_fn()("GMAIL_CREATE_EMAIL_DRAFT") is True
+
+    def test_outlook_slug_matches(self):
+        assert self._get_fn()("OUTLOOK_OUTLOOK_SEND_EMAIL") is True
+
+    def test_unrelated_toolkit_does_not_match(self):
+        assert self._get_fn()("JIRA_ATTACH_FILE_TO_ISSUE") is False
+        assert self._get_fn()("DROPBOX_UPLOAD_FILE") is False
+
+    def test_substring_match_is_not_enough_prefix_only(self):
+        assert self._get_fn()("SOME_GMAIL_ACTION") is False
+        assert self._get_fn()("gmail_lowercase_action") is False
+
+    def test_empty_string_does_not_match(self):
+        assert self._get_fn()("") is False
 
 
 # ---------------------------------------------------------------------------

--- a/src/lfx/tests/unit/test_safe_provider.py
+++ b/src/lfx/tests/unit/test_safe_provider.py
@@ -2,6 +2,8 @@
 
 Covers:
 - _sanitize_schema: adds missing 'type' keys recursively
+- _relax_attachment_requirements: drops attachment fields from 'required'
+  lists so an LLM isn't forced to fabricate an empty attachment payload
 - _patch_identifier_substitution_once: renames invalid Python identifiers in
   action schemas (e.g. 'extension-id' -> 'extension_id') and tracks the
   reverse mapping so the original name is restored when the API is called
@@ -103,6 +105,193 @@ class TestSanitizeSchema:
         self._get_fn()(None)
         self._get_fn()("string")
         self._get_fn()(42)
+
+
+# ---------------------------------------------------------------------------
+# _relax_attachment_requirements
+# ---------------------------------------------------------------------------
+
+
+class TestRelaxAttachmentRequirements:
+    """_relax_attachment_requirements drops attachment fields from 'required' lists.
+
+    Reproduces the GMAIL_CREATE_EMAIL_DRAFT / GMAIL_SEND_EMAIL failure mode:
+    Composio's raw schema marks "attachment" required even though it's
+    optional, so an LLM building a tool call fabricates an empty placeholder
+    ({"name": "", "data": ""}) to satisfy validation, which the real Gmail API
+    then rejects.
+    """
+
+    def _get_fn(self):
+        from lfx.base.composio.safe_provider import _relax_attachment_requirements
+
+        return _relax_attachment_requirements
+
+    def test_drops_bare_attachment_from_required(self):
+        schema = {
+            "type": "object",
+            "properties": {"subject": {"type": "string"}, "attachment": {"type": "string"}},
+            "required": ["subject", "attachment"],
+        }
+        self._get_fn()(schema)
+        assert schema["required"] == ["subject"]
+
+    def test_drops_dotted_attachment_subfields_from_required(self):
+        schema = {
+            "type": "object",
+            "properties": {"subject": {"type": "string"}},
+            "required": ["subject", "attachment.name", "attachment.data"],
+        }
+        self._get_fn()(schema)
+        assert schema["required"] == ["subject"]
+
+    def test_is_case_insensitive(self):
+        schema = {"required": ["Attachment", "ATTACHMENT.NAME", "subject"]}
+        self._get_fn()(schema)
+        assert schema["required"] == ["subject"]
+
+    def test_leaves_other_required_fields_untouched(self):
+        schema = {"required": ["to", "subject", "body"]}
+        self._get_fn()(schema)
+        assert schema["required"] == ["to", "subject", "body"]
+
+    def test_recurses_into_nested_properties(self):
+        schema = {
+            "properties": {
+                "email": {
+                    "properties": {"attachment": {"type": "string"}},
+                    "required": ["attachment"],
+                }
+            }
+        }
+        self._get_fn()(schema)
+        assert schema["properties"]["email"]["required"] == []
+
+    def test_recurses_into_defs(self):
+        schema = {"$defs": {"Email": {"required": ["attachment", "subject"]}}}
+        self._get_fn()(schema)
+        assert schema["$defs"]["Email"]["required"] == ["subject"]
+
+    def test_recurses_into_anyof(self):
+        schema = {"anyOf": [{"required": ["attachment"]}, {"required": ["subject"]}]}
+        self._get_fn()(schema)
+        assert schema["anyOf"][0]["required"] == []
+        assert schema["anyOf"][1]["required"] == ["subject"]
+
+    def test_noop_when_no_required_key(self):
+        schema = {"properties": {"attachment": {"type": "string"}}}
+        self._get_fn()(schema)
+        assert "required" not in schema
+
+    def test_noop_on_non_dict(self):
+        # Should not raise
+        self._get_fn()(None)
+        self._get_fn()("string")
+        self._get_fn()(42)
+
+    def test_does_not_mutate_properties(self):
+        """Only the required list is touched — the attachment property itself stays."""
+        schema = {
+            "properties": {"attachment": {"type": "string", "description": "File attachment"}},
+            "required": ["attachment"],
+        }
+        self._get_fn()(schema)
+        assert "attachment" in schema["properties"]
+        assert schema["required"] == []
+
+
+# ---------------------------------------------------------------------------
+# _harden_schema
+# ---------------------------------------------------------------------------
+
+
+class TestHardenSchema:
+    """_harden_schema applies both the type-defaulting and attachment-relaxing patches."""
+
+    def _get_fn(self):
+        from lfx.base.composio.safe_provider import _harden_schema
+
+        return _harden_schema
+
+    def test_applies_both_patches(self):
+        schema = {
+            "properties": {"attachment": {}, "subject": {"type": "string"}},
+            "required": ["attachment", "subject"],
+        }
+        self._get_fn()(schema)
+        assert schema["type"] == "object"
+        assert schema["properties"]["attachment"]["type"] == "string"
+        assert schema["required"] == ["subject"]
+
+
+# ---------------------------------------------------------------------------
+# _is_blank_attachment / _strip_blank_attachment
+# ---------------------------------------------------------------------------
+
+
+class TestIsBlankAttachment:
+    """_is_blank_attachment recognizes the placeholder an LLM fabricates."""
+
+    def _get_fn(self):
+        from lfx.base.composio.safe_provider import _is_blank_attachment
+
+        return _is_blank_attachment
+
+    def test_none_is_blank(self):
+        assert self._get_fn()(None) is True
+
+    def test_empty_string_is_blank(self):
+        assert self._get_fn()("") is True
+
+    def test_dict_with_all_blank_values_is_blank(self):
+        # The exact placeholder from the bug report.
+        assert self._get_fn()({"name": "", "data": ""}) is True
+
+    def test_dict_with_none_values_is_blank(self):
+        assert self._get_fn()({"name": None, "data": None}) is True
+
+    def test_empty_dict_is_blank(self):
+        assert self._get_fn()({}) is True
+
+    def test_dict_with_a_real_value_is_not_blank(self):
+        assert self._get_fn()({"name": "invoice.pdf", "data": ""}) is False
+
+    def test_nonempty_string_is_not_blank(self):
+        assert self._get_fn()("some-file-id") is False
+
+
+class TestStripBlankAttachment:
+    """_strip_blank_attachment drops a blank attachment, keeps a real one."""
+
+    def _get_fn(self):
+        from lfx.base.composio.safe_provider import _strip_blank_attachment
+
+        return _strip_blank_attachment
+
+    def test_drops_the_bug_reports_exact_placeholder(self):
+        arguments = {"subject": "test", "attachment": {"name": "", "data": ""}}
+        result = self._get_fn()(arguments)
+        assert result == {"subject": "test"}
+
+    def test_keeps_a_real_attachment(self):
+        arguments = {"subject": "test", "attachment": {"name": "invoice.pdf", "data": "base64=="}}
+        result = self._get_fn()(arguments)
+        assert result == arguments
+
+    def test_noop_when_no_attachment_key(self):
+        arguments = {"subject": "test"}
+        result = self._get_fn()(arguments)
+        assert result == arguments
+
+    def test_does_not_mutate_the_original_dict(self):
+        arguments = {"subject": "test", "attachment": {"name": "", "data": ""}}
+        original = dict(arguments)
+        self._get_fn()(arguments)
+        assert arguments == original
+
+    def test_noop_on_non_dict(self):
+        assert self._get_fn()(None) is None
+        assert self._get_fn()("not a dict") == "not a dict"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Composio Gmail component fails to draft or send email when used as an Agent tool (Tool Mode), even when no attachment was requested.

Prompt:

    Draft an email to myself with subject 'test'

Observed result:
GMAIL_CREATE_EMAIL_DRAFT fails with "Tool input validation error".

The tool call generated by the LLM consistently includes:

    "attachment": { "name": "", "data": "" }

The same Gmail action works correctly as a regular flow node (non-tool path). The defect is Tool Mode specific.

## Root Cause

Two separate schema-building paths are used for the same Gmail action:

1. Regular node execution (ComposioBaseComponent.execute_action)
   Uses Langflow hand-built schema, which already:
   - marks attachment as optional
   - skips attachment when empty

2. Tool Mode (configure_tools -> composio.tools.get(...))
   Uses Composio SDK raw schema directly, bypassing Langflow schema handling.

In Composio raw schema, attachment is incorrectly marked as required even though it is optional in practice. The LLM sees attachment as required and fabricates an empty placeholder to satisfy validation, causing failure either:
- at tool input validation, or
- downstream at Gmail API level.

This is the same class of issue safe_provider.py already exists to patch (raw schema defects in the tool-calling path, including prior _sanitize_schema handling for missing type keys and related Composio issues #12894/#12895). That earlier patch did not cover false positives in required.

## Fix

Implemented in safe_provider.py, through the existing SafeLangchainProvider.wrap_tool patch point, with two defenses:

### 1. Schema-level hardening: _relax_attachment_requirements

Recursively removes attachment / attachment.* from every required list in a tool schema, including nested locations:
- top-level objects
- $defs
- anyOf / oneOf / allOf branches

Effect: The LLM is no longer forced to send attachment.

### 2. Execution-level hardening: _strip_blank_attachment

Intercepts tool input immediately before Composio API execution and removes attachment when blank:
- None
- empty string ""
- object where all fields are empty

Effect: Even if the LLM still sends a placeholder attachment, it is stripped before API call, preventing Gmail-side rejection.

Both are applied together via _harden_schema, alongside existing _sanitize_schema, at all four schema-touching locations in this file.

## Automated Testing

### Unit tests (schema + sanitization logic)

- 15 new tests in src/lfx/tests/unit/test_safe_provider.py
- Fake-schema style (does not require composio package)
- Covers:
  - bare / dotted / case-insensitive attachment stripping
  - recursion through nested schema shapes
  - preserving property definitions (non-mutation of schema property itself)
  - blank-attachment detection and stripping behavior in isolation

### Integration tests (real schema shape + wrap_tool path)

- 5 new tests in src/backend/tests/unit/components/bundles/composio/test_safe_provider.py
- Guarded by pytest.importorskip (runs only when composio extra is installed)
- Covers:
  - reproducing real GMAIL_CREATE_EMAIL_DRAFT schema shape from bug report
  - verifying hardened schema allows payloads with attachment omitted (via real Pydantic model)
  - end-to-end SafeLangchainProvider.wrap_tool behavior using exact bug payload
  - confirming blank attachment is stripped before underlying execute_tool
  - confirming real non-blank attachment still passes through untouched

### Regression proof

- Stash-revert check confirms new tests fail without this fix.

## QA on Canvas (Manual Verification)

This bug depends on real schema/tool behavior from Composio + Gmail OAuth, so full reproduction requires a live Composio/Gmail setup.

### Setup

1. Ensure backend has Composio packages installed:
   - uv sync --extra bundles
   - or uv pip install "lfx-bundles[composio]" (lighter one-off)
2. Restart backend after install and code fix.
3. Open/create a flow with an Agent and attach a real LLM.
4. Add Gmail from Bundles -> Composio -> Gmail.
5. Configure COMPOSIO_API_KEY and complete Gmail OAuth.

### Verify original Tool Mode bug is fixed

1. Turn Tool Mode ON for Gmail.
2. Connect Gmail tool output to Agent tools input.
3. In Playground, start a new chat session.
4. Send:

       Draft an email to myself with subject 'test'

5. Expected:
   - Draft creation succeeds
   - No "Tool input validation error"
   - No Gmail rejected-attachment error
6. Expand tool-call trace and confirm GMAIL_CREATE_EMAIL_DRAFT:
   - omits attachment, or
   - contains only real non-blank attachment data

### Non-tool path regression check

1. Use Gmail node with Tool Mode OFF.
2. Select GMAIL_CREATE_EMAIL_DRAFT.
3. Fill recipient/subject/body, leave attachment empty.
4. Run node directly.
5. Expected: Works unchanged (this path was not impacted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gmail draft and send workflows so attachment fields are no longer incorrectly required.
  * Blank attachment placeholders are removed before tool execution, while valid attachments are preserved.
  * Improved compatibility with attachment schemas across nested tool definitions.

* **Tests**
  * Added coverage for optional attachment handling, schema hardening, blank placeholders, and preservation of genuine attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->