### PR TITLE
fix(frontend): keep auto-login auth when the session probe answers late

### DIFF
--- a/src/frontend/src/components/authorization/playgroundAuthGate/__tests__/playground-auth-gate-session-probe.test.tsx
+++ b/src/frontend/src/components/authorization/playgroundAuthGate/__tests__/playground-auth-gate-session-probe.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * The playground gate applies the same session probe as AppInitPage, so it
+ * follows the same rule: an unauthenticated answer that lands after auto-login
+ * has signed the page in must not clear `isAuthenticated`. Renders the real
+ * gate against the real auth store; only the network hooks are mocked.
+ */
+
+import { act, render } from "@testing-library/react";
+import type { SessionResponse } from "@/controllers/API/queries/auth";
+import useAuthStore from "@/stores/authStore";
+
+type SessionQueryResult = {
+  data: SessionResponse | undefined;
+  isFetched: boolean;
+};
+
+const mockUseGetAuthSession = jest.fn<SessionQueryResult, []>();
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useGetAuthSession: () => mockUseGetAuthSession(),
+  useGetAutoLogin: () => ({ isFetched: true }),
+}));
+
+jest.mock("@/pages/LoadingPage", () => ({
+  LoadingPage: () => <div data-testid="loading" />,
+}));
+
+import { PlaygroundAuthGate } from "../index";
+
+const UNAUTHENTICATED_PROBE: SessionQueryResult = {
+  data: { authenticated: false },
+  isFetched: true,
+};
+
+function renderGate() {
+  return render(
+    <PlaygroundAuthGate>
+      <div data-testid="playground" />
+    </PlaygroundAuthGate>,
+  );
+}
+
+function deliverProbe(
+  rerender: ReturnType<typeof renderGate>["rerender"],
+  probe: SessionQueryResult,
+) {
+  mockUseGetAuthSession.mockReturnValue(probe);
+  act(() => {
+    rerender(
+      <PlaygroundAuthGate>
+        <div data-testid="playground" />
+      </PlaygroundAuthGate>,
+    );
+  });
+}
+
+describe("PlaygroundAuthGate - session probe vs auto-login", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ autoLogin: null, isAuthenticated: false });
+    mockUseGetAuthSession.mockReturnValue({
+      data: undefined,
+      isFetched: false,
+    });
+  });
+
+  it("keeps auto-login's auth when an unauthenticated probe lands afterwards", () => {
+    const { rerender } = renderGate();
+
+    act(() => {
+      useAuthStore.setState({ autoLogin: true, isAuthenticated: true });
+    });
+    deliverProbe(rerender, UNAUTHENTICATED_PROBE);
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  it("still clears auth on an unauthenticated probe when auto-login is off", () => {
+    useAuthStore.setState({ autoLogin: false, isAuthenticated: true });
+    const { rerender } = renderGate();
+
+    deliverProbe(rerender, UNAUTHENTICATED_PROBE);
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+  });
+});

--- a/src/frontend/src/components/authorization/playgroundAuthGate/index.tsx
+++ b/src/frontend/src/components/authorization/playgroundAuthGate/index.tsx
@@ -4,6 +4,7 @@ import {
   useGetAuthSession,
   useGetAutoLogin,
 } from "@/controllers/API/queries/auth";
+import { canSessionProbeClearAuth } from "@/controllers/API/queries/auth/session-probe";
 import { LoadingPage } from "@/pages/LoadingPage";
 import useAuthStore from "@/stores/authStore";
 import type { Users } from "@/types/api";
