### PR TITLE
fix(release): advance lfx-bundles to 1.1.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ Documentation = "https://docs.langflow.org"
 
 [project.optional-dependencies]
 bundles = [
-    "lfx-bundles[all-no-torch]>=1.1.20,<2.0",
+    "lfx-bundles[all-no-torch]>=1.1.23,<2.0",
     "lfx-arxiv>=0.1.5,<1.0.0",
     "lfx-confluent>=0.1.0,<1.0.0",
     "lfx-duckduckgo>=0.1.5,<1.0.0",

--- a/src/bundles/lfx-bundles/pyproject.toml
+++ b/src/bundles/lfx-bundles/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lfx-bundles"
-version = "1.1.20"
+version = "1.1.23"
 description = "Langflow's long-tail provider bundles as a single manifest-less metapackage (the langchain-community model)."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -9393,7 +9393,7 @@ requires-dist = [
 
 [[package]]
 name = "lfx-bundles"
-version = "1.1.20"
+version = "1.1.23"
 source = { editable = "src/bundles/lfx-bundles" }
 dependencies = [
     { name = "lfx" },


### PR DESCRIPTION
The v1.12.1 release stops during bundle artifact planning because its lfx-bundles version (1.1.20) trails the public PyPI version (1.1.22).

Bump lfx-bundles to 1.1.23, raise Langflow's corresponding dependency floor, and regenerate uv.lock. The artifact plan now reuses the other 23 matching public bundles and publishes only lfx-bundles 1.1.23.

Validation: 59 bundle release/profile/prerelease tests passed; all 24 wheels built and passed public-index artifact planning; bundle change-plan validation, uv lock --check, and pre-commit hooks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the optional bundles component to version 1.1.23 or later, while retaining compatibility with versions below 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->