### PR TITLE
fix(db): give the flow_version CHECK constraint one name across create paths

### DIFF
--- a/src/backend/base/langflow/alembic/versions/7d327cfafab6_add_flow_history_table.py
+++ b/src/backend/base/langflow/alembic/versions/7d327cfafab6_add_flow_history_table.py
@@ -38,7 +38,13 @@ def upgrade() -> None:
             sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="SET NULL"),
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint("flow_id", "version_number", name="unique_flow_version_number"),
-            sa.CheckConstraint("version_number >= 1", name="check_version_number_positive"),
+            # op.f() marks the name final so env.py's ck_%(table_name)s_%(constraint_name)s convention
+            # does not re-prefix it; the model declares the same name via conv(). Databases created
+            # before this fix carry one of two legacy names instead and are intentionally left alone:
+            #   - check_version_number_positive (fresh installs: create_all ran without the convention)
+            #   - ck_flow_version_check_version_number_positive (upgrades: op.create_table under it)
+            # Any later migration that drops or looks up this constraint must accept all three names.
+            sa.CheckConstraint("version_number >= 1", name=op.f("ck_flow_version_version_number_positive")),
         )
         op.create_index(op.f("ix_flow_version_flow_id"), "flow_version", ["flow_id"])
         op.create_index(op.f("ix_flow_version_user_id"), "flow_version", ["user_id"])

--- a/src/backend/base/langflow/services/database/models/flow_version/model.py
+++ b/src/backend/base/langflow/services/database/models/flow_version/model.py
@@ -6,7 +6,14 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, computed_field, field_serializer
 from pydantic import Field as PydanticField
 from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, UniqueConstraint, func
+from sqlalchemy.sql.naming import conv
 from sqlmodel import JSON, Field, SQLModel
+
+# Final name of the ``version_number >= 1`` CHECK. It is wrapped in ``conv()`` below so Alembic's
+# ``ck_%(table_name)s_%(constraint_name)s`` convention (installed on SQLModel.metadata by
+# alembic/env.py) renders the same name whether the table is created by
+# ``SQLModel.metadata.create_all`` or by the migration's ``op.create_table``.
+VERSION_NUMBER_CHECK_NAME = "ck_flow_version_version_number_positive"
 
 
 class FlowVersion(SQLModel, table=True):  # type: ignore[call-arg]
@@ -32,7 +39,7 @@ class FlowVersion(SQLModel, table=True):  # type: ignore[call-arg]
     # flow_id. No additional index is needed for the list/prune queries.
     __table_args__ = (
         UniqueConstraint("flow_id", "version_number", name="unique_flow_version_number"),
-        CheckConstraint("version_number >= 1", name="check_version_number_positive"),
+        CheckConstraint("version_number >= 1", name=conv(VERSION_NUMBER_CHECK_NAME)),
     )
 
 

