### PR TITLE
fix: percent-encode slash in database connection passwords

### DIFF
--- a/src/backend/base/langflow/utils/connection_string_parser.py
+++ b/src/backend/base/langflow/utils/connection_string_parser.py
@@ -4,5 +4,5 @@ from urllib.parse import quote
 def transform_connection_string(connection_string) -> str:
     auth_part, db_url_name = connection_string.rsplit("@", 1)
     protocol_user, password_string = auth_part.rsplit(":", 1)
-    encoded_password = quote(password_string)
+    encoded_password = quote(password_string, safe="")
     return f"{protocol_user}:{encoded_password}@{db_url_name}"

--- a/src/backend/tests/unit/utils/test_connection_string_parser.py
+++ b/src/backend/tests/unit/utils/test_connection_string_parser.py
@@ -13,6 +13,8 @@ from langflow.utils.connection_string_parser import transform_connection_string
         ("protocol::password@host", "protocol::password@host"),
         ("protocol:user:password@", "protocol:user:password@"),
         ("protocol:user:pa@ss@word@host", "protocol:user:pa%40ss%40word@host"),
+        ("protocol:user:p/ss@host", "protocol:user:p%2Fss@host"),
+        ("postgresql://user:p@ss/w0rd@host:5432/db", "postgresql://user:p%40ss%2Fw0rd@host:5432/db"),
     ],
 )
 def test_transform_connection_string(connection_string, expected):

--- a/src/lfx/src/lfx/utils/connection_string_parser.py
+++ b/src/lfx/src/lfx/utils/connection_string_parser.py
@@ -7,5 +7,5 @@ def transform_connection_string(connection_string) -> str:
     """Transform connection string by encoding the password part."""
     auth_part, db_url_name = connection_string.rsplit("@", 1)
     protocol_user, password_string = auth_part.rsplit(":", 1)
-    encoded_password = quote(password_string)
+    encoded_password = quote(password_string, safe="")
     return f"{protocol_user}:{encoded_password}@{db_url_name}"


### PR DESCRIPTION
Fixes #15012.

`transform_connection_string` encoded the password with plain `quote()`, which leaves `/` unencoded (`safe='/'` default). A slash in the password survived into the URL and the connection string was misparsed, so connecting failed for those passwords.

Change: `quote(password, safe="")` in both copies of the helper (`lfx` and the `langflow` compat layer), plus regression cases in the existing unit test.

Verified: new cases fail before the fix and pass after; full `src/backend/tests/unit/utils/` suite passes (653 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection strings now correctly percent-encode slash and at-sign characters in password values.
  * PostgreSQL connection URLs with reserved characters in passwords are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->