### PR TITLE
fix(tasks): stop awaiting Celery's synchronous revoke result

### DIFF
--- a/src/backend/base/langflow/services/task/backends/celery.py
+++ b/src/backend/base/langflow/services/task/backends/celery.py
@@ -51,6 +51,9 @@ class CeleryBackend(TaskBackend):
         from celery.result import AsyncResult
 
         try:
-            return AsyncResult(task_id, app=self.celery_app).revoke(terminate=True)
+            AsyncResult(task_id, app=self.celery_app).revoke(terminate=True)
         except TaskRevokedError:
             return True
+        # AsyncResult.revoke broadcasts and returns None. True means the revoke
+        # was published, not that a worker has stopped the task.
+        return True

--- a/src/backend/base/langflow/services/task/service.py
+++ b/src/backend/base/langflow/services/task/service.py
@@ -92,7 +92,9 @@ class TaskService(Service):
 
     async def revoke_task(self, task_id: UUID | str) -> bool:
         if self.use_celery:
-            return await self.backend.revoke_task(str(task_id))
+            # CeleryBackend.revoke_task is synchronous and publishes to the
+            # broker, so run it off the event loop instead of awaiting it.
+            return await asyncio.to_thread(self.backend.revoke_task, str(task_id))
 
         job_queue_service = get_queue_service()
         try:

--- a/src/backend/tests/unit/api/v2/test_workflow.py
+++ b/src/backend/tests/unit/api/v2/test_workflow.py
@@ -12,6 +12,7 @@ Test Organization:
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -19,6 +20,7 @@ import pytest
 from httpx import AsyncClient
 from langflow.services.database.models.flow.model import Flow
 from langflow.services.database.models.jobs.model import Job, JobType
+from langflow.services.task.service import TaskService
 from lfx.schema.workflow import JobStatus, WorkflowExecutionResponse
 from lfx.services.deps import session_scope
 from sqlalchemy.exc import OperationalError
@@ -387,6 +389,55 @@ class TestWorkflowStop:
             mock_task_service.revoke_task.assert_awaited_once_with(UUID(job_id))
             mock_bg_service.stop_job.assert_awaited_once()
             mock_job_service.update_job_status.assert_awaited_once_with(UUID(job_id), JobStatus.CANCELLED)
