### PR TITLE
fix(mcp): honor explicit SSE mode and treat HTTP 400 as SSE-fallback signal

### DIFF
--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -4162,6 +4162,100 @@ class TestStreamableHttpTransportPolicy:
         assert _should_attempt_sse_after_streamable_failure(ConnectionError("x")) is False
 
 
+class TestExplicitSseMode:
+    """Regression tests: explicit SSE mode must not probe Streamable HTTP, and an
+    HTTP 400 from an SSE-only server must trigger the SSE fallback instead of
+    being retried as transient."""
+
+    def _connection_params(self):
+        return {
+            "url": "http://test-mcp.example/mcp",
+            "headers": {},
+            "timeout_seconds": 30,
+            "verify_ssl": True,
+        }
+
+    def _fake_client_session(self):
+        inst = MagicMock()
+        inst.initialize = AsyncMock()
+        inst.__aenter__ = AsyncMock(return_value=inst)
+        inst.__aexit__ = AsyncMock(return_value=None)
+        return inst
+
+    def test_400_is_not_transient(self):
+        req = httpx.Request("GET", "http://x")
+        resp_400 = httpx.Response(400, request=req)
+        assert _is_transient_streamable_http_error(httpx.HTTPStatusError("x", request=req, response=resp_400)) is False
+
+    def test_sse_fallback_after_400(self):
+        req = httpx.Request("GET", "http://x")
+        resp_400 = httpx.Response(400, request=req)
+        e = httpx.HTTPStatusError("x", request=req, response=resp_400)
+        assert _should_attempt_sse_after_streamable_failure(e) is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_sse_preference_skips_streamable_probe(self):
+        manager = MCPSessionManager()
+        try:
+            fake_sse = self._fake_client_session()
+            stream_cm = MagicMock()
+            sse_cm = MagicMock()
+            sse_cm.return_value.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+            sse_cm.return_value.__aexit__ = AsyncMock(return_value=None)
+            with (
+                patch("lfx.base.mcp.util.ClientSession", return_value=fake_sse),
+                patch("mcp.client.streamable_http.streamablehttp_client", stream_cm),
+                patch("mcp.client.sse.sse_client", sse_cm),
+            ):
+                _session, task, transport, sse_lock = await manager._create_streamable_http_session(
+                    "test_sess", self._connection_params(), "sse"
+                )
+                assert transport == "sse"
+                assert sse_lock is True
+                stream_cm.assert_not_called()
+                sse_cm.assert_called_once()
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        finally:
+            await manager.cleanup_all()
+
+    @pytest.mark.asyncio
+    async def test_get_session_forwards_explicit_sse_preference(self):
+        manager = MCPSessionManager()
+        try:
+            fake = self._fake_client_session()
+            create = AsyncMock(return_value=(fake, MagicMock(), "sse", True))
+            manager._create_streamable_http_session = create
+            params = self._connection_params()
+            params["preferred_transport"] = "sse"
+            session = await manager.get_session("ctx-1", params, "streamable_http")
+            assert session is fake
+            assert create.call_args.args[2] == "sse"
+        finally:
+            await manager.cleanup_all()
+
+    @pytest.mark.asyncio
+    async def test_update_tools_sse_mode_forces_sse_transport(self):
+        client = MagicMock()
+        client._connected = True
+        client.connect_to_server = AsyncMock(return_value=[])
+        server_config = {"mode": "SSE", "url": "http://test-mcp.example/sse"}
+        with patch("lfx.base.mcp.util.validate_connector_url_for_ssrf"):
+            await update_tools("test-server", server_config, mcp_streamable_http_client=client)
+        assert client.connect_to_server.call_args.kwargs["force_sse"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_tools_streamable_mode_does_not_force_sse(self):
+        client = MagicMock()
+        client._connected = True
+        client.connect_to_server = AsyncMock(return_value=[])
+        server_config = {"mode": "Streamable_HTTP", "url": "http://test-mcp.example/mcp"}
+        with patch("lfx.base.mcp.util.validate_connector_url_for_ssrf"):
+            await update_tools("test-server", server_config, mcp_streamable_http_client=client)
+        assert client.connect_to_server.call_args.kwargs["force_sse"] is False
+
+
 # ---------------------------------------------------------------------------
 # Regression tests for the CPU-spin / workflow-hang fix
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/base/mcp/test_mcp_util.py
+++ b/src/backend/tests/unit/base/mcp/test_mcp_util.py
@@ -4165,7 +4165,8 @@ class TestStreamableHttpTransportPolicy:
 class TestExplicitSseMode:
     """Regression tests: explicit SSE mode must not probe Streamable HTTP, and an
     HTTP 400 from an SSE-only server must trigger the SSE fallback instead of
-    being retried as transient."""
+    being retried as transient.
+    """
 
     def _connection_params(self):
         return {

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1046,15 +1046,19 @@ def _is_transient_streamable_http_error(exc: BaseException) -> bool:
                 return True
             if leaf.response.status_code == HTTP_TOO_MANY_REQUESTS:
                 return True
-            # 404/405/406: try SSE; other 4xx: retry Streamable HTTP
+            # 400/404/405/406: try SSE; other 4xx: retry Streamable HTTP
+            # (400 is how many SSE-only servers answer a Streamable HTTP POST)
             return leaf.response.status_code not in (
+                HTTP_BAD_REQUEST,
                 HTTP_NOT_FOUND,
                 HTTP_METHOD_NOT_ALLOWED,
                 HTTP_NOT_ACCEPTABLE,
             )
         if isinstance(leaf, McpError):
             msg = str(leaf).lower()
-            return not any(x in msg for x in ("404", "405", "406", "not found", "method not allowed"))
+            return not any(
+                x in msg for x in ("400", "404", "405", "406", "not found", "method not allowed", "bad request")
+            )
         msg = str(leaf).lower()
         if any(
             x in msg
@@ -1080,6 +1084,7 @@ def _should_attempt_sse_after_streamable_failure(exc: BaseException) -> bool:
         return False
     for leaf in _iter_exception_leaves(exc):
         if isinstance(leaf, httpx.HTTPStatusError) and leaf.response.status_code in (
+            HTTP_BAD_REQUEST,
             HTTP_NOT_FOUND,
             HTTP_METHOD_NOT_ALLOWED,
             HTTP_NOT_ACCEPTABLE,
@@ -1087,10 +1092,16 @@ def _should_attempt_sse_after_streamable_failure(exc: BaseException) -> bool:
             return True
         if isinstance(leaf, McpError):
             msg = str(leaf).lower()
-            if any(x in msg for x in ("404", "405", "406", "not found", "method not allowed", "not acceptable")):
+            if any(
+                x in msg
+                for x in ("400", "404", "405", "406", "not found", "method not allowed", "not acceptable", "bad request")
+            ):
                 return True
     lowered = str(exc).lower()
-    return any(x in lowered for x in ("404", "405", "406", "not found", "method not allowed", "not acceptable"))
+    return any(
+        x in lowered
+        for x in ("400", "404", "405", "406", "not found", "method not allowed", "not acceptable", "bad request")
+    )
 
 
 def _is_mcp_session_bust_error(exc: BaseException) -> bool:
@@ -1443,7 +1454,9 @@ class MCPSessionManager:
                 actual_transport = "stdio"
             elif transport_type == "streamable_http":
                 # Pass the cached transport preference if available (SSE only when last success required it)
-                preferred_transport = self._transport_preference.get(server_key)
+                preferred_transport = connection_params.get("preferred_transport") or self._transport_preference.get(
+                    server_key
+                )
                 session, task, actual_transport, sse_pref_lock = await self._create_streamable_http_session(
                     session_id, connection_params, preferred_transport
                 )
@@ -2223,8 +2236,13 @@ class MCPStreamableHttpClient:
         sse_read_timeout_seconds: int = 30,
         *,
         verify_ssl: bool = True,
+        force_sse: bool = False,
     ) -> list[StructuredTool]:
-        """Connect to MCP server using Streamable HTTP transport with SSE fallback (SDK style)."""
+        """Connect to MCP server using Streamable HTTP transport with SSE fallback (SDK style).
+
+        When ``force_sse`` is true (the server is explicitly configured for SSE mode), the
+        Streamable HTTP probe is skipped entirely and the session goes straight to SSE.
+        """
         # Validate and sanitize headers early
         validated_headers = _process_headers(headers)
 
@@ -2248,6 +2266,8 @@ class MCPStreamableHttpClient:
                 "sse_read_timeout_seconds": sse_read_timeout_seconds,
                 "verify_ssl": verify_ssl,
             }
+            if force_sse:
+                self._connection_params["preferred_transport"] = "sse"
         elif headers:
             self._connection_params["headers"] = validated_headers
 
@@ -2280,11 +2300,17 @@ class MCPStreamableHttpClient:
         sse_read_timeout_seconds: int = 30,
         *,
         verify_ssl: bool = True,
+        force_sse: bool = False,
     ) -> list[StructuredTool]:
-        """Connect to MCP server using Streamable HTTP with SSE fallback transport (SDK style)."""
+        """Connect to MCP server using Streamable HTTP with SSE fallback transport (SDK style).
+
+        Pass ``force_sse=True`` when the server is explicitly configured for SSE mode to
+        skip the Streamable HTTP probe and connect over SSE directly.
+        """
         return await asyncio.wait_for(
             self._connect_to_server(
-                url, headers, sse_read_timeout_seconds=sse_read_timeout_seconds, verify_ssl=verify_ssl
+                url, headers, sse_read_timeout_seconds=sse_read_timeout_seconds, verify_ssl=verify_ssl,
+                force_sse=force_sse,
             ),
             timeout=get_settings_service().settings.mcp_server_timeout,
         )
@@ -2692,7 +2718,9 @@ async def update_tools(
         headers = _maybe_inject_end_user_header(headers, url, end_user_id)
         verify_ssl = server_config.get("verify_ssl", True)
         try:
-            tools = await mcp_streamable_http_client.connect_to_server(url, headers=headers, verify_ssl=verify_ssl)
+            tools = await mcp_streamable_http_client.connect_to_server(
+                url, headers=headers, verify_ssl=verify_ssl, force_sse=(mode == "SSE")
+            )
         except Exception as exc:
             # A rejected credential otherwise surfaced as "unhandled errors in a TaskGroup",
             # naming neither the target nor the fact that authentication was the problem.

--- a/src/lfx/src/lfx/base/mcp/util.py
+++ b/src/lfx/src/lfx/base/mcp/util.py
@@ -1094,7 +1094,16 @@ def _should_attempt_sse_after_streamable_failure(exc: BaseException) -> bool:
             msg = str(leaf).lower()
             if any(
                 x in msg
-                for x in ("400", "404", "405", "406", "not found", "method not allowed", "not acceptable", "bad request")
+                for x in (
+                    "400",
+                    "404",
+                    "405",
+                    "406",
+                    "not found",
+                    "method not allowed",
+                    "not acceptable",
+                    "bad request",
+                )
             ):
                 return True
     lowered = str(exc).lower()
@@ -2309,7 +2318,10 @@ class MCPStreamableHttpClient:
         """
         return await asyncio.wait_for(
             self._connect_to_server(
-                url, headers, sse_read_timeout_seconds=sse_read_timeout_seconds, verify_ssl=verify_ssl,
+                url,
+                headers,
+                sse_read_timeout_seconds=sse_read_timeout_seconds,
+                verify_ssl=verify_ssl,
                 force_sse=force_sse,
             ),
             timeout=get_settings_service().settings.mcp_server_timeout,


### PR DESCRIPTION
Fixes #15024.

## Problem

A Custom MCP Tools component configured with **SSE** mode never connects to SSE-only servers (issue #15024):

1. `update_tools` routes both `Streamable_HTTP` and `SSE` modes into `MCPStreamableHttpClient.connect_to_server` (`src/lfx/src/lfx/base/mcp/util.py`), so an explicit SSE choice still starts with the Streamable HTTP probe. SSE-only servers answer that POST with **HTTP 400**.
2. `_is_transient_streamable_http_error` classifies 400 as transient (only 404/405/406 fell through to SSE), so the client retried Streamable HTTP and timed out. `_transport_preference` is only seeded after a successful connect, so it never helps the first attempt.

## Fix (one file, two complementary halves)

- **Honor the explicit mode:** `update_tools` passes `force_sse=(mode == "SSE")` through `connect_to_server` -> `_connect_to_server`, which stores `preferred_transport: "sse"` in the connection params. `MCPSessionManager.get_session` now honors an explicit `preferred_transport` from the connection params (falling back to the cached `_transport_preference`), so `_create_streamable_http_session` skips the Streamable HTTP probe and goes straight to `sse_client`. No behavior change for `Streamable_HTTP` or `Stdio` mode.
- **400 as endpoint-mismatch signal:** `_is_transient_streamable_http_error` and `_should_attempt_sse_after_streamable_failure` now treat HTTP 400 like 404/405/406, so Streamable_HTTP-mode probing of an SSE-only server falls back to SSE instead of retrying to timeout. This also fixes auto-mode probing against SSE-only servers.

## Verification (labeled evidence)

- **Repro confirmed at current `main` (`595cd72`):** the routing and classification described above read directly from `update_tools`, `_is_transient_streamable_http_error`, and `_create_streamable_http_session`.
- **Unit tests (new, 6):** `TestExplicitSseMode` in `src/backend/tests/unit/base/mcp/test_mcp_util.py` - 400 is not transient, 400 triggers the SSE fallback, explicit SSE preference skips the Streamable probe (asserts `streamablehttp_client` is never called and `sse_client` is), `get_session` forwards the explicit preference, and `update_tools` passes `force_sse=True` for `mode="SSE"` / `False` for `Streamable_HTTP`.
- **Test status:** targeted file `test_mcp_util.py`: **244 passed, 7 skipped**; the only 2 failures (`test_get_flow_snake_case_mocked`, `test_mcp_structured_tool_annotations_resolve_in_util_namespace`) fail identically on pristine `main` in this environment (missing optional deps) and are unrelated to this change. Full repo suite not run (backend env is heavy); the change is confined to one module plus its dedicated unit tests.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP connection handling for servers using legacy SSE transport.
  * HTTP 400 responses are now correctly recognized as signals to use SSE.
  * Explicit SSE connections now connect directly without unnecessary Streamable HTTP checks.
  * Transport preferences are honored more consistently when establishing sessions and updating tools.
* **Tests**
  * Added regression coverage for SSE fallback and transport selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->