### PR TITLE
fix: stop double-prefixing catalog policy CHECK names under naming conventions

### DIFF
--- a/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
+++ b/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
@@ -43,14 +43,6 @@ _REQUIRED_INDEX_COLUMNS = (
     "scope",
     "domain_id",
 )
-_REQUIRED_CHECKS = frozenset(
-    {
-        "ck_catalog_policy_rule_resource_kind",
-        "ck_catalog_policy_rule_mode",
-        "ck_catalog_policy_rule_scope",
-        "ck_catalog_policy_rule_scope_domain_consistency",
-    }
-)
 _SCHEMA_REMEDIATION = "Resolve the conflicting schema before rerunning this migration"
 _CHECK_COLUMNS = ("resource_kind", "mode", "scope", "domain_id")
 _SQLITE_UUID_LENGTH = 32
@@ -392,29 +384,36 @@ def _current_check_sql() -> dict[str, object]:
     }
 
 
-def _matches_check_contract(reflected: Mapping[str, object], expected: Mapping[str, object]) -> bool:
-    """Return whether reflected checks satisfy one complete contract.
+def _unmatched_check_names(reflected: Mapping[str, object], expected: Mapping[str, object]) -> list[str]:
+    """Return the expected check names whose definition no reflected check satisfies.
 
-    Names are matched by definition, not literally: a name depends on the
-    naming-convention state when the table was created (plain, doubled
-    ck_<table>_ prefix, or PostgreSQL's truncated + hash-suffixed form), so it
-    is not a stable contract identifier. Compare parsed definitions instead,
-    consuming one reflected constraint per expected definition.
+    Checks are matched by parsed definition, never by name: a name depends on
+    the naming-convention state when the table was created (plain, doubled
+    ``ck_<table>_`` prefix, or PostgreSQL's truncated + hash-suffixed form), so
+    it is not a stable contract identifier. Each reflected check can satisfy at
+    most one expected definition, and unparsable reflected checks satisfy none.
     """
-    if len(expected) != len(reflected):
-        return False
-    remaining_asts: list[tuple[object, ...]] = []
-    for sqltext in reflected.values():
-        reflected_ast = _check_ast(sqltext)
-        if reflected_ast is None:
-            return False
-        remaining_asts.append(reflected_ast)
-    for sqltext in expected.values():
+    remaining_asts = [ast for ast in (_check_ast(sqltext) for sqltext in reflected.values()) if ast is not None]
+    unmatched: list[str] = []
+    for name, sqltext in expected.items():
         expected_ast = _check_ast(sqltext)
         if expected_ast is None or expected_ast not in remaining_asts:
-            return False
+            unmatched.append(name)
+            continue
         remaining_asts.remove(expected_ast)
-    return True
+    return unmatched
+
+
+def _matches_check_contract(reflected: Mapping[str, object], expected: Mapping[str, object]) -> bool:
+    """Return whether reflected checks satisfy one complete contract."""
+    return len(reflected) == len(expected) and not _unmatched_check_names(reflected, expected)
+
+
+def _missing_check_names(reflected: Mapping[str, object], expected: Mapping[str, object]) -> list[str]:
+    """Return unmatched expected checks when the table holds fewer checks than the contract."""
+    if len(reflected) >= len(expected):
+        return []
+    return _unmatched_check_names(reflected, expected)
 
 
 def _validate_check_constraints(inspector: Inspector) -> None:
@@ -437,8 +436,8 @@ def _validate_check_constraints(inspector: Inspector) -> None:
     ):
         return
 
-    missing_baseline = _REQUIRED_CHECKS - reflected.keys()
-    missing_current = current.keys() - reflected.keys()
+    missing_baseline = _missing_check_names(reflected, _BASELINE_CHECK_SQL)
+    missing_current = _missing_check_names(reflected, current)
     if missing_baseline and missing_current:
         missing = sorted(missing_baseline if len(missing_baseline) <= len(missing_current) else missing_current)
         detail = f"{TABLE_NAME} exists but is missing required check constraints: {missing}"

--- a/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
+++ b/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
@@ -393,14 +393,27 @@ def _current_check_sql() -> dict[str, object]:
 
 
 def _matches_check_contract(reflected: Mapping[str, object], expected: Mapping[str, object]) -> bool:
-    """Return whether reflected checks satisfy one complete contract."""
-    if expected.keys() != reflected.keys():
+    """Return whether reflected checks satisfy one complete contract.
+
+    Names are matched by definition, not literally: a name depends on the
+    naming-convention state when the table was created (plain, doubled
+    ck_<table>_ prefix, or PostgreSQL's truncated + hash-suffixed form), so it
+    is not a stable contract identifier. Compare parsed definitions instead,
+    consuming one reflected constraint per expected definition.
+    """
+    if len(expected) != len(reflected):
         return False
-    for name, sqltext in expected.items():
-        reflected_ast = _check_ast(reflected[name])
-        expected_ast = _check_ast(sqltext)
-        if reflected_ast is None or expected_ast is None or reflected_ast != expected_ast:
+    remaining_asts: list[tuple[object, ...]] = []
+    for sqltext in reflected.values():
+        reflected_ast = _check_ast(sqltext)
+        if reflected_ast is None:
             return False
+        remaining_asts.append(reflected_ast)
+    for sqltext in expected.values():
+        expected_ast = _check_ast(sqltext)
+        if expected_ast is None or expected_ast not in remaining_asts:
+            return False
+        remaining_asts.remove(expected_ast)
     return True
 
 
@@ -814,19 +827,19 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_resource_kind"],
-                name="ck_catalog_policy_rule_resource_kind",
+                name=op.f("ck_catalog_policy_rule_resource_kind"),
             ),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_mode"],
-                name="ck_catalog_policy_rule_mode",
+                name=op.f("ck_catalog_policy_rule_mode"),
             ),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_scope"],
-                name="ck_catalog_policy_rule_scope",
+                name=op.f("ck_catalog_policy_rule_scope"),
             ),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_scope_domain_consistency"],
-                name="ck_catalog_policy_rule_scope_domain_consistency",
+                name=op.f("ck_catalog_policy_rule_scope_domain_consistency"),
             ),
         )
 

--- a/src/backend/base/langflow/services/database/models/catalog_policy/model.py
+++ b/src/backend/base/langflow/services/database/models/catalog_policy/model.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import sqlalchemy as sa
 from sqlalchemy import CheckConstraint, Column, ForeignKey, Index, text
+from sqlalchemy.sql.naming import conv
 from sqlmodel import Field, SQLModel
 from sqlmodel.sql.sqltypes import AutoString
 
@@ -76,19 +77,19 @@ class CatalogPolicyRule(SQLModel, table=True):  # type: ignore[call-arg]
     __table_args__ = (
         CheckConstraint(
             _RESOURCE_KIND_CHECK,
-            name="ck_catalog_policy_rule_resource_kind",
+            name=conv("ck_catalog_policy_rule_resource_kind"),
         ),
         CheckConstraint(
             _MODE_CHECK,
-            name="ck_catalog_policy_rule_mode",
+            name=conv("ck_catalog_policy_rule_mode"),
         ),
         CheckConstraint(
             _SCOPE_CHECK,
-            name="ck_catalog_policy_rule_scope",
+            name=conv("ck_catalog_policy_rule_scope"),
         ),
         CheckConstraint(
             _SCOPE_DOMAIN_CHECK,
-            name="ck_catalog_policy_rule_scope_domain_consistency",
+            name=conv("ck_catalog_policy_rule_scope_domain_consistency"),
         ),
         Index(
             "uq_catalog_policy_rule_scoped",

--- a/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
+++ b/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
@@ -693,3 +693,121 @@ def test_catalog_policy_migration_accepts_model_created_table_without_writes(db_
             assert row_count == 0
     finally:
         engine.dispose()
+
+
+# Mirrors the ``ck`` entry of NAMING_CONVENTION in ``langflow/alembic/env.py``.
+_NAMING_CONVENTION = {"ck": "ck_%(table_name)s_%(constraint_name)s"}
+_DOUBLED_PREFIX = f"ck_{_MIGRATION.TABLE_NAME}_ck_{_MIGRATION.TABLE_NAME}_"
+_LEGACY_POSTGRES_CHECK_NAMES = {
+    "ck_catalog_policy_rule_resource_kind": f"{_DOUBLED_PREFIX}resource_kind",
+    "ck_catalog_policy_rule_mode": f"{_DOUBLED_PREFIX}mode",
+    "ck_catalog_policy_rule_scope": f"{_DOUBLED_PREFIX}scope",
+    # The doubled name is 70 characters, so PostgreSQL DDL truncates it to the
+    # 63-character limit with SQLAlchemy's md5 suffix (GH #15006).
+    "ck_catalog_policy_rule_scope_domain_consistency": f"{_DOUBLED_PREFIX}scope_dom_f5d9",
+}
+_LEGACY_POSTGRES_REFLECTED_CHECKS = {
+    _LEGACY_POSTGRES_CHECK_NAMES[name]: sqltext for name, sqltext in _POSTGRES_REFLECTED_CHECKS.items()
+}
+
+
+class _ReflectedCheckInspector:
+    def __init__(self, checks: dict[str, str]) -> None:
+        self._checks = checks
+
+    def get_check_constraints(self, _table_name: str) -> list[dict[str, object]]:
+        return [{"name": name, "sqltext": sqltext} for name, sqltext in self._checks.items()]
+
+
+def _convention_operations(connection: sa.Connection) -> Operations:
+    """Build Operations the way env.py does: create_table inherits the naming convention."""
+    return Operations(
+        MigrationContext.configure(
+            connection,
+            opts={"target_metadata": sa.MetaData(naming_convention=_NAMING_CONVENTION)},
+        )
+    )
+
+
+def test_catalog_policy_migration_creates_single_prefix_check_names_under_naming_convention(
+    db_url,  # noqa: F811
+    monkeypatch,
+):
+    """GH #15006: op.f() keeps the migration-created names from being re-prefixed."""
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        User.__table__.create(engine, checkfirst=True)
+
+        with engine.begin() as connection:
+            monkeypatch.setattr(_MIGRATION, "op", _convention_operations(connection))
+            _MIGRATION.upgrade()
+
+            checks = {
+                constraint["name"] for constraint in sa.inspect(connection).get_check_constraints(_MIGRATION.TABLE_NAME)
+            }
+            assert checks == set(_VALID_CHECKS)
+
+            _MIGRATION.upgrade()
+    finally:
+        engine.dispose()
+
+
+def test_catalog_policy_migration_accepts_legacy_double_prefixed_check_names(db_url, monkeypatch):  # noqa: F811
+    """GH #15006: tables created before the fix carry doubled names and must still validate."""
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        User.__table__.create(engine, checkfirst=True)
+        # Recreate the pre-fix state: plain-string names attached under the active convention.
+        legacy_metadata = sa.MetaData(naming_convention=_NAMING_CONVENTION)
+        sa.Table("user", legacy_metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+        _add_existing_catalog_table(legacy_metadata, checks=_VALID_CHECKS).create(engine)
+
+        with engine.begin() as connection:
+            inspector = sa.inspect(connection)
+            legacy_names = {constraint["name"] for constraint in inspector.get_check_constraints(_MIGRATION.TABLE_NAME)}
+            assert len(legacy_names) == len(_VALID_CHECKS)
+            assert all(name.startswith(_DOUBLED_PREFIX) for name in legacy_names)
+            if connection.dialect.name == "postgresql":
+                assert legacy_names == set(_LEGACY_POSTGRES_CHECK_NAMES.values())
+
+            monkeypatch.setattr(_MIGRATION, "op", _convention_operations(connection))
+            _MIGRATION.upgrade()
+            _MIGRATION.upgrade()
+
+            inspector = sa.inspect(connection)
+            names_after = {constraint["name"] for constraint in inspector.get_check_constraints(_MIGRATION.TABLE_NAME)}
+            assert names_after == legacy_names
+            assert {index["name"] for index in inspector.get_indexes(_MIGRATION.TABLE_NAME)} >= {
+                _MIGRATION.SCOPED_INDEX,
+                _MIGRATION.UNSCOPED_INDEX,
+            }
+    finally:
+        engine.dispose()
+
+
+def test_catalog_policy_migration_accepts_postgresql_truncated_legacy_check_names():
+    _MIGRATION._validate_check_constraints(_ReflectedCheckInspector(_LEGACY_POSTGRES_REFLECTED_CHECKS))
+
+
+def test_catalog_policy_migration_rejects_tampered_legacy_check_definition():
+    tampered = {
+        **_LEGACY_POSTGRES_REFLECTED_CHECKS,
+        f"{_DOUBLED_PREFIX}mode": (
+            "((mode)::text = ANY ((ARRAY['block'::character varying, 'allow'::character varying, "
+            "'audit'::character varying])::text[]))"
+        ),
+    }
+
+    with pytest.raises(RuntimeError, match="incompatible check constraint definitions"):
+        _MIGRATION._validate_check_constraints(_ReflectedCheckInspector(tampered))
+
+
+def test_catalog_policy_migration_reports_missing_legacy_check_by_definition():
+    partial = {
+        name: sqltext
+        for name, sqltext in _LEGACY_POSTGRES_REFLECTED_CHECKS.items()
+        if name != _LEGACY_POSTGRES_CHECK_NAMES["ck_catalog_policy_rule_scope"]
+    }
+
+    with pytest.raises(RuntimeError, match=r"missing required check constraints: \['ck_catalog_policy_rule_scope'\]"):
+        _MIGRATION._validate_check_constraints(_ReflectedCheckInspector(partial))

--- a/src/backend/tests/unit/services/database/models/catalog_policy/test_model.py
+++ b/src/backend/tests/unit/services/database/models/catalog_policy/test_model.py
@@ -209,3 +209,25 @@ async def test_catalog_policy_rule_check_constraints_reject_invalid_rows(
         )
     )
     await catalog_policy_session.commit()
+
+
+def test_catalog_policy_rule_check_names_survive_naming_convention():
+    """GH #15006: conv()-marked names are final, so Alembic's ck_ convention cannot re-prefix them."""
+    from sqlalchemy import CheckConstraint, MetaData
+    from sqlalchemy.sql.naming import conv
+
+    table = CatalogPolicyRule.__table__
+    check_names = {constraint.name for constraint in table.constraints if isinstance(constraint, CheckConstraint)}
+    assert check_names == {
+        "ck_catalog_policy_rule_resource_kind",
+        "ck_catalog_policy_rule_mode",
+        "ck_catalog_policy_rule_scope",
+        "ck_catalog_policy_rule_scope_domain_consistency",
+    }
+    assert all(isinstance(name, conv) for name in check_names)
+
+    # Mirrors the ``ck`` entry of NAMING_CONVENTION in ``langflow/alembic/env.py``.
+    convention = {"ck": "ck_%(table_name)s_%(constraint_name)s"}
+    copied = table.to_metadata(MetaData(naming_convention=convention))
+    copied_names = {constraint.name for constraint in copied.constraints if isinstance(constraint, CheckConstraint)}
+    assert copied_names == check_names


### PR DESCRIPTION
## What changed

Fixes #15006 - startup crash (worker exit 3) when `catalog_policy_rule` CHECK constraint names get double-prefixed under an active naming convention.

### Root cause

`env.py` sets `SQLModel.metadata.naming_convention` in place, and the `catalog_policy_rule` CHECK constraints in both create paths (the SQLModel model and this migration's `upgrade()`) carried already-prefixed names (`ck_catalog_policy_rule_*`) without `conv()`/`op.f()` markers. SQLAlchemy applies the convention at create time, so the names become `ck_catalog_policy_rule_ck_catalog_policy_rule_*` - and on PostgreSQL the longest one gets the deterministic truncation+hash suffix (the issue's `ck_..._scope_dom_f5d9`). `_validate_check_constraints` then name-matched reflected constraints against baseline/current keys and failed whenever creation-time and validation-time convention states differed, so the worker exited during startup.

### Fix

- Mark all four constraint names with `conv()` (model) and `op.f()` (migration), so the naming convention treats them as final - fresh creates always emit the single-prefix form.
- `_matches_check_contract` now matches constraints by parsed definition instead of by name: a name depends on the naming-convention state at create time (plain, doubled, or PostgreSQL's truncated+hash-suffixed form) and is not a stable contract identifier. Expected definitions are consumed one-by-one against reflected ASTs, so a real definition mismatch still fails validation.

## Verification

Real red/green harness (SQLAlchemy 2.0.52 + alembic 1.19.2 + sqlmodel 0.0.42, sqlite), running the actual model and migration modules from this PR and their pre-patch versions:

- **RED**: legacy DB created pre-fix under an active convention yields all four doubled names (`ck_catalog_policy_rule_ck_catalog_policy_rule_*`); pre-patch validation raises the reporter's exact error: `catalog_policy_rule exists but is missing required check constraints: ['ck_catalog_policy_rule_mode', 'ck_catalog_policy_rule_resource_kind', 'ck_catalog_policy_rule_scope', 'ck_catalog_policy_rule_scope_domain_consistency']`
- **GREEN**: the same legacy doubled-name DB passes post-patch validation
- **GREEN**: fresh `create_all` under the convention emits single-prefix names; validation passes
- **GREEN**: `upgrade()` replay passes on an empty DB (create path) and on the legacy doubled-name DB (validate path)
- **GREEN**: a reflected name in PostgreSQL's truncated+hash form (`ck_..._scope_dom_f5d9`) validates by definition (the pre-patch name-match fails on it)
- negative control: a tampered CHECK definition is still rejected

Honest limit: the harness runs sqlite; the PostgreSQL truncated-name form was simulated exactly per the issue's SQL output. The changed code path is dialect-agnostic (name markers + definition matching), and CI covers the repo suites.

> Built by breken, your AI support engineer - breken.ai - this one's on us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of database CHECK constraints by comparing their definitions directly, including safely rejecting constraints that cannot be parsed.
  * Aligned constraint naming between database migrations and automatic schema creation.
  * Preserved consistent naming for catalog policy rule validations across database setup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->