### PR TITLE
fix(ci): start patch-release RCs at rc0 when the SDK is unchanged

### DIFF
--- a/.github/workflows/ci-scripts-test.yml
+++ b/.github/workflows/ci-scripts-test.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "scripts/ci/**"
       - ".github/workflows/ci-scripts-test.yml"
+      - ".github/workflows/release.yml"
       - "pyproject.toml"
       - "src/bundles/*/pyproject.toml"
       - "src/bundles/lfx-bundles/src/lfx_bundles/*/__init__.py"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,19 @@ jobs:
             fi
           }
 
+          # A package whose final is already on PyPI is reused rather than re-released,
+          # so the RCs it shipped in an earlier cycle must not raise the shared number.
+          consider_unreleased_versions() {
+            local label="$1"
+            local base_version="$2"
+            local versions_file="$3"
+            if grep -Fxq "$base_version" "$versions_file"; then
+              echo "${label}: final ${base_version} is already published; excluding its historical RCs."
+              return
+            fi
+            consider_versions "$label" "$base_version" "$versions_file"
+          }
+
           tmp_dir="$(mktemp -d)"
 
           if [ "${{ inputs.release_package_main }}" = "true" ]; then
@@ -344,7 +357,7 @@ jobs:
           if [ "${{ inputs.release_sdk || inputs.release_lfx }}" = "true" ]; then
             version="$(read_pyproject_version src/sdk/pyproject.toml)"
             fetch_pypi_versions "langflow-sdk" "$tmp_dir/langflow-sdk-pypi.txt"
-            consider_versions "PyPI langflow-sdk" "$version" "$tmp_dir/langflow-sdk-pypi.txt"
+            consider_unreleased_versions "PyPI langflow-sdk" "$version" "$tmp_dir/langflow-sdk-pypi.txt"
           fi
 
           if [ "${{ inputs.release_bundles }}" = "true" ]; then
@@ -361,11 +374,7 @@ jobs:
               version="$(read_pyproject_version "$pyproject")"
               output_file="$tmp_dir/${package_name}-pypi.txt"
               fetch_pypi_versions "$package_name" "$output_file"
-              if grep -Fxq "$version" "$output_file"; then
-                echo "PyPI ${package_name}: final ${version} is already published; excluding its historical RCs."
-              else
-                consider_versions "PyPI ${package_name}" "$version" "$output_file"
-              fi
+              consider_unreleased_versions "PyPI ${package_name}" "$version" "$output_file"
             done
           fi
 
@@ -591,10 +600,19 @@ jobs:
             fi
           else
             if [ ${{inputs.pre_release}} == "true" ]; then
-              rc_number="${{ needs.determine-rc-number.outputs.rc_number }}"
-              version="$(uv run ./scripts/ci/langflow_pre_release_tag.py "$version" --rc-number "$rc_number")"
-              echo "Shared release candidate number: rc$rc_number"
-              echo "SDK pre-release version to be released: $version"
+              # Fail the step rather than guess: determine-rc-number left a published SDK out of
+              # the shared number, so minting an RC of it by mistake could collide on PyPI.
+              sdk_pypi_json="$(curl --retry 3 --retry-delay 2 --retry-connrefused -fsS "https://pypi.org/pypi/langflow-sdk/json")"
+              sdk_published="$(jq --arg version "$version" '.releases | has($version)' <<< "$sdk_pypi_json")"
+              if [ "$sdk_published" = "true" ]; then
+                echo "SDK $version is already published; reusing it for this pre-release."
+                last_released_version="$version"
+              else
+                rc_number="${{ needs.determine-rc-number.outputs.rc_number }}"
+                version="$(uv run ./scripts/ci/langflow_pre_release_tag.py "$version" --rc-number "$rc_number")"
+                echo "Shared release candidate number: rc$rc_number"
+                echo "SDK pre-release version to be released: $version"
+              fi
             else
               last_released_version=$(curl -s "https://pypi.org/pypi/langflow-sdk/json" | jq -r '.releases | keys | .[]' | grep -vE '(a|b|rc|dev|alpha|beta)' | sort -V | tail -n 1)
               echo "Latest SDK release version: $last_released_version"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -169,7 +169,7 @@
         "filename": ".github/workflows/release.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 624,
