### PR TITLE
fix: allow vectorizing multiple knowledge base columns

### DIFF
--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/__tests__/tableComponent.vectorize.test.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/__tests__/tableComponent.vectorize.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, waitFor, within } from "@testing-library/react";
+import type { GridApi } from "ag-grid-community";
+import { FormatterType } from "@/types/utils/functions";
+import { FormatColumns } from "@/utils/utils";
+import TableComponent, { type TableComponentProps } from "../index";
+
+type EditableMode = "all" | "fields" | "callbacks";
+
+function renderColumnConfig(
+  mode: EditableMode,
+  vectorizeField = "vectorize",
+  editableCell = true,
+) {
+  const onUpdate = jest.fn();
+  const rowData = [
+    { column_name: "question", [vectorizeField]: true, identifier: true },
+    { column_name: "answer", [vectorizeField]: false, identifier: false },
+    { column_name: "category", [vectorizeField]: false, identifier: false },
+  ];
+  const fields = [vectorizeField, "identifier"];
+  const editable: TableComponentProps["editable"] =
+    mode === "all"
+      ? true
+      : mode === "fields"
+        ? fields
+        : fields.map((field) => ({
+            field,
+            editableCell,
+            onUpdate,
+          }));
+  let api: GridApi;
+  const result = render(
+    <TableComponent
+      columnDefs={FormatColumns(
+        fields.map((name) => ({
+          name,
+          display_name: name,
+          sortable: false,
+          filterable: false,
+          formatter: FormatterType.boolean,
+          edit_mode: "inline",
+        })),
+      )}
+      context={{}}
+      editable={editable}
+      rowData={rowData}
+      onCellValueChanged={mode === "callbacks" ? undefined : onUpdate}
+      onGridReady={(event) => {
+        api = event.api;
+      }}
+      suppressColumnVirtualisation
+      suppressRowVirtualisation
+    />,
+  );
+
+  function getToggle(rowIndex: number, field = vectorizeField) {
+    const cell = result.container.querySelector<HTMLElement>(
+      `[row-index="${rowIndex}"] [col-id="${field}"]`,
+    );
+    expect(cell).not.toBeNull();
+    return within(cell!).getByRole("switch");
+  }
+
+  return { ...result, getApi: () => api, getToggle, onUpdate, rowData };
+}
+
+describe.each<EditableMode>(["all", "fields", "callbacks"])(
+  "TableComponent vectorization with %s editability",
+  (mode) => {
+    it.each(["vectorize", "Vectorize"])(
+      "edits multiple %s rows independently and reports boolean values",
+      async (field) => {
+        const { getApi, getToggle, onUpdate, rowData } = renderColumnConfig(
+          mode,
+          field,
+        );
+        await waitFor(() => expect(getToggle(1)).toBeEnabled());
+
+        // Both the inline editor and the rendered switch must stay editable.
+        const api = getApi();
+        const column = api.getColumn(field)!;
+        expect(column.isCellEditable(api.getDisplayedRowAtIndex(1)!)).toBe(
+          true,
+        );
+
+        fireEvent.click(getToggle(1));
+        fireEvent.click(getToggle(2));
+
+        await waitFor(() => {
+          expect(rowData.map((row) => row[field])).toEqual([true, true, true]);
+          expect(getToggle(0)).toBeChecked();
+          expect(getToggle(1)).toBeChecked();
+          expect(getToggle(2)).toBeChecked();
+        });
+        expect(onUpdate).toHaveBeenCalledTimes(2);
+        expect(onUpdate).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            data: rowData[2],
+            newValue: true,
+            oldValue: false,
+          }),
+        );
+
+        fireEvent.click(getToggle(0));
+        await waitFor(() => {
+          expect(rowData.map((row) => row[field])).toEqual([false, true, true]);
+          expect(getToggle(0)).not.toBeChecked();
+        });
+        expect(column.isCellEditable(api.getDisplayedRowAtIndex(0)!)).toBe(
+          true,
+        );
+
+        fireEvent.click(getToggle(0));
+        await waitFor(() => expect(getToggle(0)).toBeChecked());
+        expect(rowData.map((row) => row[field])).toEqual([true, true, true]);
+        expect(rowData.map((row) => row.identifier)).toEqual([
+          true,
+          false,
+          false,
+        ]);
+
+        // Saving the table reads these same grid rows.
+        const savedRows: unknown[] = [];
+        api.forEachNode((node) => savedRows.push(node.data));
+        expect(savedRows).toEqual(rowData);
+      },
+    );
+
+    it("preserves the identifier single-selection behavior", async () => {
+      const { getApi, getToggle, rowData } = renderColumnConfig(mode);
+      await waitFor(() => expect(getToggle(1, "identifier")).toBeDisabled());
+      const api = getApi();
+      expect(
+        api
+          .getColumn("identifier")!
+          .isCellEditable(api.getDisplayedRowAtIndex(1)!),
+      ).toBe(false);
+
+      fireEvent.click(getToggle(0, "identifier"));
+      // Callback-based editors refresh the grid without a parent re-render.
+      await waitFor(() => expect(getToggle(1, "identifier")).toBeEnabled());
+      fireEvent.click(getToggle(1, "identifier"));
+      await waitFor(() => expect(getToggle(0, "identifier")).toBeDisabled());
+      expect(rowData.map((row) => row.identifier)).toEqual([
+        false,
+        true,
+        false,
+      ]);
+    });
+  },
+);
+
+it("keeps explicitly read-only vectorize cells disabled", async () => {
+  const { getApi, getToggle, onUpdate, rowData } = renderColumnConfig(
+    "callbacks",
+    "vectorize",
+    false,
+  );
+  await waitFor(() => expect(getToggle(1)).toBeDisabled());
+  expect(getToggle(0)).toBeDisabled();
+  const api = getApi();
+  expect(
+    api.getColumn("vectorize")!.isCellEditable(api.getDisplayedRowAtIndex(1)!),
+  ).toBe(false);
+
+  fireEvent.click(getToggle(1));
+  expect(onUpdate).not.toHaveBeenCalled();
+  expect(rowData.map((row) => row.vectorize)).toEqual([true, false, false]);
+});

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAutoCellRender/index.tsx
@@ -162,10 +162,11 @@ export default function TableAutoCellRender({
             editNode={true}
             id={"toggle" + colDef?.colId + uniqueId()}
             disabled={
-              colDef?.cellRendererParams?.isSingleToggleColumn &&
+              colDef?.cellRendererParams?.editableCell === false ||
+              (colDef?.cellRendererParams?.isSingleToggleColumn &&
               colDef?.cellRendererParams?.checkSingleToggleEditable
                 ? !colDef.cellRendererParams.checkSingleToggleEditable(props)
-                : false
+                : false)
             }
           />
         ) : (

--- a/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
+++ b/src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/index.tsx
@@ -90,12 +90,9 @@ const TableComponent = forwardRef<
       currentRowValue: any,
     ) => {
       try {
-        // Check if this is a single-toggle column (Vectorize or Identifier)
+        // Vectorize flags are independent; only Identifier is single-toggle.
         const isSingleToggleColumn =
-          colField === "Vectorize" ||
-          colField === "vectorize" ||
-          colField === "Identifier" ||
-          colField === "identifier";
+          colField === "Identifier" || colField === "identifier";
 
         if (!isSingleToggleColumn) return true;
 
@@ -169,12 +166,9 @@ const TableComponent = forwardRef<
             props.editable.every((field) => typeof field === "string") &&
             (props.editable as Array<string>).includes(newCol.field ?? ""))
         ) {
-          // Special handling for single-toggle columns (Vectorize and Identifier)
+          // Special handling for single-toggle Identifier columns
           const isSingleToggleColumn =
-            newCol.field === "Vectorize" ||
-            newCol.field === "vectorize" ||
-            newCol.field === "Identifier" ||
-            newCol.field === "identifier";
+            newCol.field === "Identifier" || newCol.field === "identifier";
 
           if (isSingleToggleColumn) {
             newCol = {
@@ -226,12 +220,9 @@ const TableComponent = forwardRef<
             }>
           ).find((field) => field.field === newCol.field);
           if (field) {
-            // Special handling for single-toggle columns (Vectorize and Identifier)
+            // Special handling for single-toggle Identifier columns
             const isSingleToggleColumn =
-              newCol.field === "Vectorize" ||
-              newCol.field === "vectorize" ||
-              newCol.field === "Identifier" ||
-              newCol.field === "identifier";
+              newCol.field === "Identifier" || newCol.field === "identifier";
 
             if (isSingleToggleColumn) {
               newCol = {
@@ -285,6 +276,10 @@ const TableComponent = forwardRef<
               newCol = {
                 ...newCol,
                 editable: field.editableCell,
+                cellRendererParams: {
+                  ...newCol.cellRendererParams,
+                  editableCell: field.editableCell,
+                },
                 onCellValueChanged: (e) => field.onUpdate(e),
               };
             }
@@ -666,10 +661,8 @@ const TableComponent = forwardRef<
           onCellValueChanged={
             props.onCellValueChanged
               ? (e) => {
-                  // Handle single-toggle column changes (Vectorize and Identifier) to refresh grid editability
+                  // Refresh grid editability after single-toggle Identifier changes
                   const isSingleToggleField =
-                    e.colDef.field === "Vectorize" ||
-                    e.colDef.field === "vectorize" ||
                     e.colDef.field === "Identifier" ||
                     e.colDef.field === "identifier";
 
@@ -692,10 +685,7 @@ const TableComponent = forwardRef<
                           ?.filter((col) => {
                             const field = col.getColDef().field;
                             return (
-                              field === "Vectorize" ||
-                              field === "vectorize" ||
-                              field === "Identifier" ||
-                              field === "identifier"
+                              field === "Identifier" || field === "identifier"
                             );
                           });
                         if (


### PR DESCRIPTION
Allow multiple columns to be marked Vectorize in Knowledge Base column configuration. Remove the shared table's single-selection restriction for vectorize fields while preserving identifier selection and explicitly read-only cells.

Fixes #14994.

Validation:
- Six real-grid regression cases fail on the release base and pass with the fix; all 148 table and Knowledge Base upload tests pass.
- Production frontend build and Biome checks pass.
- Full TypeScript checking produces the same 254 existing diagnostics as the unchanged release base, with no new diagnostics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved editing behavior for Vectorize boolean fields across supported editability modes.
  - Vectorize switches now correctly support inline and switch-based updates, with boolean values reported consistently.
  - Explicitly read-only Vectorize fields remain disabled and do not trigger update callbacks.
  - Preserved single-selection behavior for Identifier fields.
- **Tests**
  - Added coverage for Vectorize and Identifier toggle rendering, editing, read-only states, and update callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->