### PR TITLE
fix: stop awaiting Celery revoke result so workflow stop works with celery enabled

### DIFF
--- a/src/backend/base/langflow/services/task/backends/celery.py
+++ b/src/backend/base/langflow/services/task/backends/celery.py
@@ -47,10 +47,11 @@ class CeleryBackend(TaskBackend):
         return AsyncResult(task_id, app=self.celery_app)
 
     def revoke_task(self, task_id: str) -> bool:
+        import contextlib
+
         from celery.exceptions import TaskRevokedError
         from celery.result import AsyncResult
 
-        try:
-            return AsyncResult(task_id, app=self.celery_app).revoke(terminate=True)
-        except TaskRevokedError:
-            return True
+        with contextlib.suppress(TaskRevokedError):
+            AsyncResult(task_id, app=self.celery_app).revoke(terminate=True)
+        return True

--- a/src/backend/base/langflow/services/task/service.py
+++ b/src/backend/base/langflow/services/task/service.py
@@ -92,7 +92,8 @@ class TaskService(Service):
 
     async def revoke_task(self, task_id: UUID | str) -> bool:
         if self.use_celery:
-            return await self.backend.revoke_task(str(task_id))
+            result = self.backend.revoke_task(str(task_id))
+            return await result if isinstance(result, Coroutine) else result
 
         job_queue_service = get_queue_service()
         try:

--- a/src/backend/tests/unit/services/tasks/test_task_service_revoke.py
+++ b/src/backend/tests/unit/services/tasks/test_task_service_revoke.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from langflow.services.task.service import TaskService
+
+
+def _celery_enabled_service() -> TaskService:
+    return TaskService(SimpleNamespace(settings=SimpleNamespace(celery_enabled=True)))
+
+
+def test_revoke_task_with_sync_backend_result():
+    """TaskService must not await a synchronous backend result."""
+    service = _celery_enabled_service()
+    seen: list[str] = []
+
+    class SyncBackend:
+        def revoke_task(self, task_id: str) -> bool:
+            seen.append(task_id)
+            return True
+
+    task_id = uuid4()
+    service.backend = SyncBackend()
+    assert asyncio.run(service.revoke_task(task_id)) is True
+    assert seen == [str(task_id)]
+
+
+def test_revoke_task_with_async_backend_result():
+    """TaskService must still await an async backend result."""
+    service = _celery_enabled_service()
+    seen: list[str] = []
+
+    class AsyncBackend:
+        async def revoke_task(self, task_id: str) -> bool:
+            seen.append(task_id)
+            return True
+
+    task_id = uuid4()
+    service.backend = AsyncBackend()
+    assert asyncio.run(service.revoke_task(task_id)) is True
+    assert seen == [str(task_id)]
+
+
+def test_revoke_task_celery_backend_broadcast():
+    """Real Celery revoke broadcast must resolve to True, not raise TypeError."""
+    pytest.importorskip("celery")
+    from celery import Celery
+
+    with (
+        Celery("test-revoke", broker="memory://", set_as_current=False) as app,
+        patch("langflow.worker.celery_app", app),
+    ):
+        assert asyncio.run(_celery_enabled_service().revoke_task(uuid4())) is True

--- a/src/backend/tests/unit/services/tasks/test_task_service_revoke.py
+++ b/src/backend/tests/unit/services/tasks/test_task_service_revoke.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -10,7 +9,12 @@ from langflow.services.task.service import TaskService
 
 
 def _celery_enabled_service() -> TaskService:
-    return TaskService(SimpleNamespace(settings=SimpleNamespace(celery_enabled=True)))
+    # Bypass __init__/get_backend so the sync/async tests run in envs
+    # without the optional celery dependency installed.
+    service = TaskService.__new__(TaskService)
+    service.use_celery = True
+    service.backend = None
+    return service
 
 
 def test_revoke_task_with_sync_backend_result():
@@ -54,4 +58,8 @@ def test_revoke_task_celery_backend_broadcast():
         Celery("test-revoke", broker="memory://", set_as_current=False) as app,
         patch("langflow.worker.celery_app", app),
     ):
-        assert asyncio.run(_celery_enabled_service().revoke_task(uuid4())) is True
+        from langflow.services.task.backends.celery import CeleryBackend
+
+        service = _celery_enabled_service()
+        service.backend = CeleryBackend()
+        assert asyncio.run(service.revoke_task(uuid4())) is True


### PR DESCRIPTION
With celery enabled, stopping a workflow job always failed. Celery's revoke call is synchronous and returns None, but the task service awaited it, so every cancellation raised TypeError before the job status was updated.

This returns True from the Celery backend once the revoke is published, and only awaits the backend result in the service when it is actually a coroutine (same pattern as launch_task).

Fixes #14943

Reproduced with the snippet from the issue (real Celery, memory transport): TypeError before, True after. New tests in test_task_service_revoke.py fail without the fix and pass with it. Neighbors pass: services/tasks plus revoke/cancel tests in api/v2/test_workflow.py and test_knowledge_bases_api.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cancellation handling for both synchronous and asynchronous backends.
  * Prevented errors when cancelling tasks through Celery, with successful revocations now resolving consistently.

* **Tests**
  * Added coverage for synchronous results, asynchronous results, and Celery task cancellation broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Note: CI Group 5 caught that the new tests imported the optional celery dependency at service-construction time (`ModuleNotFoundError: No module named 'celery'`). Fixed by building the test double via `TaskService.__new__` with `use_celery=True` instead of going through `get_backend()`; the broadcast test still wires the real `CeleryBackend` behind `importorskip("celery")`.