+
+    async def test_stop_workflow_with_celery_task_service(
+        self,
+        client: AsyncClient,
+        created_api_key,
+        monkeypatch,
+    ):
+        """Celery mode must reach the stop signal and CANCELLED update (#14943).
+
+        The other stop tests replace TaskService with an AsyncMock, which hides
+        that CeleryBackend.revoke_task is synchronous.
+        """
+        job_id = uuid4()
+        mock_job = MagicMock(
+            job_id=job_id,
+            status=JobStatus.IN_PROGRESS,
+            type=JobType.WORKFLOW,
+            user_id=None,
+            job_metadata={"request": {"mode": "background"}},
+        )
+        celery_backend = MagicMock(name="CeleryBackend")
+        celery_backend.revoke_task.return_value = True
+        monkeypatch.setattr("langflow.services.task.service.CeleryBackend", lambda: celery_backend)
+        task_service = TaskService(SimpleNamespace(settings=SimpleNamespace(celery_enabled=True)))
+
+        with (
+            patch("langflow.api.v2.workflow.get_job_service") as mock_get_job_service,
+            patch("langflow.api.v2.workflow.get_task_service", return_value=task_service),
+            patch("langflow.api.v2.workflow.get_background_execution_service") as mock_get_bg_service,
+        ):
+            mock_job_service = MagicMock()
+            mock_job_service.get_job_by_job_id = AsyncMock(return_value=mock_job)
+            mock_job_service.update_job_status = AsyncMock()
+            mock_get_job_service.return_value = mock_job_service
+            mock_bg_service = MagicMock()
+            mock_bg_service.stop_job = AsyncMock()
+            mock_get_bg_service.return_value = mock_bg_service
+
+            response = await client.post(
+                "api/v2/workflows/stop",
+                json={"job_id": str(job_id)},
+                headers={"x-api-key": created_api_key.api_key},
+            )
+
+        assert response.status_code == 200, response.text
+        assert "cancelled successfully" in response.json()["message"]
+        celery_backend.revoke_task.assert_called_once_with(str(job_id))
+        mock_bg_service.stop_job.assert_awaited_once()
+        mock_job_service.update_job_status.assert_awaited_once_with(job_id, JobStatus.CANCELLED)
 
     @pytest.mark.parametrize(
         ("job_metadata", "job_status", "expected_mode"),

--- a/src/backend/tests/unit/services/tasks/test_task_service_revoke.py
+++ b/src/backend/tests/unit/services/tasks/test_task_service_revoke.py
@@ -1,0 +1,103 @@
+"""TaskService.revoke_task must bridge the synchronous Celery backend (#14943).
+
+``CeleryBackend.revoke_task`` publishes a revoke broadcast synchronously. The
+service used to ``await`` its return value directly, so every Celery-mode
+cancellation (workflow stop, KB ingestion cancel, memory-base delete) raised
+``TypeError: object NoneType can't be used in 'await' expression``.
+
+Celery is not a declared dependency, so the service-contract tests use a
+synchronous stand-in backend and run everywhere; the real-Celery tests skip
+unless ``celery`` is installed.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from langflow.services.task.service import TaskService
+
+
+class _SyncRevokeBackend:
+    """Stand-in with CeleryBackend's synchronous ``revoke_task`` contract."""
+
+    name = "celery"
+
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, int]] = []
+
+    def revoke_task(self, task_id: str) -> bool:
+        self.calls.append((task_id, threading.get_ident()))
+        if self.error is not None:
+            raise self.error
+        return True
+
+
+def _celery_task_service(monkeypatch, backend) -> TaskService:
+    monkeypatch.setattr("langflow.services.task.service.CeleryBackend", lambda: backend)
+    return TaskService(SimpleNamespace(settings=SimpleNamespace(celery_enabled=True)))
+
+
+async def test_celery_revoke_accepts_synchronous_backend(monkeypatch):
+    backend = _SyncRevokeBackend()
+    service = _celery_task_service(monkeypatch, backend)
+    task_id = uuid4()
+
+    assert await service.revoke_task(task_id) is True
+    assert [sent_task_id for sent_task_id, _ in backend.calls] == [str(task_id)]
+
+
+async def test_celery_revoke_publishes_off_the_event_loop(monkeypatch):
+    backend = _SyncRevokeBackend()
+    service = _celery_task_service(monkeypatch, backend)
+
+    await service.revoke_task(uuid4())
+
+    [(_, publish_thread)] = backend.calls
+    assert publish_thread != threading.get_ident()
+
+
+async def test_celery_revoke_propagates_broker_errors(monkeypatch):
+    service = _celery_task_service(monkeypatch, _SyncRevokeBackend(error=ConnectionError("broker unavailable")))
+
+    with pytest.raises(ConnectionError, match="broker unavailable"):
+        await service.revoke_task(uuid4())
+
+
+@pytest.fixture
+def celery_app(monkeypatch):
+    celery = pytest.importorskip("celery")
+    # In-memory transport: exercises the real AsyncResult -> control -> kombu
+    # publish path with no external broker and no worker.
+    with celery.Celery("revoke-test", broker="memory://", set_as_current=False) as app:
+        monkeypatch.setattr("langflow.worker.celery_app", app)
+        yield app
+
+
+def test_celery_backend_reports_published_revoke(celery_app, monkeypatch):
+    """``AsyncResult.revoke`` returns ``None``; the backend must still report success."""
+    from langflow.services.task.backends.celery import CeleryBackend
+
+    sent = []
+    original_revoke = celery_app.control.revoke
+
+    def spy_revoke(task_id, **kwargs):
+        sent.append((task_id, kwargs.get("terminate")))
+        return original_revoke(task_id, **kwargs)
+
+    monkeypatch.setattr(celery_app.control, "revoke", spy_revoke)
+    task_id = str(uuid4())
+
+    assert CeleryBackend().revoke_task(task_id) is True
+    assert sent == [(task_id, True)]
+
+
+async def test_task_service_revoke_with_real_celery(celery_app):
+    """The reproduction from #14943, end to end through the real Celery backend."""
+    service = TaskService(SimpleNamespace(settings=SimpleNamespace(celery_enabled=True)))
+
+    assert service.backend.celery_app is celery_app
+    assert await service.revoke_task(uuid4()) is True


### PR DESCRIPTION
## Summary

With `LANGFLOW_CELERY_ENABLED=true`, every cancellation raised `TypeError: object NoneType can't be used in 'await' expression`. `TaskService.revoke_task()` awaited the return value of `CeleryBackend.revoke_task()`, which is a plain synchronous method that forwards `AsyncResult.revoke()`'s return value. Celery's `revoke()` has no `return` statement (checked against Celery 5.6.3 source), so that value is always `None`.

