### PR TITLE
fix(migrations): stop double-prefixing CHECK constraint names under the naming convention

### DIFF
--- a/src/backend/base/langflow/alembic/versions/7c8d9e0f1a2b_authz_foundations.py
+++ b/src/backend/base/langflow/alembic/versions/7c8d9e0f1a2b_authz_foundations.py
@@ -326,16 +326,16 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.CheckConstraint(
                 "scope IN ('private', 'team', 'user', 'public')",
-                name="ck_authz_share_scope_enum",
+                name=op.f("ck_authz_share_scope_enum"),
             ),
             sa.CheckConstraint(
                 "permission_level IN ('read', 'write', 'execute', 'admin')",
-                name="ck_authz_share_permission_enum",
+                name=op.f("ck_authz_share_permission_enum"),
             ),
             sa.CheckConstraint(
                 "(scope IN ('team', 'user') AND target_id IS NOT NULL) "
                 "OR (scope IN ('private', 'public') AND target_id IS NULL)",
-                name="ck_authz_share_scope_target_consistency",
+                name=op.f("ck_authz_share_scope_target_consistency"),
             ),
         )
         with op.batch_alter_table("authz_share", schema=None) as batch_op:
@@ -413,7 +413,7 @@ def upgrade() -> None:
             # silently violate the constraint.
             sa.CheckConstraint(
                 "result IN ('allow', 'deny', 'owner_override')",
-                name="ck_authz_audit_log_result_enum",
+                name=op.f("ck_authz_audit_log_result_enum"),
             ),
         )
         with op.batch_alter_table("authz_audit_log", schema=None) as batch_op:

--- a/src/backend/base/langflow/alembic/versions/cp01a2b3c4d5_add_role_assignment_grant_sources.py
+++ b/src/backend/base/langflow/alembic/versions/cp01a2b3c4d5_add_role_assignment_grant_sources.py
@@ -47,7 +47,7 @@ def upgrade() -> None:
         sa.CheckConstraint(
             "(source_kind = 'manual' AND provider_id IS NULL AND external_group IS NULL) "
             "OR (source_kind = 'idp' AND provider_id IS NOT NULL AND external_group IS NOT NULL)",
-            name="ck_authz_role_assignment_grant_source",
+            name=op.f("ck_authz_role_assignment_grant_source"),
         ),
         sa.ForeignKeyConstraint(
             ["administrative_actor"],

--- a/src/backend/base/langflow/alembic/versions/cp03a2b3c4d5_allow_skipped_authz_audit_results.py
+++ b/src/backend/base/langflow/alembic/versions/cp03a2b3c4d5_allow_skipped_authz_audit_results.py
@@ -44,7 +44,7 @@ def upgrade() -> None:
             constraint_name = batch_op.f(existing["name"])
             batch_op.drop_constraint(constraint_name, type_="check")
         else:
-            constraint_name = _CONSTRAINT_NAME
+            constraint_name = batch_op.f(_CONSTRAINT_NAME)
         batch_op.create_check_constraint(constraint_name, _RESULT_CHECK)
 
 

--- a/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
+++ b/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
@@ -43,14 +43,6 @@ _REQUIRED_INDEX_COLUMNS = (
     "scope",
     "domain_id",
 )
-_REQUIRED_CHECKS = frozenset(
-    {
-        "ck_catalog_policy_rule_resource_kind",
-        "ck_catalog_policy_rule_mode",
-        "ck_catalog_policy_rule_scope",
-        "ck_catalog_policy_rule_scope_domain_consistency",
-    }
-)
 _SCHEMA_REMEDIATION = "Resolve the conflicting schema before rerunning this migration"
 _CHECK_COLUMNS = ("resource_kind", "mode", "scope", "domain_id")
 _SQLITE_UUID_LENGTH = 32
@@ -392,29 +384,36 @@ def _current_check_sql() -> dict[str, object]:
     }
 
 
-def _matches_check_contract(reflected: Mapping[str, object], expected: Mapping[str, object]) -> bool:
-    """Return whether reflected checks satisfy one complete contract.
+def _unmatched_check_names(reflected: Mapping[str, object], expected: Mapping[str, object]) -> list[str]:
+    """Return the expected check names whose definition no reflected check satisfies.
 