@@ -43,7 +44,11 @@ export function PlaygroundAuthGate({
       if (sessionData.store_api_key) {
         storeApiKey(sessionData.store_api_key);
       }
-    } else if (sessionData && !sessionData.authenticated) {
+    } else if (
+      sessionData &&
+      !sessionData.authenticated &&
+      canSessionProbeClearAuth()
+    ) {
       setIsAuthenticated(false);
     }
     setSessionProcessed(true);

--- a/src/frontend/src/controllers/API/queries/auth/session-probe.ts
+++ b/src/frontend/src/controllers/API/queries/auth/session-probe.ts
@@ -1,0 +1,20 @@
+import useAuthStore from "@/stores/authStore";
+
+/**
+ * Whether a session probe that answered `authenticated: false` may clear the
+ * store's auth state.
+ *
+ * The probe answers for the cookie it was sent with. On a fresh auto-login
+ * context it goes out before auto-login has set that cookie, so the backend
+ * correctly says "not authenticated" — but the answer can land after login()
+ * has already authenticated the page, and a failed probe resolves to the same
+ * shape. Auto-login does not run again once it has settled, so honouring that
+ * stale answer would leave every `enabled: isAuthenticated` query disabled
+ * until a reload.
+ *
+ * Reads the store at call time: callers apply this from effects keyed on the
+ * probe's data, not on auth state.
+ */
+export function canSessionProbeClearAuth(): boolean {
+  return useAuthStore.getState().autoLogin !== true;
+}

--- a/src/frontend/src/pages/AppInitPage/__tests__/app-init-page-late-session-probe.test.tsx
+++ b/src/frontend/src/pages/AppInitPage/__tests__/app-init-page-late-session-probe.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * AppInitPage fires the session probe and auto-login in parallel. On a fresh
+ * auto-login context the probe carries no cookie, so the backend correctly
+ * answers `{ authenticated: false }`. If that answer lands after login() has
+ * already authenticated the page — or the probe fails, which resolves to the
+ * same shape — it must not clear `isAuthenticated`: auto-login never re-runs,
+ * so every `enabled: isAuthenticated` query (global variables, projects) would
+ * stay disabled until a reload and `refetchQueries` would silently skip them.
+ *
+ * These tests render the real page against the real auth store and mock only
+ * the network hooks, so the assertions exercise the effect that applies the
+ * probe rather than a re-derivation of it.
+ */
+
+import { act, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { AuthContext } from "@/contexts/authContext";
+import type { SessionResponse } from "@/controllers/API/queries/auth";
+import useAuthStore from "@/stores/authStore";
+
+type SessionQueryResult = {
+  data: SessionResponse | undefined;
+  isFetched: boolean;
+};
+
+const mockUseGetAuthSession = jest.fn<SessionQueryResult, []>();
+const mockSetUserData = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  Outlet: () => <div data-testid="outlet" />,
+}));
+
+jest.mock("@/controllers/API/queries/auth", () => ({
+  useGetAuthSession: () => mockUseGetAuthSession(),
+  useGetAutoLogin: () => ({ isFetched: true }),
+}));
+
+jest.mock("@/controllers/API/queries/config/use-get-config", () => ({
+  useGetConfig: () => ({ isFetched: true }),
+}));
+
+jest.mock("@/controllers/API/queries/flows/use-get-basic-examples", () => ({
+  useGetBasicExamplesQuery: () => ({ isFetched: true, refetch: jest.fn() }),
+}));
+
+jest.mock("@/controllers/API/queries/folders/use-get-folders", () => ({
+  useGetFoldersQuery: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/store", () => ({
+  useGetTagsQuery: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/variables", () => ({
+  useGetGlobalVariables: jest.fn(),
+}));
+
+jest.mock("@/controllers/API/queries/version", () => ({
+  useGetVersionQuery: jest.fn(),
+}));
+
+jest.mock("@/customization/hooks/use-custom-primary-loading", () => ({
+  useCustomPrimaryLoading: () => ({ isFetched: true }),
+}));
+
+jest.mock("@/stores/darkStore", () => ({
+  useDarkStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ refreshStars: jest.fn(), refreshDiscordCount: jest.fn() }),
+}));
+
+jest.mock("@/stores/flowsManagerStore", () => ({
+  __esModule: true,
+  default: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ isLoading: false }),
+}));
+
+jest.mock("@/customization/components/custom-loading-page", () => ({
+  CustomLoadingPage: () => <div data-testid="custom-loading" />,
+}));
+
+jest.mock("../../LoadingPage", () => ({
+  LoadingPage: () => <div data-testid="loading" />,
+}));
+
+import { AppInitPage } from "../index";
+
+const AuthWrapper = ({ children }: { children: ReactNode }) => (
+  <AuthContext.Provider
+    value={
+      {
+        accessToken: null,
+        apiKey: null,
+        authenticationErrorCount: 0,
+        clearAuthSession: jest.fn(),
+        getUser: jest.fn(),
+        login: jest.fn(),
+        setApiKey: jest.fn(),
+        setUserData: mockSetUserData,
+        storeApiKey: jest.fn(),
+        userData: null,
+      } as React.ContextType<typeof AuthContext>
+    }
+  >
+    {children}
+  </AuthContext.Provider>
+);
+
+const PENDING_PROBE: SessionQueryResult = { data: undefined, isFetched: false };
+const UNAUTHENTICATED_PROBE: SessionQueryResult = {
+  data: { authenticated: false },
+  isFetched: true,
+};
+
+function renderPage() {
+  return render(<AppInitPage />, { wrapper: AuthWrapper });
+}
+
+// What login() leaves behind once both of its legs have settled.
+function completeAutoLogin() {
+  act(() => {
+    useAuthStore.setState({ autoLogin: true, isAuthenticated: true });
+  });
+}
+
+function deliverProbe(
+  rerender: ReturnType<typeof renderPage>["rerender"],
+  probe: SessionQueryResult,
+) {
+  mockUseGetAuthSession.mockReturnValue(probe);
+  act(() => {
+    rerender(<AppInitPage />);
+  });
+}
+
+describe("AppInitPage - session probe vs auto-login", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.setState({
+      autoLogin: null,
+      isAuthenticated: false,
+      isAdmin: false,
+    });
+    mockUseGetAuthSession.mockReturnValue(PENDING_PROBE);
+  });
+
+  it("keeps auto-login's auth when an unauthenticated probe lands afterwards", () => {
+    const { rerender } = renderPage();
+
+    completeAutoLogin();
+    deliverProbe(rerender, UNAUTHENTICATED_PROBE);
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  it("reaches the same auth state whichever request lands first", () => {
+    const { rerender } = renderPage();
+
+    deliverProbe(rerender, UNAUTHENTICATED_PROBE);
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+
+    completeAutoLogin();
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  it("still clears auth on an unauthenticated probe when auto-login is off", () => {
+    useAuthStore.setState({ autoLogin: false, isAuthenticated: true });
+    const { rerender } = renderPage();
+
+    deliverProbe(rerender, UNAUTHENTICATED_PROBE);
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+  });
+
+  it("applies an authenticated probe", () => {
+    const { rerender } = renderPage();
+    const user = {
+      id: "user-1",
+      username: "langflow",
+      is_active: true,
+      is_superuser: true,
+    };
+
+    deliverProbe(rerender, {
+      data: { authenticated: true, user },
+      isFetched: true,
+    });
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().isAdmin).toBe(true);
+    expect(mockSetUserData).toHaveBeenCalledWith(user);
+  });
+});

--- a/src/frontend/src/pages/AppInitPage/index.tsx
+++ b/src/frontend/src/pages/AppInitPage/index.tsx
@@ -5,6 +5,7 @@ import {
   useGetAuthSession,
   useGetAutoLogin,
 } from "@/controllers/API/queries/auth";
+import { canSessionProbeClearAuth } from "@/controllers/API/queries/auth/session-probe";
 import { useGetConfig } from "@/controllers/API/queries/config/use-get-config";
 import { useGetBasicExamplesQuery } from "@/controllers/API/queries/flows/use-get-basic-examples";
 import { useGetFoldersQuery } from "@/controllers/API/queries/folders/use-get-folders";
@@ -69,8 +70,12 @@ export function AppInitPage() {
       if (sessionData.store_api_key) {
         storeApiKey(sessionData.store_api_key);
       }
-    } else if (sessionData && !sessionData.authenticated) {
-      // Explicitly not authenticated
+    } else if (
+      sessionData &&
+      !sessionData.authenticated &&
+      canSessionProbeClearAuth()
+    ) {
+      // Explicitly not authenticated, and auto-login hasn't signed the page in.
       setIsAuthenticated(false);
     }
   }, [sessionData]);