--- a/src/backend/tests/unit/alembic/test_flow_version_check_constraint_naming.py
+++ b/src/backend/tests/unit/alembic/test_flow_version_check_constraint_naming.py
@@ -1,0 +1,115 @@
+"""Constraint-name parity for the ``flow_version`` ``version_number >= 1`` CHECK.
+
+The model marks the name with ``conv()`` and the migration with ``op.f()`` so both create paths
+render ``ck_flow_version_version_number_positive`` under the ``ck_%(table_name)s_%(constraint_name)s``
+convention that ``langflow/alembic/env.py`` installs. Databases created before that fix carry a
+legacy name and must be left untouched.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from langflow.services.database.models.flow_version.model import VERSION_NUMBER_CHECK_NAME, FlowVersion
+
+from .test_migration_execution import _engine_url, db_url  # noqa: F401
+
+_MIGRATION = importlib.import_module("langflow.alembic.versions.7d327cfafab6_add_flow_history_table")
+TABLE_NAME = "flow_version"
+# Mirrors NAMING_CONVENTION in ``langflow/alembic/env.py`` (env.py cannot be imported: it runs migrations on import).
+_NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+# Fresh installs created the table via create_all before env.py installed the convention.
+_LEGACY_PLAIN_NAME = "check_version_number_positive"
+# Upgraded installs created it via op.create_table, which prefixed the plain string.
+_LEGACY_DOUBLED_NAME = f"ck_{TABLE_NAME}_{_LEGACY_PLAIN_NAME}"
+
+
+def _convention_operations(connection: sa.Connection) -> Operations:
+    """Build Operations the way env.py does: create_table inherits the naming convention."""
+    return Operations(
+        MigrationContext.configure(
+            connection,
+            opts={"target_metadata": sa.MetaData(naming_convention=_NAMING_CONVENTION)},
+        )
+    )
+
+
+def _scratch_metadata(*, under_convention: bool) -> sa.MetaData:
+    """Return a MetaData holding stub ``user`` and ``flow`` tables so flow_version's foreign keys resolve."""
+    metadata = sa.MetaData(naming_convention=_NAMING_CONVENTION) if under_convention else sa.MetaData()
+    sa.Table("user", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    sa.Table("flow", metadata, sa.Column("id", sa.Uuid(), primary_key=True))
+    return metadata
+
+
+def _pre_fix_flow_version_table(metadata: sa.MetaData) -> sa.Table:
+    """Rebuild flow_version as the pre-fix model and migration declared it: a plain-string CHECK name."""
+    return sa.Table(
+        TABLE_NAME,
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("flow_id", sa.Uuid(), sa.ForeignKey("flow.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("data", sa.JSON(), nullable=True),
+        sa.Column("version_number", sa.Integer(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("flow_id", "version_number", name="unique_flow_version_number"),
+        sa.CheckConstraint("version_number >= 1", name=_LEGACY_PLAIN_NAME),
+    )
+
+
+def _reflected_check_names(connection: sa.Connection) -> set[str]:
+    return {constraint["name"] for constraint in sa.inspect(connection).get_check_constraints(TABLE_NAME)}
+
+
+@pytest.mark.parametrize("create_path", ["migration", "model_without_convention", "model_under_convention"])
+def test_flow_version_check_name_is_identical_across_create_paths(db_url, create_path, monkeypatch):  # noqa: F811
+    """Every way the table gets created must emit the one canonical CHECK name."""
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        if create_path == "migration":
+            _scratch_metadata(under_convention=False).create_all(engine)
+            with engine.begin() as connection:
+                monkeypatch.setattr(_MIGRATION, "op", _convention_operations(connection))
+                _MIGRATION.upgrade()
+        else:
+            metadata = _scratch_metadata(under_convention=create_path == "model_under_convention")
+            FlowVersion.__table__.to_metadata(metadata)
+            metadata.create_all(engine)
+
+        with engine.connect() as connection:
+            assert _reflected_check_names(connection) == {VERSION_NUMBER_CHECK_NAME}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("legacy_name", [_LEGACY_PLAIN_NAME, _LEGACY_DOUBLED_NAME])
+def test_migration_leaves_legacy_check_names_untouched(db_url, legacy_name, monkeypatch):  # noqa: F811
+    """Existing databases keep whichever legacy name they were created with; nothing renames or duplicates it."""
+    engine = sa.create_engine(_engine_url(db_url))
+    try:
+        metadata = _scratch_metadata(under_convention=legacy_name == _LEGACY_DOUBLED_NAME)
+        _pre_fix_flow_version_table(metadata)
+        metadata.create_all(engine)
+
+        with engine.begin() as connection:
+            assert _reflected_check_names(connection) == {legacy_name}
+
+            monkeypatch.setattr(_MIGRATION, "op", _convention_operations(connection))
+            _MIGRATION.upgrade()
+            _MIGRATION.upgrade()
+
+            assert _reflected_check_names(connection) == {legacy_name}
+    finally:
+        engine.dispose()

--- a/src/backend/tests/unit/services/database/models/flow_version/test_model.py
+++ b/src/backend/tests/unit/services/database/models/flow_version/test_model.py
@@ -1,0 +1,44 @@
+"""Schema contracts for the ``flow_version`` model."""
+
+from __future__ import annotations
+
+from langflow.services.database.models.flow_version.model import VERSION_NUMBER_CHECK_NAME, FlowVersion
+from sqlalchemy import CheckConstraint, Column, Integer, MetaData, Table
+from sqlalchemy.sql.naming import conv
+
+# Mirrors NAMING_CONVENTION in ``langflow/alembic/env.py`` (env.py cannot be imported: it runs migrations on import).
+_NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+def _check_names(table: Table) -> set[str]:
+    return {constraint.name for constraint in table.constraints if isinstance(constraint, CheckConstraint)}
+
+
+def test_flow_version_check_name_is_final_and_survives_naming_convention():
+    """The conv()-marked name must not be re-prefixed when the table is copied under env.py's convention."""
+    table = FlowVersion.__table__
+    check_names = _check_names(table)
+
+    assert check_names == {VERSION_NUMBER_CHECK_NAME}
+    assert all(isinstance(name, conv) for name in check_names)
+
+    copied = table.to_metadata(MetaData(naming_convention=_NAMING_CONVENTION))
+    assert _check_names(copied) == check_names
+
+
+def test_plain_string_check_name_is_re_prefixed_by_naming_convention():
+    """Negative control: a plain-string name is rewritten by the convention, which is the drift being guarded."""
+    table = Table(
+        "flow_version",
+        MetaData(naming_convention=_NAMING_CONVENTION),
+        Column("version_number", Integer),
+        CheckConstraint("version_number >= 1", name="check_version_number_positive"),
+    )
+
+    assert _check_names(table) == {"ck_flow_version_check_version_number_positive"}


### PR DESCRIPTION
## What changed

The `flow_version` table's `version_number >= 1` CHECK constraint now renders the same name on both create paths: `ck_flow_version_version_number_positive`.

### Root cause

`langflow/alembic/env.py` installs `"ck": "ck_%(table_name)s_%(constraint_name)s"` on `SQLModel.metadata`, and SQLAlchemy applies that template to any plain-string constraint name. Both definitions of this constraint used the plain string `check_version_number_positive`, so the name depended on which path created the table:

| Create path | Name emitted before this PR |
|---|---|
| Fresh install (`SQLModel.metadata.create_all`, before env.py installs the convention) | `check_version_number_positive` |
| Upgrade (`op.create_table` in `7d327cfafab6`, under the convention) | `ck_flow_version_check_version_number_positive` |

Nothing references the name in application code, so this is a consistency issue rather than a bug. It is the same class of drift fixed for `catalog_policy_rule` in #15006 / #15007; that guard only covers names that already start with `ck_`, so this one was not covered.

### Fix

- `flow_version/model.py`: wrap the name in `conv()` and expose it as `VERSION_NUMBER_CHECK_NAME` so tests do not repeat the literal.
- `7d327cfafab6_add_flow_history_table.py`: wrap the same name in `op.f()`. The migration is guarded by `table_exists`, so re-running it on an existing database is still a no-op.
- Existing databases are **not** renamed. A comment in the migration records both legacy names and the rule that any later migration that drops or looks up this constraint must accept all three (`check_version_number_positive`, `ck_flow_version_check_version_number_positive`, `ck_flow_version_version_number_positive`). `grep -rn version_number_positive src/` shows no other references.

Note: the table is `flow_version`; only the migration's filename says `flow_history`, which is why the canonical name is `ck_flow_version_...`.

### Tests

- `src/backend/tests/unit/services/database/models/flow_version/test_model.py`: asserts the model's name is a `conv` instance and survives `Table.to_metadata(MetaData(naming_convention=...))` unchanged, plus a negative control showing a plain string is re-prefixed.
- `src/backend/tests/unit/alembic/test_flow_version_check_constraint_naming.py` (parametrized over SQLite and PostgreSQL via `db_url`):
  - creates the table via the migration under the convention, via the model without it, and via the model under it, and asserts one reflected CHECK name;
  - rebuilds both legacy states through the original mechanisms, runs `upgrade()` twice, and asserts the legacy name is untouched and not duplicated.

## Verification

| Run | Result |
|---|---|
| New tests, SQLite + PostgreSQL 16 | 12 passed |
| Same tests against the pre-fix model/migration | 7 failed, 5 passed (legacy-untouched cases pass by design) |
| `uv run pytest src/backend/tests/unit/alembic` with `LANGFLOW_TEST_DATABASE_URI` set | 178 passed, 3 pre-existing skips |
| flow_version API, CRUD and deployment-attachment suites | 103 passed |
| `ruff check` / `ruff format` on touched files | clean |

The touched files are byte-identical on `main` and `release-1.12.2`, so the change applies to both without adaptation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized naming for the flow version number validation constraint across database creation and migration paths.
  * Preserved supported legacy constraint names without renaming or duplicating them during upgrades.

* **Tests**
  * Added coverage for consistent constraint naming with and without database naming conventions.
  * Added validation that legacy constraints remain unchanged across repeated migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->