The `TypeError` fires before any caller reaches its cleanup:

| Caller | Before this PR |
| --- | --- |
| `POST /api/v2/workflows/stop` | 500 `Failed to stop job …`. No durable stop signal, job never marked `CANCELLED`. |
| KB ingestion cancel (`knowledge_bases.py`) | 500 `Error cancelling ingestion.` Status not updated, partial chunks not cleaned up. |
| Memory-base delete → `cancel_active_jobs` | Delete aborts: the handler only catches `RuntimeError`/`ValueError`/`OSError`, so the `TypeError` escapes. Not mentioned in the issue. |

## Fix

- `TaskService.revoke_task` runs the synchronous backend call with `asyncio.to_thread`, so the broker publish no longer blocks the request's event loop.
- `CeleryBackend.revoke_task` returns `True` once the revoke is published. `True` means the command was sent, **not** that a worker has stopped the task.
- Broker errors propagate as before. They were already raised synchronously, ahead of the `await`.

No API, schema or backend-interface changes. `CeleryBackend` stays synchronous, like its `launch_task`/`get_task`.

Fixes #14943

## Tests

Celery is not a declared dependency (it's not in `uv.lock`), so CI never has it installed. Upstream #14944's tests all `importorskip("celery")` and would be skipped in CI. This PR splits coverage so the regression is still caught in CI:

- **Run in CI (no Celery needed).** Service-contract tests use a synchronous stand-in backend with `CeleryBackend`'s contract. They check that the service accepts a sync backend, publishes off the event-loop thread (by thread-identity assertion), and propagates broker errors. There's also an API-level test that drives `POST /api/v2/workflows/stop` through a real `TaskService` in Celery mode, instead of the `AsyncMock` the other stop tests use (that mock is why this bug was never caught).
- **Real Celery (skipped unless `celery` is installed).** These run the actual `AsyncResult → control.revoke → kombu` publish path on the `memory://` transport. The first checks that `CeleryBackend.revoke_task` returns `True` and sends `terminate=True`. The second runs the issue's reproduction end to end.

| | Unfixed `release-1.12.2` | This PR |
| --- | --- | --- |
| Without Celery (CI env) | 3 failed (`TypeError` ×2, stop endpoint 500), 1 passed, 2 skipped | 4 passed, 2 skipped |
| With Celery 5.6.3 (`uv run --with celery`) | 4 failed (incl. the real `NoneType` `TypeError`), 1 passed | 5 passed |
| Issue reproduction script | `TypeError` | `service result: True` |

The test that passes on unfixed code is the broker-error guard, which checks that behavior is unchanged.

Existing suites still pass: `api/v2/test_workflow.py` + `services/tasks/` (44 passed, 2 skipped), and the KB/memory-base cancel and delete tests (29 passed).

```bash
uv run pytest src/backend/tests/unit/services/tasks/test_task_service_revoke.py "src/backend/tests/unit/api/v2/test_workflow.py::TestWorkflowStop"
uv run --with 'celery>=5.3' pytest src/backend/tests/unit/services/tasks/test_task_service_revoke.py
```

## Notes

- `src/backend/base/langflow/services/task/` is byte-identical on `main`, `release-1.13.0` and `release-1.12.2`, so this carries forward through the normal release back-merge. It covers the same fix as the open community PR #14944 (which targets `release-1.13.0`), plus the CI-running tests.
- Not tested: a real worker actually terminating a revoked task, or a networked broker (Redis/RabbitMQ).
- Out of scope, pre-existing: the Celery path of `TaskService.fire_and_forget_task` also calls the synchronous `launch_task` (a broker publish) on the event loop.

## Test plan

- [x] New tests fail on unfixed code and pass with the fix, both with and without Celery installed
- [x] Issue reproduction script passes against the fixed code
- [x] Existing workflow-stop, task-service, KB-cancel and memory-base suites pass
- [x] `ruff format` / `ruff check` / pre-commit hooks pass
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Celery task cancellation so broker publishing does not block the event loop.
  * Cancellation now consistently reports whether the revoke signal was published.
  * Preserved error propagation when task cancellation fails.

* **Tests**
  * Added coverage for workflow stopping and Celery task cancellation, including broker errors and successful cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->