### PR DESCRIPTION
## Summary

Under `LANGFLOW_AUTO_LOGIN=true`, a late or failed `GET /api/v1/session` at startup can sign the page back out after auto-login has already signed it in. When that happens, the global-variables and projects queries stay disabled until a full reload. Creating a variable then returns 201 and saves the row, but the list never refetches, so the row never appears.

`AppInitPage` sends the session probe and auto-login in parallel. On a fresh context the probe has no cookie, so the backend correctly answers `200 {"authenticated": false}`. Auto-login then calls `login()`, which sets `isAuthenticated = true` once its whoami and global-variables requests have both finished. If the probe's answer arrives after that, this branch undoes it:

```tsx
} else if (sessionData && !sessionData.authenticated) {
  setIsAuthenticated(false);
}
```

Nothing restores the state afterwards. `useGetAutoLogin` has already run and uses `staleTime: Infinity` / `refetchOnMount: false`. Meanwhile `useGetGlobalVariables` and `useGetFoldersQuery` gate on `enabled: isAuthenticated && …`. `queryClient.refetchQueries` skips a query whose observers are all disabled, so the refetch after each create is dropped without a request or an error. A failed probe causes the same thing: `useGetAuthSession` catches the error and returns `{ authenticated: false }`, so a single timeout is enough.

