### PR TITLE
fix(deps): override shell-quote and websocket-driver in docs/ to patched versions

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -18865,9 +18865,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -21091,9 +21091,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -54,6 +54,8 @@
     "node": "22.22.0"
   },
   "overrides": {
+    "shell-quote": "^1.8.4",
+    "websocket-driver": "^0.7.5",
     "brace-expansion": "^5.0.9",
     "ip-address": "^10.3.1",
     "undici": "^7.29.0",


### PR DESCRIPTION
## Summary

`docs/package-lock.json` resolves two transitive dev-toolchain dependencies to versions with known CVEs. Neither is a direct dependency of `docs/package.json` — both come in via `@docusaurus/core`'s `webpack-dev-server`:

- **shell-quote 1.8.3** (via `launch-editor`) — [CVE-2026-9277](https://github.com/advisories/GHSA-w7jw-789q-3m8p), arbitrary code execution via command injection. Fixed upstream in 1.8.4.
- **websocket-driver 0.7.4** (via `sockjs` → `faye-websocket`) — [CVE-2026-54466](https://github.com/advisories/GHSA-xv26-6w52-cph6). Fixed upstream in 0.7.5.

Found via automated dependency scanning, cross-confirmed by two independent engines (OSV-Scanner + Trivy).

## Approach

Since both are transitive-only, bumping the direct dependency that pulls them in isn't possible without an unrelated Docusaurus upgrade. This uses npm's native `overrides` field instead — the same mechanism `docs/package.json` already uses for `brace-expansion`/`ip-address`/`undici`/etc. just above these two entries — to pin the resolved version across the whole tree regardless of which parent requests it.

`package-lock.json` was regenerated for real via `npm install` against the new overrides, not hand-edited.

## Verification

```
$ npm ls shell-quote websocket-driver
└─┬ @docusaurus/core@3.9.2
  └─┬ webpack-dev-server@5.2.2
    ├─┬ launch-editor@2.12.0
    │ └── shell-quote@1.10.0 overridden
    └─┬ sockjs@0.3.24
      ├─┬ faye-websocket@0.11.4
      │ └── websocket-driver@0.7.5 deduped
      └── websocket-driver@0.7.5 overridden
```

A fresh OSV-Scanner pass against the regenerated lockfile reports zero remaining advisories for either package. No other dependency version changed — diff is limited to these two override entries plus the corresponding lockfile updates.

## Why this and not Dependabot

This repo's `dependabot.yml` currently covers `github-actions` only, so npm/pip ecosystems (including `docs/`) aren't on an automated update path yet — this was caught by a one-off manual scan rather than an existing bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHdnN5YdqU5YczHRmsmpXn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation tooling dependency resolutions for improved compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->