-    Names are matched by definition, not literally: a name depends on the
-    naming-convention state when the table was created (plain, doubled
-    ck_<table>_ prefix, or PostgreSQL's truncated + hash-suffixed form), so it
-    is not a stable contract identifier. Compare parsed definitions instead,
-    consuming one reflected constraint per expected definition.
+    Checks are matched by parsed definition, never by name: a name depends on
+    the naming-convention state when the table was created (plain, doubled
+    ``ck_<table>_`` prefix, or PostgreSQL's truncated + hash-suffixed form), so
+    it is not a stable contract identifier. Each reflected check can satisfy at
+    most one expected definition, and unparsable reflected checks satisfy none.
     """
-    if len(expected) != len(reflected):
-        return False
-    remaining_asts: list[tuple[object, ...]] = []
-    for sqltext in reflected.values():
-        reflected_ast = _check_ast(sqltext)
-        if reflected_ast is None:
-            return False
-        remaining_asts.append(reflected_ast)
-    for sqltext in expected.values():
+    remaining_asts = [ast for ast in (_check_ast(sqltext) for sqltext in reflected.values()) if ast is not None]
+    unmatched: list[str] = []
+    for name, sqltext in expected.items():
         expected_ast = _check_ast(sqltext)
         if expected_ast is None or expected_ast not in remaining_asts:
-            return False
+            unmatched.append(name)
+            continue
         remaining_asts.remove(expected_ast)
-    return True
+    return unmatched
+
+
+def _matches_check_contract(reflected: Mapping[str, object], expected: Mapping[str, object]) -> bool:
+    """Return whether reflected checks satisfy one complete contract."""
+    return len(reflected) == len(expected) and not _unmatched_check_names(reflected, expected)
+
+
+def _missing_check_names(reflected: Mapping[str, object], expected: Mapping[str, object]) -> list[str]:
+    """Return unmatched expected checks when the table holds fewer checks than the contract."""
+    if len(reflected) >= len(expected):
+        return []
+    return _unmatched_check_names(reflected, expected)
 
 
 def _validate_check_constraints(inspector: Inspector) -> None:
@@ -437,8 +436,8 @@ def _validate_check_constraints(inspector: Inspector) -> None:
     ):
         return
 
-    missing_baseline = _REQUIRED_CHECKS - reflected.keys()
-    missing_current = current.keys() - reflected.keys()
+    missing_baseline = _missing_check_names(reflected, _BASELINE_CHECK_SQL)
+    missing_current = _missing_check_names(reflected, current)
     if missing_baseline and missing_current:
         missing = sorted(missing_baseline if len(missing_baseline) <= len(missing_current) else missing_current)
         detail = f"{TABLE_NAME} exists but is missing required check constraints: {missing}"

--- a/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
+++ b/src/backend/base/langflow/alembic/versions/d4a7c9e1b2f6_add_catalog_policy_rule.py
@@ -393,14 +393,27 @@ def _current_check_sql() -> dict[str, object]:
 
 
 def _matches_check_contract(reflected: Mapping[str, object], expected: Mapping[str, object]) -> bool:
-    """Return whether reflected checks satisfy one complete contract."""
-    if expected.keys() != reflected.keys():
+    """Return whether reflected checks satisfy one complete contract.
+
+    Names are matched by definition, not literally: a name depends on the
+    naming-convention state when the table was created (plain, doubled
+    ck_<table>_ prefix, or PostgreSQL's truncated + hash-suffixed form), so it
+    is not a stable contract identifier. Compare parsed definitions instead,
+    consuming one reflected constraint per expected definition.
+    """
+    if len(expected) != len(reflected):
         return False
-    for name, sqltext in expected.items():
-        reflected_ast = _check_ast(reflected[name])
-        expected_ast = _check_ast(sqltext)
-        if reflected_ast is None or expected_ast is None or reflected_ast != expected_ast:
+    remaining_asts: list[tuple[object, ...]] = []
+    for sqltext in reflected.values():
+        reflected_ast = _check_ast(sqltext)
+        if reflected_ast is None:
             return False
+        remaining_asts.append(reflected_ast)
+    for sqltext in expected.values():
+        expected_ast = _check_ast(sqltext)
+        if expected_ast is None or expected_ast not in remaining_asts:
+            return False
+        remaining_asts.remove(expected_ast)
     return True
 
 
@@ -814,19 +827,19 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_resource_kind"],
-                name="ck_catalog_policy_rule_resource_kind",
+                name=op.f("ck_catalog_policy_rule_resource_kind"),
             ),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_mode"],
-                name="ck_catalog_policy_rule_mode",
+                name=op.f("ck_catalog_policy_rule_mode"),
             ),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_scope"],
-                name="ck_catalog_policy_rule_scope",
+                name=op.f("ck_catalog_policy_rule_scope"),
             ),
             sa.CheckConstraint(
                 _BASELINE_CHECK_SQL["ck_catalog_policy_rule_scope_domain_consistency"],
-                name="ck_catalog_policy_rule_scope_domain_consistency",
+                name=op.f("ck_catalog_policy_rule_scope_domain_consistency"),
             ),
         )
 

--- a/src/backend/base/langflow/alembic/versions/e9f2a3b4c5d6_allow_multiple_sso_identities_per_user.py
+++ b/src/backend/base/langflow/alembic/versions/e9f2a3b4c5d6_allow_multiple_sso_identities_per_user.py
@@ -214,7 +214,7 @@ def _create_and_backfill_sso_settings(conn: sa.Connection) -> None:
             _SETTINGS_TABLE,
             sa.Column("id", sa.Integer(), nullable=False),
             sa.Column("enforce_sso", sa.Boolean(), nullable=False),
-            sa.CheckConstraint("id = 1", name=_SETTINGS_SINGLETON_CHECK),
+            sa.CheckConstraint("id = 1", name=op.f(_SETTINGS_SINGLETON_CHECK)),
             sa.PrimaryKeyConstraint("id"),
         )
 

--- a/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
+++ b/src/backend/base/langflow/alembic/versions/f7a9c2d4e6b8_add_shared_policy_bundle.py
@@ -212,8 +212,8 @@ def _create_revision_table() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.Column("reason", sa.String(length=REASON_MAX_LENGTH), nullable=True),
         sa.Column("rollback_of_revision", sa.Integer(), nullable=True),
-        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_revision_positive"),
-        sa.CheckConstraint("length(content_hash) = 64", name="ck_policy_bundle_revision_hash_length"),
+        sa.CheckConstraint("revision >= 1", name=op.f("ck_policy_bundle_revision_positive")),
+        sa.CheckConstraint("length(content_hash) = 64", name=op.f("ck_policy_bundle_revision_hash_length")),
         sa.ForeignKeyConstraint(
             ["rollback_of_revision"],
             [f"{REVISION_TABLE}.revision"],
@@ -230,8 +230,8 @@ def _create_active_table() -> None:
         sa.Column("revision", sa.Integer(), nullable=False),
         sa.Column("initialized", sa.Boolean(), nullable=False, server_default=sa.false()),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
-        sa.CheckConstraint(f"id = {SINGLETON_ID}", name="ck_policy_bundle_active_singleton"),
-        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_active_revision_positive"),
+        sa.CheckConstraint(f"id = {SINGLETON_ID}", name=op.f("ck_policy_bundle_active_singleton")),
+        sa.CheckConstraint("revision >= 1", name=op.f("ck_policy_bundle_active_revision_positive")),
         sa.PrimaryKeyConstraint("id"),
     )
 

--- a/src/backend/base/langflow/alembic/versions/kb1a2b3c4d5e_add_knowledge_base_schema.py
+++ b/src/backend/base/langflow/alembic/versions/kb1a2b3c4d5e_add_knowledge_base_schema.py
@@ -101,7 +101,7 @@ def upgrade() -> None:
             # Value allow-list mirrors the ``KnowledgeBaseStatus`` Python
             # enum. A typo in app code now fails at COMMIT instead of
             # silently storing an invalid state.
-            sa.CheckConstraint(f"status IN ({kb_status_values})", name="ck_knowledge_base_status"),
+            sa.CheckConstraint(f"status IN ({kb_status_values})", name=op.f("ck_knowledge_base_status")),
         )
 
         with op.batch_alter_table(KB_TABLE, schema=None) as batch_op:
@@ -153,7 +153,7 @@ def upgrade() -> None:
             # Value allow-list mirrors ``IngestionRunStatus``. Prevents
             # typos ("Running" vs "running") from silently storing an
             # invalid state that list filters can't match.
-            sa.CheckConstraint(f"status IN ({run_status_values})", name="ck_ingestion_run_status"),
+            sa.CheckConstraint(f"status IN ({run_status_values})", name=op.f("ck_ingestion_run_status")),
         )
 
         with op.batch_alter_table(RUN_TABLE, schema=None) as batch_op:

--- a/src/backend/base/langflow/services/database/models/auth/authz.py
+++ b/src/backend/base/langflow/services/database/models/auth/authz.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import sqlalchemy as sa
 from sqlalchemy import CheckConstraint, Column, ForeignKey, Index, UniqueConstraint, text
+from sqlalchemy.sql.naming import conv
 from sqlmodel import Field, Relationship, SQLModel
 
 from langflow.schema.serialize import UUIDstr
@@ -170,7 +171,7 @@ class AuthzRoleAssignmentGrant(SQLModel, table=True):  # type: ignore[call-arg]
         CheckConstraint(
             "(source_kind = 'manual' AND provider_id IS NULL AND external_group IS NULL) "
             "OR (source_kind = 'idp' AND provider_id IS NOT NULL AND external_group IS NOT NULL)",
-            name="ck_authz_role_assignment_grant_source",
+            name=conv("ck_authz_role_assignment_grant_source"),
         ),
         Index(
             "uq_authz_role_assignment_grant_manual",
@@ -269,11 +270,11 @@ class AuthzShare(SQLModel, table=True):  # type: ignore[call-arg]
         # partial unique indexes (which match on the lowercase form).
         CheckConstraint(
             "scope IN ('private', 'team', 'user', 'public')",
-            name="ck_authz_share_scope_enum",
+            name=conv("ck_authz_share_scope_enum"),
         ),
         CheckConstraint(
             "permission_level IN ('read', 'write', 'execute', 'admin')",
-            name="ck_authz_share_permission_enum",
+            name=conv("ck_authz_share_permission_enum"),
         ),
         # Targeted (TEAM/USER) shares require a target_id; untargeted
         # (PRIVATE/PUBLIC) shares forbid one. Matches the partial-unique-index
@@ -282,7 +283,7 @@ class AuthzShare(SQLModel, table=True):  # type: ignore[call-arg]
         CheckConstraint(
             "(scope IN ('team', 'user') AND target_id IS NOT NULL) "
             "OR (scope IN ('private', 'public') AND target_id IS NULL)",
-            name="ck_authz_share_scope_target_consistency",
+            name=conv("ck_authz_share_scope_target_consistency"),
         ),
         Index(
             "uq_authz_share_targeted",
@@ -356,7 +357,7 @@ class AuthzAuditLog(SQLModel, table=True):  # type: ignore[call-arg]
         # not apply an authoritative directory snapshot.
         CheckConstraint(
             "result IN ('allow', 'deny', 'owner_override', 'skip')",
-            name="ck_authz_audit_log_result_enum",
+            name=conv("ck_authz_audit_log_result_enum"),
         ),
     )
 

--- a/src/backend/base/langflow/services/database/models/auth/sso.py
+++ b/src/backend/base/langflow/services/database/models/auth/sso.py
@@ -724,7 +724,7 @@ class SSOSettings(SQLModel, table=True):  # type: ignore[call-arg]
     """Singleton instance-level SSO policy settings."""
 
     __tablename__ = "sso_settings"
-    __table_args__ = (CheckConstraint("id = 1", name="ck_sso_settings_singleton"),)
+    __table_args__ = (CheckConstraint("id = 1", name=conv("ck_sso_settings_singleton")),)
 
     id: int = Field(default=1, primary_key=True)
     enforce_sso: bool = Field(default=False)

--- a/src/backend/base/langflow/services/database/models/catalog_policy/model.py
+++ b/src/backend/base/langflow/services/database/models/catalog_policy/model.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import sqlalchemy as sa
 from sqlalchemy import CheckConstraint, Column, ForeignKey, Index, text
+from sqlalchemy.sql.naming import conv
 from sqlmodel import Field, SQLModel
 from sqlmodel.sql.sqltypes import AutoString
 
@@ -76,19 +77,19 @@ class CatalogPolicyRule(SQLModel, table=True):  # type: ignore[call-arg]
     __table_args__ = (
         CheckConstraint(
             _RESOURCE_KIND_CHECK,
-            name="ck_catalog_policy_rule_resource_kind",
+            name=conv("ck_catalog_policy_rule_resource_kind"),
         ),
         CheckConstraint(
             _MODE_CHECK,
-            name="ck_catalog_policy_rule_mode",
+            name=conv("ck_catalog_policy_rule_mode"),
         ),
         CheckConstraint(
             _SCOPE_CHECK,
-            name="ck_catalog_policy_rule_scope",
+            name=conv("ck_catalog_policy_rule_scope"),
         ),
         CheckConstraint(
             _SCOPE_DOMAIN_CHECK,
-            name="ck_catalog_policy_rule_scope_domain_consistency",
+            name=conv("ck_catalog_policy_rule_scope_domain_consistency"),
         ),
         Index(
             "uq_catalog_policy_rule_scoped",

--- a/src/backend/base/langflow/services/database/models/ingestion_run/model.py
+++ b/src/backend/base/langflow/services/database/models/ingestion_run/model.py
@@ -32,6 +32,7 @@ from uuid import UUID, uuid4
 import sqlalchemy as sa
 from sqlalchemy import JSON, BigInteger, CheckConstraint, Column, DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql.naming import conv
 from sqlmodel import Field, SQLModel
 
 # JSONB on Postgres (binary, dedup, GIN-indexable on the ``items``
@@ -137,6 +138,6 @@ class IngestionRun(IngestionRunBase, table=True):  # type: ignore[call-arg]
     __table_args__ = (
         CheckConstraint(
             "status IN (" + ", ".join(f"'{v}'" for v in _RUN_STATUS_VALUES) + ")",
-            name="ck_ingestion_run_status",
+            name=conv("ck_ingestion_run_status"),
         ),
     )

--- a/src/backend/base/langflow/services/database/models/knowledge_base/model.py
+++ b/src/backend/base/langflow/services/database/models/knowledge_base/model.py
@@ -40,6 +40,7 @@ from uuid import UUID, uuid4
 import sqlalchemy as sa
 from sqlalchemy import JSON, BigInteger, CheckConstraint, Column, DateTime, ForeignKey, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql.naming import conv
 from sqlmodel import Field, SQLModel
 
 # JSONB on Postgres for GIN indexability + binary storage; JSON on
@@ -143,6 +144,6 @@ class KnowledgeBaseRecord(KnowledgeBaseRecordBase, table=True):  # type: ignore[
         UniqueConstraint("user_id", "name", name="uq_knowledge_base_user_name"),
         CheckConstraint(
             "status IN (" + ", ".join(f"'{v}'" for v in _KB_STATUS_VALUES) + ")",
-            name="ck_knowledge_base_status",
+            name=conv("ck_knowledge_base_status"),
         ),
     )

--- a/src/backend/base/langflow/services/database/models/model_provider_policy/model.py
+++ b/src/backend/base/langflow/services/database/models/model_provider_policy/model.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.sql.naming import conv
 from sqlmodel import Field, SQLModel
 
 MODEL_PROVIDER_POLICY_SINGLETON_ID = 1
@@ -11,9 +12,9 @@ class ModelProviderPolicy(SQLModel, table=True):  # type: ignore[call-arg]
     __table_args__ = (
         sa.CheckConstraint(
             f"id = {MODEL_PROVIDER_POLICY_SINGLETON_ID}",
-            name="ck_model_provider_policy_singleton",
+            name=conv("ck_model_provider_policy_singleton"),
         ),
-        sa.CheckConstraint("version >= 0", name="ck_model_provider_policy_version"),
+        sa.CheckConstraint("version >= 0", name=conv("ck_model_provider_policy_version")),
     )
 
     id: int = Field(default=MODEL_PROVIDER_POLICY_SINGLETON_ID, primary_key=True)

--- a/src/backend/base/langflow/services/database/models/policy_bundle/model.py
+++ b/src/backend/base/langflow/services/database/models/policy_bundle/model.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
+from sqlalchemy.sql.naming import conv
 from sqlmodel import Field, SQLModel
 
 from langflow.schema.serialize import UUIDstr
@@ -21,8 +22,8 @@ class PolicyBundleRevision(SQLModel, table=True):  # type: ignore[call-arg]
 
     __tablename__ = "policy_bundle_revision"
     __table_args__ = (
-        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_revision_positive"),
-        sa.CheckConstraint("length(content_hash) = 64", name="ck_policy_bundle_revision_hash_length"),
+        sa.CheckConstraint("revision >= 1", name=conv("ck_policy_bundle_revision_positive")),
+        sa.CheckConstraint("length(content_hash) = 64", name=conv("ck_policy_bundle_revision_hash_length")),
     )
 
     revision: int = Field(primary_key=True, ge=1)
@@ -75,9 +76,9 @@ class PolicyBundleActive(SQLModel, table=True):  # type: ignore[call-arg]
     __table_args__ = (
         sa.CheckConstraint(
             f"id = {POLICY_BUNDLE_SINGLETON_ID}",
-            name="ck_policy_bundle_active_singleton",
+            name=conv("ck_policy_bundle_active_singleton"),
         ),
-        sa.CheckConstraint("revision >= 1", name="ck_policy_bundle_active_revision_positive"),
+        sa.CheckConstraint("revision >= 1", name=conv("ck_policy_bundle_active_revision_positive")),
     )
 
     id: int = Field(default=POLICY_BUNDLE_SINGLETON_ID, primary_key=True)

--- a/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
+++ b/src/backend/tests/unit/alembic/test_catalog_policy_rule_migration.py
@@ -693,3 +693,121 @@ def test_catalog_policy_migration_accepts_model_created_table_without_writes(db_
             assert row_count == 0
     finally:
         engine.dispose()
+
+
+# Mirrors the ``ck`` entry of NAMING_CONVENTION in ``langflow/alembic/env.py``.
+_NAMING_CONVENTION = {"ck": "ck_%(table_name)s_%(constraint_name)s"}
+_DOUBLED_PREFIX = f"ck_{_MIGRATION.TABLE_NAME}_ck_{_MIGRATION.TABLE_NAME}_"
+_LEGACY_POSTGRES_CHECK_NAMES = {
+    "ck_catalog_policy_rule_resource_kind": f"{_DOUBLED_PREFIX}resource_kind",
+    "ck_catalog_policy_rule_mode": f"{_DOUBLED_PREFIX}mode",
+    "ck_catalog_policy_rule_scope": f"{_DOUBLED_PREFIX}scope",
+    # The doubled name is 70 characters, so PostgreSQL DDL truncates it to the
+    # 63-character limit with SQLAlchemy's md5 suffix (GH #15006).
+    "ck_catalog_policy_rule_scope_domain_consistency": f"{_DOUBLED_PREFIX}scope_dom_f5d9",
+}
+_LEGACY_POSTGRES_REFLECTED_CHECKS = {
+    _LEGACY_POSTGRES_CHECK_NAMES[name]: sqltext for name, sqltext in _POSTGRES_REFLECTED_CHECKS.items()
+}
+
+
+class _ReflectedCheckInspector:
+    def __init__(self, checks: dict[str, str]) -> None:
+        self._checks = checks
+
+    def get_check_constraints(self, _table_name: str) -> list[dict[str, object]]:
+        return [{"name": name, "sqltext": sqltext} for name, sqltext in self._checks.items()]
+
+
+def _convention_operations(connection: sa.Connection) -> Operations:
+    """Build Operations the way env.py does: create_table inherits the naming convention."""
+    return Operations(
+        MigrationContext.configure(
+            connection,
+            opts={"target_metadata": sa.MetaData(naming_convention=_NAMING_CONVENTION)},
+        )
+    )
+
+
+def test_catalog_policy_migration_creates_single_prefix_check_names_under_naming_convention(
+    db_url,  # noqa: F811
+    monkeypatch,
+):
+    """GH #15006: op.f() keeps the migration-created names from being re-prefixed."""
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        User.__table__.create(engine, checkfirst=True)
+
+        with engine.begin() as connection:
+            monkeypatch.setattr(_MIGRATION, "op", _convention_operations(connection))
+            _MIGRATION.upgrade()
+
+            checks = {
+                constraint["name"] for constraint in sa.inspect(connection).get_check_constraints(_MIGRATION.TABLE_NAME)
+            }
+            assert checks == set(_VALID_CHECKS)
+
+            _MIGRATION.upgrade()
+    finally:
+        engine.dispose()
+
+
+def test_catalog_policy_migration_accepts_legacy_double_prefixed_check_names(db_url, monkeypatch):  # noqa: F811
+    """GH #15006: tables created before the fix carry doubled names and must still validate."""
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        User.__table__.create(engine, checkfirst=True)
+        # Recreate the pre-fix state: plain-string names attached under the active convention.
+        legacy_metadata = sa.MetaData(naming_convention=_NAMING_CONVENTION)
+        sa.Table("user", legacy_metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+        _add_existing_catalog_table(legacy_metadata, checks=_VALID_CHECKS).create(engine)
+
+        with engine.begin() as connection:
+            inspector = sa.inspect(connection)
+            legacy_names = {constraint["name"] for constraint in inspector.get_check_constraints(_MIGRATION.TABLE_NAME)}
+            assert len(legacy_names) == len(_VALID_CHECKS)
+            assert all(name.startswith(_DOUBLED_PREFIX) for name in legacy_names)
+            if connection.dialect.name == "postgresql":
+                assert legacy_names == set(_LEGACY_POSTGRES_CHECK_NAMES.values())
+
+            monkeypatch.setattr(_MIGRATION, "op", _convention_operations(connection))
+            _MIGRATION.upgrade()
+            _MIGRATION.upgrade()
+
+            inspector = sa.inspect(connection)
+            names_after = {constraint["name"] for constraint in inspector.get_check_constraints(_MIGRATION.TABLE_NAME)}
+            assert names_after == legacy_names
+            assert {index["name"] for index in inspector.get_indexes(_MIGRATION.TABLE_NAME)} >= {
+                _MIGRATION.SCOPED_INDEX,
+                _MIGRATION.UNSCOPED_INDEX,
+            }
+    finally:
+        engine.dispose()
+
+
+def test_catalog_policy_migration_accepts_postgresql_truncated_legacy_check_names():
+    _MIGRATION._validate_check_constraints(_ReflectedCheckInspector(_LEGACY_POSTGRES_REFLECTED_CHECKS))
+
+
+def test_catalog_policy_migration_rejects_tampered_legacy_check_definition():
+    tampered = {
+        **_LEGACY_POSTGRES_REFLECTED_CHECKS,
+        f"{_DOUBLED_PREFIX}mode": (
+            "((mode)::text = ANY ((ARRAY['block'::character varying, 'allow'::character varying, "
+            "'audit'::character varying])::text[]))"
+        ),
+    }
+
+    with pytest.raises(RuntimeError, match="incompatible check constraint definitions"):
+        _MIGRATION._validate_check_constraints(_ReflectedCheckInspector(tampered))
+
+
+def test_catalog_policy_migration_reports_missing_legacy_check_by_definition():
+    partial = {
+        name: sqltext
+        for name, sqltext in _LEGACY_POSTGRES_REFLECTED_CHECKS.items()
+        if name != _LEGACY_POSTGRES_CHECK_NAMES["ck_catalog_policy_rule_scope"]
+    }
+
+    with pytest.raises(RuntimeError, match=r"missing required check constraints: \['ck_catalog_policy_rule_scope'\]"):
+        _MIGRATION._validate_check_constraints(_ReflectedCheckInspector(partial))

--- a/src/backend/tests/unit/alembic/test_check_constraint_naming.py
+++ b/src/backend/tests/unit/alembic/test_check_constraint_naming.py
@@ -1,0 +1,141 @@
+"""Guard against CHECK constraint names being double-prefixed by the naming convention.
+
+``langflow/alembic/env.py`` installs ``ck_%(table_name)s_%(constraint_name)s`` on
+``SQLModel.metadata``. SQLAlchemy applies that template to any plain-string
+constraint name, so a name that already carries the ``ck_<table>_`` prefix is
+rendered as ``ck_<table>_ck_<table>_...`` (truncated with a hash suffix on
+PostgreSQL) unless it is marked final with ``op.f()`` / ``conv()`` (GH #15006).
+"""
+
+from __future__ import annotations
+
+import ast
+
+import sqlalchemy as sa
+from alembic import command
+from langflow.services.database import models  # noqa: F401  # registers every table on SQLModel.metadata
+from sqlalchemy.sql.naming import conv
+from sqlmodel import SQLModel
+
+from .test_migration_execution import _SCRIPT_LOCATION, _engine_url, _make_alembic_cfg, db_url  # noqa: F401
+
+# Mirrors the ``ck`` entry of NAMING_CONVENTION in ``langflow/alembic/env.py``.
+_NAMING_CONVENTION = {"ck": "ck_%(table_name)s_%(constraint_name)s"}
+
+
+def _doubled_prefix_names(table_name: str, names: set[str]) -> set[str]:
+    return {name for name in names if name.startswith(f"ck_{table_name}_ck_")}
+
+
+def _prefixed_checks(table: sa.Table) -> list[sa.CheckConstraint]:
+    return [
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, sa.CheckConstraint) and str(constraint.name).startswith("ck_")
+    ]
+
+
+def test_model_check_names_are_final_under_naming_convention():
+    """Prefixed model CHECK names must be conv()-marked and survive re-attachment under the convention."""
+    violations: dict[str, dict[str, list[str]]] = {}
+    for table in SQLModel.metadata.sorted_tables:
+        prefixed = _prefixed_checks(table)
+        if not prefixed:
+            continue
+        unmarked = sorted(str(constraint.name) for constraint in prefixed if not isinstance(constraint.name, conv))
+        copied = table.to_metadata(sa.MetaData(naming_convention=_NAMING_CONVENTION))
+        rendered = {
+            str(constraint.name) for constraint in copied.constraints if isinstance(constraint, sa.CheckConstraint)
+        }
+        doubled = sorted(_doubled_prefix_names(table.name, rendered))
+        if unmarked or doubled:
+            violations[table.name] = {"unmarked": unmarked, "doubled": doubled}
+    assert violations == {}
+
+
+def _string_assignments(module: ast.Module) -> dict[str, str]:
+    """Resolve ``NAME = "literal"`` (directly or through ``NAME = OTHER_NAME``) anywhere in the module."""
+    literals: dict[str, str] = {}
+    aliases: dict[str, str] = {}
+    for node in ast.walk(module):
+        target = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            target = node.targets[0].id
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target = node.target.id
+        if target is None:
+            continue
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            literals[target] = node.value.value
+        elif isinstance(node.value, ast.Name):
+            aliases[target] = node.value.id
+    for name, source in aliases.items():
+        seen = {name}
+        resolved = source
+        while resolved in aliases and resolved not in seen:
+            seen.add(resolved)
+            resolved = aliases[resolved]
+        if resolved in literals:
+            literals[name] = literals[resolved]
+    return literals
+
+
+def _check_name_argument(call: ast.Call) -> ast.expr | None:
+    callee = call.func
+    if isinstance(callee, ast.Attribute):
+        attribute = callee.attr
+    elif isinstance(callee, ast.Name):
+        attribute = callee.id
+    else:
+        return None
+    if attribute == "CheckConstraint":
+        return next((keyword.value for keyword in call.keywords if keyword.arg == "name"), None)
+    if attribute == "create_check_constraint":
+        named = next((keyword.value for keyword in call.keywords if keyword.arg == "constraint_name"), None)
+        if named is not None:
+            return named
+        return call.args[0] if call.args else None
+    return None
+
+
+def _plain_name(node: ast.expr | None, literals: dict[str, str]) -> str | None:
+    """Return the plain-string name an argument resolves to; ``op.f()``/``conv()`` calls resolve to None."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return literals.get(node.id)
+    return None
+
+
+def test_migrations_mark_prefixed_check_names_final():
+    """A migration must wrap an already-prefixed CHECK name in ``op.f()`` so the convention leaves it alone."""
+    offenders: list[str] = []
+    for path in sorted((_SCRIPT_LOCATION / "versions").glob("*.py")):
+        module = ast.parse(path.read_text(encoding="utf-8"))
+        literals = _string_assignments(module)
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _plain_name(_check_name_argument(node), literals)
+            if name is not None and name.startswith("ck_"):
+                offenders.append(f"{path.name}:{node.lineno}: {name}")
+    assert offenders == []
+
+
+def test_migrated_schema_has_no_double_prefixed_check_names(db_url):  # noqa: F811
+    """Upgrading a fresh database to head must not render ``ck_<table>_ck_<table>_...`` names."""
+    command.upgrade(_make_alembic_cfg(db_url), "head")
+
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        inspector = sa.inspect(engine)
+        doubled: dict[str, list[str]] = {}
+        for table_name in inspector.get_table_names():
+            names = {str(check["name"]) for check in inspector.get_check_constraints(table_name) if check.get("name")}
+            rendered = _doubled_prefix_names(table_name, names)
+            if rendered:
+                doubled[table_name] = sorted(rendered)
+    finally:
+        engine.dispose()
+
+    assert doubled == {}

--- a/src/backend/tests/unit/services/database/models/catalog_policy/test_model.py
+++ b/src/backend/tests/unit/services/database/models/catalog_policy/test_model.py
@@ -209,3 +209,25 @@ async def test_catalog_policy_rule_check_constraints_reject_invalid_rows(
         )
     )
     await catalog_policy_session.commit()
+
+
+def test_catalog_policy_rule_check_names_survive_naming_convention():
+    """GH #15006: conv()-marked names are final, so Alembic's ck_ convention cannot re-prefix them."""
+    from sqlalchemy import CheckConstraint, MetaData
+    from sqlalchemy.sql.naming import conv
+
+    table = CatalogPolicyRule.__table__
+    check_names = {constraint.name for constraint in table.constraints if isinstance(constraint, CheckConstraint)}
+    assert check_names == {
+        "ck_catalog_policy_rule_resource_kind",
+        "ck_catalog_policy_rule_mode",
+        "ck_catalog_policy_rule_scope",
+        "ck_catalog_policy_rule_scope_domain_consistency",
+    }
+    assert all(isinstance(name, conv) for name in check_names)
+
+    # Mirrors the ``ck`` entry of NAMING_CONVENTION in ``langflow/alembic/env.py``.
+    convention = {"ck": "ck_%(table_name)s_%(constraint_name)s"}
+    copied = table.to_metadata(MetaData(naming_convention=convention))
+    copied_names = {constraint.name for constraint in copied.constraints if isinstance(constraint, CheckConstraint)}
+    assert copied_names == check_names


### PR DESCRIPTION
## Summary

Follow-up to #15006 / #15007. The catalog policy migration was the only place where a double-prefixed CHECK constraint name caused a failure, but the same pattern exists elsewhere: migrations and models pass names that already carry the `ck_<table>_` prefix as plain strings. Alembic builds `create_table` tables with the naming convention from `env.py` (`ck_%(table_name)s_%(constraint_name)s`), and SQLAlchemy re-renders any plain-string name through that template, so upgraded installs get `ck_<table>_ck_<table>_...` names (truncated with a hash suffix on PostgreSQL) while fresh installs created via `create_all` get the single-prefix form.

This PR marks every already-prefixed CHECK name as final, following the precedent already in `7c8e9f0a1b2d_add_sso_config_invariant_checks.py` and `e8f1a2b3c4d5_add_model_provider_policy.py`.

## Changes

**Migrations (`op.f()` / `batch_op.f()`)**
- `7c8d9e0f1a2b_authz_foundations.py`: `authz_share` (3) and `authz_audit_log` (1)
- `cp01a2b3c4d5_add_role_assignment_grant_sources.py`: `authz_role_assignment_grant` (1)
- `cp03a2b3c4d5_allow_skipped_authz_audit_results.py`: the create branch used when no result check exists yet
- `e9f2a3b4c5d6_allow_multiple_sso_identities_per_user.py`: `sso_settings` (1)
- `f7a9c2d4e6b8_add_shared_policy_bundle.py`: `policy_bundle_revision` (2) and `policy_bundle_active` (2)
- `kb1a2b3c4d5e_add_knowledge_base_schema.py`: `knowledge_base` (1) and `ingestion_run` (1)

**Models (`conv()`)**: `auth/authz.py`, `auth/sso.py`, `knowledge_base/model.py`, `ingestion_run/model.py`, `policy_bundle/model.py`, `model_provider_policy/model.py`. Model-created names are already single-prefix in the app (models import before `env.py` installs the convention); `conv()` makes that independent of import order.

**Tests** (`src/backend/tests/unit/alembic/test_check_constraint_naming.py`)
- every prefixed model CHECK name is `conv()`-marked and survives `to_metadata()` under the convention
- an AST scan of `alembic/versions/*.py` rejects a plain `ck_...` name passed to `CheckConstraint` / `create_check_constraint`
- upgrading a fresh database to head (real `env.py`, SQLite and PostgreSQL) yields no `ck_<table>_ck_...` names

## Why this is safe

- Existing databases are not touched: no constraint is renamed, so installs that already carry doubled names keep them. Only future `create_table` runs change.
- Nothing references these names. No application code matches on them; the two migrations that look CHECK names up (`cp03a2b3c4d5` and `7c8e9f0a1b2d`) already accept both the plain and the doubled form.
- Alembic autogenerate (`command.check` at startup) does not compare CHECK constraints, so neither name form produces drift.
- All single-prefix names are well under PostgreSQL's 63-character identifier limit.

Left alone on purpose: `7d327cfafab6_add_flow_history_table.py` names its check `check_version_number_positive` (no `ck_` prefix), so the convention renders `ck_flow_history_check_version_number_positive` rather than a doubled prefix. Different pattern, out of scope here.

## Verification

- All four new test cases fail on the pre-fix sources and pass with this change, on SQLite and PostgreSQL 16.
- `src/backend/tests/unit/alembic`, `test_authz_models.py`, `services/database`, the policy bundle and model provider policy store tests, and the knowledge base tests: 661 passed, 12 skipped, on SQLite and PostgreSQL.
- `ruff check` and `ruff format` are clean.

> **Stacked on #15007.** This branch is based on the rebased #15007 head because the fresh-database test needs the catalog policy fix too. Merge #15007 into `release-1.12.2` first; this PR's diff then reduces to the single commit above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database migration compatibility across naming conventions.
  - Prevented duplicate or inconsistent names for database validation rules.
  - Made schema validation more resilient when working with existing databases and legacy constraint names.

- **Tests**
  - Added coverage to verify consistent constraint names across models, migrations, and upgraded databases.
  - Added regression tests for legacy and truncated database constraint names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->