### PR TITLE
fix: preserve restricted-component diagnostics in streamed errors

### DIFF
--- a/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
+++ b/scripts/ci/bundle_profile_locks/enterprise-hardened.lock.json
@@ -2,14 +2,14 @@
   "application": {
     "distribution": "langflow",
     "requested": ">=1.12.0,<1.13.0",
-    "requirement": "langflow==1.12.1",
-    "resolved_version": "1.12.1"
+    "requirement": "langflow==1.12.2",
+    "resolved_version": "1.12.2"
   },
   "bundle_api": {
     "distribution": "lfx",
     "requested": ">=1.12.0.dev0,<1.13.0",
-    "requirement": "lfx==1.12.1",
-    "resolved_version": "1.12.1"
+    "requirement": "lfx==1.12.2",
+    "resolved_version": "1.12.2"
   },
   "bundles": [
     {

--- a/scripts/ci/test_bundle_profiles.py
+++ b/scripts/ci/test_bundle_profiles.py
@@ -18,6 +18,7 @@ from manage_bundle_profiles import (
     compile_profile,
     discover_bundle_catalog,
     read_json,
+    read_project,
     validate_contract,
     validate_installed,
 )
@@ -50,11 +51,13 @@ def test_profile_compilation_is_deterministic() -> None:
 
     first = compile_profile(contract, "enterprise-hardened", catalog)
     second = compile_profile(contract, "enterprise-hardened", catalog)
+    root_project = read_project(REPO_ROOT / "pyproject.toml")
+    lfx_project = read_project(REPO_ROOT / "src" / "lfx" / "pyproject.toml")
 
     assert first == second
     assert first["image_families"] == ["enterprise-ubi-hardened"]
-    assert first["application"]["requirement"] == "langflow==1.12.1"
-    assert first["bundle_api"]["requirement"] == "lfx==1.12.1"
+    assert first["application"]["requirement"] == f"langflow=={root_project['version']}"
+    assert first["bundle_api"]["requirement"] == f"lfx=={lfx_project['version']}"
     assert first["bundles"] == sorted(first["bundles"], key=lambda item: item["distribution"])
 
 

--- a/src/frontend/src/pages/FlowPage/components/flowBuildingComponent/__tests__/index.test.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowBuildingComponent/__tests__/index.test.tsx
@@ -1,15 +1,17 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
-import { useEffect } from "react";
+import { act, render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
 import FlowBuildingComponent from "../index";
 
 // Mock dependencies
 jest.mock("framer-motion", () => {
-  const React = require("react");
+  const React = jest.requireActual<typeof import("react")>("react");
   return {
-    AnimatePresence: ({ children }: any) => <div>{children}</div>,
+    AnimatePresence: ({ children }: { children?: ReactNode }) => (
+      <div>{children}</div>
+    ),
     motion: {
-      div: React.forwardRef(
-        ({ children, className, ...props }: any, ref: any) => (
+      div: React.forwardRef<HTMLDivElement, ComponentProps<"div">>(
+        ({ children, className, ...props }, ref) => (
           <div ref={ref} className={className} {...props}>
             {children}
           </div>
@@ -21,7 +23,7 @@ jest.mock("framer-motion", () => {
 
 jest.mock("react-markdown", () => ({
   __esModule: true,
-  default: ({ children }: any) => <div>{children}</div>,
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 
 jest.mock("remark-gfm", () => ({
@@ -38,7 +40,7 @@ jest.mock(
 
 jest.mock("@/components/common/genericIconComponent", () => ({
   __esModule: true,
-  default: ({ name, className }: any) => (
+  default: ({ name, className }: { name: string; className?: string }) => (
     <div data-testid={`icon-${name}`} className={className}>
       {name}
     </div>
@@ -50,7 +52,12 @@ jest.mock("@/components/core/border-trail", () => ({
 }));
 
 jest.mock("@/components/ui/button", () => ({
-  Button: ({ children, onClick, "data-testid": testId, ...props }: any) => (
+  Button: ({
+    children,
+    onClick,
+    "data-testid": testId,
+    ...props
+  }: ComponentProps<"button"> & { "data-testid"?: string }) => (
     <button onClick={onClick} data-testid={testId} {...props}>
       {children}
     </button>
@@ -58,13 +65,13 @@ jest.mock("@/components/ui/button", () => ({
 }));
 
 jest.mock("@/components/ui/TextShimmer", () => ({
-  TextShimmer: ({ children }: any) => (
+  TextShimmer: ({ children }: { children?: ReactNode }) => (
     <div data-testid="text-shimmer">{children}</div>
   ),
 }));
 
 jest.mock("@/utils/utils", () => ({
-  cn: (...classes: any[]) => classes.filter(Boolean).join(" "),
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(" "),
 }));
 
 jest.mock("@/constants/enums", () => ({
@@ -82,12 +89,12 @@ const mockBuildFlow = jest.fn();
 
 let mockIsBuilding = false;
 let mockFlowBuildStatus = {};
-let mockBuildInfo: any = null;
-let mockPastBuildFlowParams: any = null;
+let mockBuildInfo: { error?: string[]; success?: boolean } | null = null;
+let mockPastBuildFlowParams: Record<string, unknown> | null = null;
 
 jest.mock("@/stores/flowStore", () => ({
   __esModule: true,
-  default: (selector: any) => {
+  default: (selector: (state: Record<string, unknown>) => unknown) => {
     const state = {
       isBuilding: mockIsBuilding,
       flowBuildStatus: mockFlowBuildStatus,
@@ -255,6 +262,21 @@ describe("FlowBuildingComponent - Timer Tests", () => {
 
       expect(screen.getByText("Flow build failed")).toBeInTheDocument();
       expect(screen.getByTestId("icon-CircleAlert")).toBeInTheDocument();
+    });
+
+    it("makes the full error and policy explanation keyboard accessible", () => {
+      const error = "No model selected. Please select a language model.";
+      const note =
+        "Note: custom components are disabled on this server (LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false).";
+      mockBuildInfo = { error: [`${error}\n\n${note}`] };
+
+      render(<FlowBuildingComponent />);
+
+      const details = screen.getByRole("region", { name: "Flow build failed" });
+      expect(details).toHaveTextContent(error);
+      expect(details).toHaveTextContent(note);
+      details.focus();
+      expect(details).toHaveFocus();
     });
 
     it("should show stop button when building", () => {

--- a/src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx
+++ b/src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx
@@ -251,6 +251,10 @@ export default function FlowBuildingComponent() {
                   <AnimatePresence>
                     {buildInfo?.error && (
                       <motion.div
+                        role="region"
+                        aria-label={t("flowBuild.buildFailed")}
+                        tabIndex={0}
+                        className="max-h-48 overflow-y-auto"
                         initial={{ opacity: 0, height: 0 }}
                         animate={{ opacity: 1, height: "auto" }}
                         exit={{ opacity: 0, height: 0 }}
@@ -258,7 +262,7 @@ export default function FlowBuildingComponent() {
                       >
                         <Markdown
                           remarkPlugins={[remarkGfm]}
-                          className="my-1.5 align-text-top truncate-doubleline"
+                          className="my-1.5 break-words [&>p+p]:mt-2"
                           components={{
                             a: ({ node, ...props }) => (
                               <a
@@ -270,13 +274,6 @@ export default function FlowBuildingComponent() {
                                 {props.children}
                               </a>
                             ),
-                            p({ node, ...props }) {
-                              return (
-                                <span className="inline-block w-fit max-w-full align-text-top truncate-doubleline">
-                                  {props.children}
-                                </span>
-                              );
-                            },
                           }}
                         >
                           {buildInfo?.error?.join("\n")}

--- a/src/lfx/src/lfx/custom/custom_component/component.py
+++ b/src/lfx/src/lfx/custom/custom_component/component.py
@@ -2310,12 +2310,23 @@ class Component(CustomComponent):
         flow_id = self.graph.flow_id if hasattr(self, "graph") else None
         if not session_id:
             return None
+        # AG-UI treats this first error event as terminal, before Vertex can enrich
+        # the raised exception. Include the same diagnosis on the emitted message.
+        from lfx.utils.flow_validation import explain_restricted_component_mismatch
+
+        vertex_data = getattr(self._vertex, "data", None)
+        context_note = (
+            explain_restricted_component_mismatch(vertex_data.get("type"), vertex_data.get("node"))
+            if isinstance(vertex_data, Mapping)
+            else None
+        )
         error_message = ErrorMessage(
             flow_id=flow_id,
             exception=exception,
             session_id=session_id,
             trace_name=trace_name,
             source=source,
+            context_note=context_note,
         )
         await self.send_message(error_message)
         return error_message

--- a/src/lfx/src/lfx/schema/message.py
+++ b/src/lfx/src/lfx/schema/message.py
@@ -941,6 +941,7 @@ class ErrorMessage(Message):
         session_metadata: dict | None = None,
         *,
         include_traceback: bool = True,
+        context_note: str | None = None,
     ) -> None:
         # This is done to avoid circular imports
         if exception.__class__.__name__ == "ExceptionWithMessageError" and exception.__cause__ is not None:
@@ -948,6 +949,11 @@ class ErrorMessage(Message):
 
         plain_reason = self._format_plain_reason(exception)
         markdown_reason = self._format_markdown_reason(exception)
+        # Keep the original exception's formatting and metadata while adding
+        # diagnostic context to both the streamed text and the error details.
+        if context_note:
+            plain_reason = f"{plain_reason.rstrip()}\n\n{context_note}\n"
+            markdown_reason = f"{markdown_reason.rstrip()}\n\n{context_note}\n"
         # Get the sender ID
         if trace_name:
             match = re.search(r"\((.*?)\)", trace_name)

--- a/src/lfx/src/lfx/utils/flow_validation.py
+++ b/src/lfx/src/lfx/utils/flow_validation.py
@@ -1408,7 +1408,7 @@ def describe_restricted_component_mismatch(component_type: Any, node_info: Any) 
 def explain_restricted_component_mismatch(component_type: Any, node_info: Any) -> str | None:
     """Never-raising wrapper for :func:`describe_restricted_component_mismatch`.
 
-    The only caller is a build-error handler, where a diagnostic that raises would replace the
+    Callers are build-error handlers, where a diagnostic that raises would replace the
     component's real error with an unrelated one.
     """
     try:

--- a/src/lfx/tests/unit/utils/test_restricted_component_mismatch.py
+++ b/src/lfx/tests/unit/utils/test_restricted_component_mismatch.py
@@ -193,12 +193,16 @@ async def test_first_streamed_error_carries_the_diagnosis(monkeypatch, allow_cus
     from lfx.events.event_manager import EventManager
     from lfx.exceptions.component import ComponentBuildError
     from lfx.graph import Graph
+    from lfx.interface import components as components_module
     from lfx.services.deps import get_settings_service
     from lfx.workflow.agui_translator import AGUITranslator
 
     registry = dict(json.loads(files("lfx").joinpath("_assets/component_index.json").read_text())["entries"])
-    monkeypatch.setattr(component_cache, "all_types_dict", registry)
-    monkeypatch.setattr(component_cache, "all_types_ready", True)
+    # Keep the registry and its derived lookups isolated from earlier tests.
+    cache = components_module.ComponentCache()
+    cache.all_types_dict = registry
+    cache.all_types_ready = True
+    monkeypatch.setattr(components_module, "component_cache", cache)
     settings = get_settings_service().settings
     monkeypatch.setattr(settings, "allow_custom_components", allow_custom)
     monkeypatch.setattr(settings, "substitute_outdated_component_code", True)

--- a/src/lfx/tests/unit/utils/test_restricted_component_mismatch.py
+++ b/src/lfx/tests/unit/utils/test_restricted_component_mismatch.py
@@ -11,6 +11,9 @@ These tests pin the diagnosis appended to such a failure, and the cases it must 
 """
 
 import asyncio
+import json
+from copy import deepcopy
+from importlib.resources import files
 from types import SimpleNamespace
 
 import pytest
@@ -153,7 +156,7 @@ def test_explain_never_raises(monkeypatch):
     assert explain_restricted_component_mismatch("Agent", _customized_agent()) is None
 
 
-def test_build_error_carries_the_diagnosis(monkeypatch):
+async def test_build_error_carries_the_diagnosis(monkeypatch):
     """The failure a user actually sees names the policy, not just the stock component's complaint."""
     from lfx.exceptions.component import ComponentBuildError
     from lfx.graph.vertex.base import Vertex
@@ -172,9 +175,75 @@ def test_build_error_carries_the_diagnosis(monkeypatch):
     vertex.graph = SimpleNamespace(flow_id=None)
 
     with pytest.raises(ComponentBuildError) as excinfo:
-        asyncio.run(vertex._build_results(custom_component=None, custom_params={}, base_type="component"))
+        await vertex._build_results(custom_component=None, custom_params={}, base_type="component")
 
     message = str(excinfo.value)
     assert "No model selected" in message
     assert "LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false" in message
     assert "missing required input: model" in message
+
+
+@pytest.mark.parametrize(
+    ("allow_custom", "customized", "expect_hint"),
+    [(False, True, True), (False, False, False), (True, True, False)],
+)
+async def test_first_streamed_error_carries_the_diagnosis(monkeypatch, allow_custom, customized, expect_hint):
+    """The real Agent emits an error before the vertex wraps it; AG-UI stops on that first event."""
+    from ag_ui.core import RunErrorEvent
+    from lfx.events.event_manager import EventManager
+    from lfx.exceptions.component import ComponentBuildError
+    from lfx.graph import Graph
+    from lfx.services.deps import get_settings_service
+    from lfx.workflow.agui_translator import AGUITranslator
+
+    registry = dict(json.loads(files("lfx").joinpath("_assets/component_index.json").read_text())["entries"])
+    monkeypatch.setattr(component_cache, "all_types_dict", registry)
+    monkeypatch.setattr(component_cache, "all_types_ready", True)
+    settings = get_settings_service().settings
+    monkeypatch.setattr(settings, "allow_custom_components", allow_custom)
+    monkeypatch.setattr(settings, "substitute_outdated_component_code", True)
+    saved = deepcopy(registry["models_and_agents"]["Agent"])
+    if customized:
+        saved["template"].pop("model")
+        saved["template"]["code"]["value"] += "\n# Customized Agent\n"
+        saved["template"]["provider"] = {
+            "name": "provider",
+            "type": "str",
+            "value": "",
+            "required": True,
+            "show": True,
+        }
+    node = {"id": "Agent-repro", "data": {"id": "Agent-repro", "type": "Agent", "node": saved}}
+    graph = Graph.from_payload({"nodes": [node], "edges": []}, emit_extension_events=False)
+    graph.set_run_id()
+    graph.session_id = "restricted-component-stream-test"
+    graph.persist_messages = False
+    vertex = graph.get_vertex("Agent-repro")
+    queue = asyncio.Queue()
+    event_manager = EventManager(queue)
+    event_manager.register_event("on_error", "error")
+    vertex.custom_component.set_event_manager(event_manager)
+
+    with pytest.raises(ComponentBuildError, match="No model selected") as excinfo:
+        await vertex._build_results(custom_component=vertex.custom_component, custom_params={}, base_type="component")
+
+    _, raw, _ = await asyncio.wait_for(queue.get(), timeout=1)
+    payload = json.loads(raw)
+    events = AGUITranslator(run_id="run", thread_id=graph.session_id).translate(payload["event"], payload["data"])
+    assert len(events) == 1
+    assert isinstance(events[0], RunErrorEvent)
+    assert "No model selected" in events[0].message
+    assert ("LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false" in events[0].message) is expect_hint
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert ("LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false" in str(excinfo.value)) is expect_hint
+    if expect_hint:
+        assert "missing required input: model" in events[0].message
+        reasons = [
+            content["reason"]
+            for block in payload["data"]["content_blocks"]
+            for content in block.get("contents", [])
+            if content["type"] == "error"
+        ]
+        assert len(reasons) == 1
+        assert "ValueError" in reasons[0]
+        assert "LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false" in reasons[0]


### PR DESCRIPTION
A customized Agent in restricted mode emits “No model selected” before the vertex adds the policy explanation from #14931. AG-UI treats that first error as terminal, so the canvas never receives the explanation.

Add the diagnosis before the component emits its error, preserving the original exception and including the note in both streamed text and structured error details. Make the popup's full message keyboard-scrollable instead of clamping it to two lines.

Refresh the enterprise bundle profile lock for version 1.12.2 and derive the profile test's expected versions from package metadata.

Validation: the real-Agent regression fails on the base and passes with this fix; permissive mode and matching components stay unchanged. The regression uses an isolated registry cache and passes with a preloaded cache on Python 3.10 and 3.14. Full LFX unit suite on Python 3.14: 8,124 passed, 51 skipped, 5 xfailed, 2 xpassed. Related LFX tests on Python 3.10: 223 passed. Frontend tests: 27 passed. CI release-script tests: 151 passed. Ruff, Biome, and commit hooks passed. A Playwright component preview confirmed the note renders and keyboard scrolling reaches the end.

Follow-up to #14931. Targets `release-1.12.2` after its separate version-bump commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Flow build error messages are now presented in a focusable, labeled region, helping keyboard and assistive-technology users quickly locate failures.

- **Bug Fixes**
  - Long error explanations now wrap correctly and display complete paragraphs instead of being truncated.
  - Build errors include additional diagnostic context when a restricted component configuration causes the failure.
  - Error details remain consistent across displayed messages and streamed error events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