+        "line_number": 642,
         "is_secret": false
       }
     ],
@@ -7417,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-08T15:45:42Z"
+  "generated_at": "2026-09-10T23:04:46Z"
 }

--- a/scripts/ci/test_release_rc_number.py
+++ b/scripts/ci/test_release_rc_number.py
@@ -1,0 +1,254 @@
+"""Run release.yml's RC-numbering steps against fixture PyPI data.
+
+``test_release_workflow.py`` pins the workflow's text; these tests execute the
+real ``run:`` scripts, with ``curl`` and ``uv`` stubbed, so a regression in what
+the steps compute fails here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+TAG_SCRIPT = Path(__file__).resolve().parent / "langflow_pre_release_tag.py"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="the release workflow steps need bash and jq",
+)
+
+PROJECT_DIRS = {
+    "langflow": ".",
+    "langflow-base": "src/backend/base",
+    "lfx": "src/lfx",
+    "langflow-sdk": "src/sdk",
+    "lfx-google": "src/bundles/lfx-google",
+}
+
+# PyPI as it stood when release-1.12.2 was cut: the SDK and the bundle rode
+# through the 1.12.0 RC cycle and shipped finals that 1.12.2 reuses unchanged.
+PYPI_AFTER_1_12_1 = {
+    "langflow": [*(f"1.12.0rc{n}" for n in range(5)), "1.12.0", "1.12.1"],
+    "langflow-base": [*(f"1.12.0rc{n}" for n in range(5)), "1.12.0", "1.12.1"],
+    "lfx": [*(f"1.12.0rc{n}" for n in range(5)), "1.12.0", "1.12.1"],
+    "langflow-sdk": [*(f"0.4.0rc{n}" for n in range(5)), "0.4.0"],
+    "lfx-google": [*(f"0.1.1rc{n}" for n in range(4)), "0.1.1"],
+}
+VERSIONS_1_12_2 = {
+    "langflow": "1.12.2",
+    "langflow-base": "1.12.2",
+    "lfx": "1.12.2",
+    "langflow-sdk": "0.4.0",
+    "lfx-google": "0.1.1",
+}
+FULL_PRERELEASE_INPUTS = {
+    "inputs.release_package_main": "true",
+    "inputs.release_package_base": "true",
+    "inputs.release_lfx": "true",
+    "inputs.release_sdk || inputs.release_lfx": "true",
+    "inputs.release_bundles": "true",
+    "inputs.build_docker_main": "false",
+    "inputs.build_docker_base": "false",
+}
+
+# Serves $PYPI_FIXTURES/<package>.json (404 when absent), honouring -o and -w.
+# From call number $PYPI_DOWN_FROM_CALL onwards it fails like an unreachable PyPI.
+CURL_STUB = """\
+#!/usr/bin/env python3
+import os, sys
+from pathlib import Path
+
+fixtures = Path(os.environ["PYPI_FIXTURES"])
+calls = fixtures / ".calls"
+call = int(calls.read_text()) + 1 if calls.exists() else 1
+calls.write_text(str(call))
+down_from = int(os.environ.get("PYPI_DOWN_FROM_CALL", "0"))
+if down_from and call >= down_from:
+    sys.exit("curl: (7) Failed to connect to pypi.org port 443")
+
+args = sys.argv[1:]
+url = next(arg for arg in args if arg.startswith("https://pypi.org/pypi/"))
+fixture = fixtures / (url.split("/")[-2] + ".json")
+status, body = ("200", fixture.read_text()) if fixture.exists() else ("404", "{}")
+if "-o" in args:
+    Path(args[args.index("-o") + 1]).write_text(body)
+else:
+    sys.stdout.write(body)
+if "-w" in args:
+    sys.stdout.write(status)
+"""
+UV_STUB = """\
+#!/usr/bin/env bash
+[ "$1" = run ] || { echo "unexpected uv invocation: $*" >&2; exit 1; }
+shift
+exec python3 "$@"
+"""
+
+
+def _step_script(job: str, step: str) -> str:
+    lines = WORKFLOW_PATH.read_text(encoding="utf-8").splitlines()
+    job_at = lines.index(f"  {job}:")
+    step_at = next(i for i in range(job_at, len(lines)) if lines[i].strip() == f"- name: {step}")
+    run_at = next(i for i in range(step_at, len(lines)) if lines[i].strip() == "run: |")
+    run_indent = len(lines[run_at]) - len(lines[run_at].lstrip())
+    body = []
+    for line in lines[run_at + 1 :]:
+        if line.strip() and len(line) - len(line.lstrip()) <= run_indent:
+            break
+        body.append(line)
+    return textwrap.dedent("\n".join(body))
+
+
+def _render(script: str, expressions: dict[str, str]) -> str:
+    def substitute(match: re.Match[str]) -> str:
+        expression = match.group(1)
+        if expression not in expressions:
+            msg = f"unmapped workflow expression: {expression}"
+            raise KeyError(msg)
+        return expressions[expression]
+
+    return re.sub(r"\$\{\{\s*(.*?)\s*\}\}", substitute, script)
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_step(
+    tmp_path: Path,
+    *,
+    job: str,
+    step: str,
+    expressions: dict[str, str],
+    versions: dict[str, str],
+    releases: dict[str, list[str]],
+    pypi_down_from_call: int = 0,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    workspace = tmp_path / "repo"
+    for package, version in versions.items():
+        project = workspace / PROJECT_DIRS[package] / "pyproject.toml"
+        project.parent.mkdir(parents=True, exist_ok=True)
+        project.write_text(f'[project]\nname = "{package}"\nversion = "{version}"\n', encoding="utf-8")
+    (workspace / "scripts" / "ci").mkdir(parents=True)
+    shutil.copy(TAG_SCRIPT, workspace / "scripts" / "ci" / TAG_SCRIPT.name)
+
+    fixtures = tmp_path / "pypi"
+    fixtures.mkdir()
+    for package, released in releases.items():
+        (fixtures / f"{package}.json").write_text(json.dumps({"releases": {version: [] for version in released}}))
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "python3", f'#!/usr/bin/env bash\nexec {shlex.quote(sys.executable)} "$@"\n')
+    _write_executable(bin_dir / "curl", CURL_STUB)
+    _write_executable(bin_dir / "uv", UV_STUB)
+
+    github_output = tmp_path / "github_output"
+    github_output.touch()
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "GITHUB_OUTPUT": str(github_output),
+        "PYPI_FIXTURES": str(fixtures),
+        "PYPI_DOWN_FROM_CALL": str(pypi_down_from_call),
+    }
+    script = _render(_step_script(job, step), expressions)
+    # GitHub runs a step without an explicit `shell:` as `bash -e {0}`.
+    result = subprocess.run(  # noqa: S603
+        ["bash", "-e", "-c", script],  # noqa: S607
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    outputs = dict(line.split("=", 1) for line in github_output.read_text().splitlines())
+    return result, outputs
+
+
+def _shared_rc_number(tmp_path: Path, versions: dict[str, str], releases: dict[str, list[str]]) -> str:
+    result, outputs = _run_step(
+        tmp_path,
+        job="determine-rc-number",
+        step="Determine shared pre-release RC number",
+        expressions=FULL_PRERELEASE_INPUTS,
+        versions=versions,
+        releases=releases,
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    return outputs["rc_number"]
+
+
+def _run_sdk_version_step(
+    tmp_path: Path,
+    versions: dict[str, str],
+    releases: dict[str, list[str]],
+    rc_number: str,
+    pypi_down_from_call: int = 0,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    return _run_step(
+        tmp_path,
+        job="determine-sdk-version",
+        step="Determine version",
+        expressions={"inputs.pre_release": "true", "needs.determine-rc-number.outputs.rc_number": rc_number},
+        versions=versions,
+        releases=releases,
+        pypi_down_from_call=pypi_down_from_call,
+    )
+
+
+def _sdk_version(
+    tmp_path: Path, versions: dict[str, str], releases: dict[str, list[str]], rc_number: str
+) -> tuple[str, str]:
+    result, outputs = _run_sdk_version_step(tmp_path, versions, releases, rc_number)
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    return outputs["version"], outputs["skipped"]
+
+
+def test_first_rc_of_a_patch_release_starts_at_rc0(tmp_path: Path) -> None:
+    assert _shared_rc_number(tmp_path, VERSIONS_1_12_2, PYPI_AFTER_1_12_1) == "0"
+
+
+def test_langflow_rc_history_for_the_same_version_raises_the_shared_number(tmp_path: Path) -> None:
+    releases = {**PYPI_AFTER_1_12_1, "langflow": [*PYPI_AFTER_1_12_1["langflow"], "1.12.2rc0", "1.12.2rc1"]}
+
+    assert _shared_rc_number(tmp_path, VERSIONS_1_12_2, releases) == "2"
+
+
+def test_rc_history_of_an_sdk_being_released_still_raises_the_shared_number(tmp_path: Path) -> None:
+    versions = {**VERSIONS_1_12_2, "langflow-sdk": "0.4.1"}
+    releases = {**PYPI_AFTER_1_12_1, "langflow-sdk": [*PYPI_AFTER_1_12_1["langflow-sdk"], "0.4.1rc0", "0.4.1rc1"]}
+
+    assert _shared_rc_number(tmp_path, versions, releases) == "2"
+
+
+def test_prerelease_reuses_an_already_published_sdk_final(tmp_path: Path) -> None:
+    assert _sdk_version(tmp_path, VERSIONS_1_12_2, PYPI_AFTER_1_12_1, rc_number="0") == ("0.4.0", "true")
+
+
+def test_prerelease_builds_an_rc_for_an_unreleased_sdk_version(tmp_path: Path) -> None:
+    versions = {**VERSIONS_1_12_2, "langflow-sdk": "0.4.1"}
+
+    assert _sdk_version(tmp_path, versions, PYPI_AFTER_1_12_1, rc_number="2") == ("0.4.1rc2", "false")
+
+
+def test_prerelease_fails_instead_of_minting_an_sdk_rc_when_pypi_is_unreachable(tmp_path: Path) -> None:
+    # PyPI answers the step's first probe, then drops out before the "already published?" check.
+    result, outputs = _run_sdk_version_step(
+        tmp_path, VERSIONS_1_12_2, PYPI_AFTER_1_12_1, rc_number="0", pypi_down_from_call=2
+    )
+
+    assert result.returncode != 0
+    assert "Failed to connect to pypi.org" in result.stderr
+    assert outputs == {}

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -24,9 +24,10 @@ def _job_block(path: Path, start_job: str, end_job: str) -> str:
 def test_finalized_bundles_do_not_influence_shared_rc_number() -> None:
     rc_job = _job_block(WORKFLOW_PATH, "determine-rc-number", "determine-base-version")
 
-    assert 'if grep -Fxq "$version" "$output_file"; then' in rc_job
+    assert 'if grep -Fxq "$base_version" "$versions_file"; then' in rc_job
     assert "excluding its historical RCs" in rc_job
-    assert 'consider_versions "PyPI ${package_name}"' in rc_job
+    assert 'consider_unreleased_versions "PyPI ${package_name}"' in rc_job
+    assert 'consider_unreleased_versions "PyPI langflow-sdk"' in rc_job
     assert "langflow-core" not in rc_job
 
 


### PR DESCRIPTION
## Summary

Cutting the first RC of a patch release picks up the RC number of the *previous* minor cycle: the first 1.12.2 RC comes out as `1.12.2rc5` (the number 1.12.0's next RC would have used) instead of `1.12.2rc0`.

### Root cause

`determine-rc-number` takes the max of `langflow_pre_release_tag.py --print-rc-number` across every package the run publishes. `next_rc_number()` returns `max(rcN) + 1` for a base version **even when that exact final is already published**. `langflow-sdk` isn't bumped for patch releases (it's still `0.4.0` on release-1.12.2), and PyPI still has `0.4.0rc0`…`0.4.0rc4` from the 1.12.0 cycle, so the SDK contributes `5` and wins:

```
PyPI langflow: next rc number for 1.12.2 is 0
PyPI langflow-base: next rc number for 1.12.2 is 0
PyPI lfx: next rc number for 1.12.2 is 0
PyPI langflow-sdk: next rc number for 0.4.0 is 5
Shared pre-release rc number: 5
```

Bundles already had a guard for exactly this case (`final … is already published; excluding its historical RCs`). The SDK path didn't.

### Fix

- **`determine-rc-number`**: move the bundle guard into a `consider_unreleased_versions` helper and use it for `langflow-sdk` too. langflow / langflow-base / lfx still count their RC history on purpose: a pre-release run always publishes them, so their RC numbers have to stay collision-free.
- **`determine-sdk-version`**: in pre-release mode, reuse an already-published SDK final (`skipped=true`) instead of minting an RC. This change is required. Once the SDK stops raising the shared number, the RC would be `0.4.0rc0`, which already exists on PyPI, so `publish-sdk` would fail. It also matches the stable path, which already skips an unchanged SDK. `build-lfx`, `test-cross-platform`, `release-inventory` and `publish-lfx` already handle `build-sdk` being skipped, and lfx's `langflow-sdk>=0.4.0` resolves to the published final.
- That PyPI lookup retries and **fails the step** on a network or parse error instead of falling through to "not published". Falling through would silently bring the collision back.
- `ci-scripts-test.yml` now also triggers on `release.yml`, so edits to these steps run the tests that cover them.

## Tests

New `scripts/ci/test_release_rc_number.py` pulls the real `run:` scripts out of `release.yml` and runs them under `bash -e` with `curl`/`uv` stubbed against fixture PyPI data. The fixture matches PyPI as of 1.12.1. The existing tests only check the workflow's text, so they couldn't catch a wrong computed number.

| Case | Before | After |
|---|---|---|
| First 1.12.2 RC, SDK unchanged | `rc5` | `rc0` |
| langflow already has `1.12.2rc0`, `rc1` | `rc5` | `rc2` |
| SDK bumped to `0.4.1` with `0.4.1rc0`, `rc1` on PyPI | `rc2` | `rc2` (still coordinates) |
| SDK step, `0.4.0` final published | `0.4.0rc0`, `skipped=false` | `0.4.0`, `skipped=true` |
| SDK step, PyPI unreachable mid-step | exit 0, mints `0.4.0rc0` | step fails |

## Test plan

- [x] `python -m pytest scripts/ci/`: 157 passed
- [x] Patched `determine-rc-number` step with real `curl` against live PyPI and Docker Hub on this branch → `rc_number=0` (SDK and 22 published bundles excluded)
- [x] Patched `determine-sdk-version` step against live PyPI → `version=0.4.0`, `skipped=true`
- [ ] Dry-run `release.yml` as a pre-release on `release-1.12.2`: `Determine Shared RC Number` logs `Shared pre-release rc number: 0` and `Determine SDK Version` logs `SDK 0.4.0 is already published; reusing it for this pre-release.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release candidate numbering now ignores versions already published on PyPI, preventing historical releases from inflating new RC numbers.
  * Published SDK versions are reused when appropriate instead of generating unnecessary new release candidates.
  * Release workflow validation now better handles unavailable package registry responses.

* **Tests**
  * Expanded release workflow coverage for RC numbering, SDK version reuse, shared package histories, and registry failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->