The backend is behaving correctly here. The bug is entirely in client state.

## Fix

- New `canSessionProbeClearAuth()` (`controllers/API/queries/auth/session-probe.ts`): an unauthenticated probe may clear auth only when `autoLogin !== true`. It reads the store at call time, because both callers run it from effects keyed on the probe's data, not on auth state.
- `AppInitPage` and `PlaygroundAuthGate` both use it. They are the only two consumers of the session probe, and they write the same store.
- Manual-login mode (`autoLogin === false`) behaves as before. A negative probe still clears auth there.

In `PlaygroundAuthGate` the change has no visible effect today, because every playground consumer of `isAuthenticated` also requires `autoLogin === false`. It is included so both probe consumers follow the same rule.

No API, backend, or query-option changes. The `useGetAuthSession` error path is unchanged. Under auto-login the guard already covers it, and turning a failed probe into a query error is a separate change.

## Tests

**Unit** (real components, real zustand auth store; only the network hooks are mocked):

- `pages/AppInitPage/__tests__/app-init-page-late-session-probe.test.tsx`
  - late unauthenticated probe after auto-login → auth kept
  - probe first, then auto-login → authenticated (same end state either order)
  - auto-login off → a negative probe still clears auth
  - positive probe → auth, admin and user data applied
- `components/authorization/playgroundAuthGate/__tests__/playground-auth-gate-session-probe.test.tsx`
  - the same late-probe and manual-mode cases for the gate

With only the two source changes reverted, exactly the two late-probe cases fail and the other four pass. The full frontend jest suite passes: 667 suites, 7,101 tests. Biome is clean, and `tsc --noEmit` reports the same 254 pre-existing errors with and without this change.

**Browser**: `release-1.12.2` backend with `LANGFLOW_AUTO_LOGIN=true`, Vite dev server, a fresh Chrome context per run, and Playwright interception on `/api/v1/session` only. Each run opens `/settings/global-variables`, creates a variable and saves it. Requests are recorded by an in-page XHR wrapper, and `isAuthenticated` is read from the live store.

| Condition | Unfixed | This PR |
| --- | --- | --- |
| control (no interception) | 2/2 pass | 2/2 pass |
| response delivered +100 ms | 2/2 pass | – |
| response delivered +200 ms | 1 of 2 fails | 2/2 pass |
| response delivered +500 ms | 3/3 fail | 5/5 pass |
| response delivered +1500 ms | 2/2 fail | 4/4 pass |
| aborted at 1500 ms | 3/3 fail | 5/5 pass |

A failing run means `autoLogin: true` but `isAuthenticated: false`, the POST returns 201 with zero refetches, and the row is saved but missing from the grid. A passing run sends one refetch whose response includes the new row, and the row is rendered.

The counts include an A/B/A pass: after the fixed runs, reverting the two call sites made +500 ms and abort fail again (2/2), and reapplying them made both pass (2/2).

The outcome depends on a single ordering. The bug happens only when the negative probe arrives after `login()`'s last request has finished. Every unfixed run matched that rule: every failure arrived after it, and every pass arrived before it. The +200 ms row shows the edge: one run arrived 20 ms after and failed, the other 126 ms before and passed. Without injection, the gap on this machine ranged from about 140 to 440 ms.

Note for anyone reproducing this: delay the *response*, not the request (`route.fetch()` → wait → `route.fulfill({ response })`). Holding the request with a delayed `route.continue()` sends it after auto-login has set the cookie, so it comes back `authenticated: true` and the bug never shows.

Only global variables was verified in the browser. Projects (`useGetFoldersQuery`, `usePostFolders`) uses the same `enabled: isAuthenticated` gate and the same `refetchQueries` call, so it is covered by the same fix, but that was not observed directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented delayed session checks from incorrectly signing users out after auto-login has already authenticated them.
  - Authentication state is now preserved when an outdated “not authenticated” response arrives during automatic sign-in.
  - Session checks continue to clear authentication when automatic sign-in is disabled or the unauthenticated result is current.

- **Tests**
  - Added coverage for session-check timing, automatic sign-in, and authenticated and unauthenticated outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->