### PR TITLE
fix(graph): keep Component.stop() branches inactive while a sibling completes

### DIFF
--- a/src/backend/base/langflow/api/build.py
+++ b/src/backend/base/langflow/api/build.py
@@ -791,7 +791,7 @@ async def _generate_flow_events(
             vertex.add_build_time(timedelta)
             # Capture both inactivated and conditionally excluded vertices
             inactivated_vertices = list(graph.inactivated_vertices.union(graph.conditionally_excluded_vertices))
-            graph.reset_inactivated_vertices()
+            graph.reset_inactivated_vertices(vertex.id)
             graph.reset_activated_vertices()
 
             # Note: Do not reset conditionally_excluded_vertices each iteration

--- a/src/backend/base/langflow/api/v1/chat.py
+++ b/src/backend/base/langflow/api/v1/chat.py
@@ -723,7 +723,7 @@ async def build_vertex(
         result_data_response.timedelta = timedelta
         vertex.add_build_time(timedelta)
         inactivated_vertices = list(graph.inactivated_vertices)
-        graph.reset_inactivated_vertices()
+        graph.reset_inactivated_vertices(vertex.id)
         graph.reset_activated_vertices()
 
         await chat_service.set_cache(flow_id_str, graph)

--- a/src/backend/tests/unit/api/test_build_stopped_branch_race.py
+++ b/src/backend/tests/unit/api/test_build_stopped_branch_race.py
@@ -1,0 +1,182 @@
+"""A branch stopped by ``Component.stop()`` stays stopped while a sibling completes (#14966).
+
+The /build driver runs sibling vertices concurrently and, after every vertex completes, used
+to reset the graph-wide ``inactivated_vertices`` set. When one component had called
+``self.stop()`` and was still running, an unrelated sibling finishing first reactivated the
+stopped branch, and the stopped vertex then ran with the blocked output's value.
+
+The components below make the interleaving deterministic instead of relying on sleeps:
+the sibling finishes only after the stop is in place, and the stopper returns only after the
+sibling's completion (and its reset) has run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from httpx import codes
+from lfx.custom.eval import eval_custom_component_code
+from lfx.graph.graph.base import Graph
+
+from tests.unit.build_utils import build_flow, create_flow, get_build_events
+
+START_ID = "RaceStart-a1b2c"
+STOPPER_ID = "RaceStopper-d3e4f"
+TRIGGER_ID = "RaceTrigger-g5h6i"
+VICTIM_ID = "RaceVictim-j7k8l"
+GOAL_ID = "RaceGoal-m9n0p"
+
+START_CODE = """
+from lfx.custom.custom_component.component import Component
+from lfx.io import Output
+from lfx.schema.data import Data
+
+
+class RaceStart(Component):
+    display_name = "Race Start"
+    outputs = [Output(name="start", display_name="Start", method="emit")]
+
+    def emit(self) -> Data:
+        return Data(data={"start": True})
+"""
+
+STOPPER_CODE = f"""
+import asyncio
+
+from lfx.custom.custom_component.component import Component
+from lfx.io import DataInput, Output
+from lfx.schema.data import Data
+
+
+class RaceStopper(Component):
+    display_name = "Race Stopper"
+    inputs = [DataInput(name="start", display_name="Start")]
+    outputs = [
+        Output(name="blocked", display_name="Blocked", method="blocked_output", group_outputs=True),
+        Output(name="done", display_name="Done", method="done_output", group_outputs=True),
+    ]
+
+    def blocked_output(self) -> Data:
+        return Data(data={{"stopped_branch_value": True}})
+
+    async def done_output(self) -> Data:
+        self.stop("blocked")
+        # Stay running until the sibling has completed; its completion path is what used to
+        # reset every inactivated vertex in the graph.
+        for _ in range(200):
+            if "{TRIGGER_ID}" in self.graph.run_manager.ran_at_least_once:
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.5)
+        return Data(data={{"stopper_done": True}})
+"""
+
+TRIGGER_CODE = f"""
+import asyncio
+
+from lfx.custom.custom_component.component import Component
+from lfx.io import DataInput, Output
+from lfx.schema.data import Data
+
+
+class RaceTrigger(Component):
+    display_name = "Race Trigger"
+    inputs = [DataInput(name="start", display_name="Start")]
+    outputs = [Output(name="trigger", display_name="Trigger", method="emit")]
+
+    async def emit(self) -> Data:
+        # Complete only once the stopper's stop is in place.
+        for _ in range(200):
+            if "{VICTIM_ID}" in self.graph.inactivated_vertices:
+                break
+            await asyncio.sleep(0.05)
+        return Data(data={{"trigger_done": True}})
+"""
+
+VICTIM_CODE = """
+from lfx.custom.custom_component.component import Component
+from lfx.io import DataInput, Output
+from lfx.schema.data import Data
+
+
+class RaceVictim(Component):
+    display_name = "Race Victim"
+    inputs = [DataInput(name="value", display_name="Value")]
+    outputs = [Output(name="result", display_name="Result", method="run")]
+
+    def run(self) -> Data:
+        msg = "a branch stopped by Component.stop() was executed"
+        raise ValueError(msg)
+"""
+
+GOAL_CODE = """
+from lfx.custom.custom_component.component import Component
+from lfx.io import DataInput, Output
+from lfx.schema.data import Data
+
+
+class RaceGoal(Component):
+    display_name = "Race Goal"
+    inputs = [
+        DataInput(name="stopper_done", display_name="Stopper Done"),
+        DataInput(name="trigger_done", display_name="Trigger Done"),
+    ]
+    outputs = [Output(name="result", display_name="Result", method="run")]
+
+    def run(self) -> Data:
+        return Data(data={"goal": True})
+"""
+
+
+@pytest.fixture(autouse=True)
+def allow_custom_components(monkeypatch):
+    monkeypatch.setenv("LANGFLOW_ALLOW_CUSTOM_COMPONENTS", "true")
+
+
+def _race_flow() -> str:
+    graph = Graph()
+    for vertex_id, code in (
+        (START_ID, START_CODE),
+        (STOPPER_ID, STOPPER_CODE),
+        (TRIGGER_ID, TRIGGER_CODE),
+        (VICTIM_ID, VICTIM_CODE),
+        (GOAL_ID, GOAL_CODE),
+    ):
+        component = eval_custom_component_code(code)(_id=vertex_id, _code=code)
+        graph.add_component(component, vertex_id)
+    graph.add_component_edge(START_ID, ("start", "start"), STOPPER_ID)
+    graph.add_component_edge(START_ID, ("start", "start"), TRIGGER_ID)
+    graph.add_component_edge(STOPPER_ID, ("blocked", "value"), VICTIM_ID)
+    graph.add_component_edge(STOPPER_ID, ("done", "stopper_done"), GOAL_ID)
+    graph.add_component_edge(TRIGGER_ID, ("trigger", "trigger_done"), GOAL_ID)
+    graph.prepare()
+    return json.dumps(graph.dump(name="Stopped branch race"))
+
+
+async def _end_vertex_events(response) -> list[dict]:
+    async def collect() -> list[dict]:
+        events = []
+        async for line in response.aiter_lines():
+            if line:
+                event = json.loads(line)
+                if event.get("event") == "end_vertex":
+                    events.append(event["data"]["build_data"])
+        return events
+
+    return await asyncio.wait_for(collect(), timeout=30)
+
+
+async def test_sibling_completion_does_not_reactivate_a_stopped_branch(client, logged_in_headers):
+    flow_id = await create_flow(client, _race_flow(), logged_in_headers)
+    job_id = (await build_flow(client, flow_id, logged_in_headers))["job_id"]
+    response = await get_build_events(client, job_id, logged_in_headers)
+    assert response.status_code == codes.OK
+
+    built = await _end_vertex_events(response)
+    built_by_id = {build_data["id"]: build_data for build_data in built}
+
+    assert VICTIM_ID not in built_by_id, "the stopped branch was reactivated and executed"
+    assert VICTIM_ID in built_by_id[STOPPER_ID]["inactivated_vertices"]
+    assert built_by_id[GOAL_ID]["valid"]

--- a/src/lfx/src/lfx/graph/checkpoint/builder.py
+++ b/src/lfx/src/lfx/graph/checkpoint/builder.py
@@ -65,6 +65,10 @@ def build_checkpoint(graph: Graph) -> GraphCheckpoint:
         vertices_layers=[list(layer) for layer in graph.vertices_layers],
         first_layer=list(graph._first_layer),  # noqa: SLF001
         inactivated_vertices={str(v) for v in graph.inactivated_vertices},
+        branch_inactivation_sources={
+            str(source): {str(vertex) for vertex in vertices}
+            for source, vertices in graph.branch_inactivation_sources.items()
+        },
         conditionally_excluded_vertices={str(v) for v in graph.conditionally_excluded_vertices},
         activated_vertices=list(graph.activated_vertices),
         vertex_results={vertex.id: _vertex_data(vertex) for vertex in graph.vertices},

--- a/src/lfx/src/lfx/graph/checkpoint/resume.py
+++ b/src/lfx/src/lfx/graph/checkpoint/resume.py
@@ -160,6 +160,10 @@ def restore_graph_from_checkpoint(checkpoint: GraphCheckpoint, *, store: Checkpo
     graph._call_order = list(checkpoint.call_order)  # noqa: SLF001
     # Without these, every vertex resumes ACTIVE and compute_resume_layer revives a ConditionalRouter-stopped branch.
     graph.inactivated_vertices = {str(v) for v in checkpoint.inactivated_vertices}
+    graph.branch_inactivation_sources = {
+        str(source): {str(vertex) for vertex in vertices}
+        for source, vertices in checkpoint.branch_inactivation_sources.items()
+    }
     graph.conditionally_excluded_vertices = {str(v) for v in checkpoint.conditionally_excluded_vertices}
     graph.human_input_decisions = dict(checkpoint.human_input_decisions)
     graph.activated_vertices = list(checkpoint.activated_vertices)

--- a/src/lfx/src/lfx/graph/checkpoint/schema.py
+++ b/src/lfx/src/lfx/graph/checkpoint/schema.py
@@ -50,6 +50,7 @@ class GraphCheckpoint(BaseModel):
     vertices_layers: list[list[str]] = Field(default_factory=list)
     first_layer: list[str] = Field(default_factory=list)
     inactivated_vertices: set[str] = Field(default_factory=set)
+    branch_inactivation_sources: dict[str, set[str]] = Field(default_factory=dict)
     conditionally_excluded_vertices: set[str] = Field(default_factory=set)
     activated_vertices: list[str] = Field(default_factory=list)
     vertex_results: dict[str, VertexCheckpointData] = Field(default_factory=dict)

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -1383,28 +1383,30 @@ class Graph:
         self.in_degree_map = self.build_in_degree(edges)
         self.parent_child_map = self.build_parent_child_map(vertices)
 
-    def reset_inactivated_vertices(self, source_vertex_id: str | None = None) -> None:
-        """Reset branch inactivations owned by a completed source vertex.
+    def _held_branch_inactivations(self) -> set[str]:
+        """Vertices a source vertex stopped and has not released yet."""
+        return set().union(*self.branch_inactivation_sources.values())
 
-        Passing no source preserves the graph-wide reset used when initializing
-        a run. Cached graphs written before source ownership was introduced also
-        fall back to that legacy behavior.
+    def reset_inactivated_vertices(self, source_vertex_id: str | None = None) -> None:
+        """Reactivate inactivated vertices.
+
+        With ``source_vertex_id``, release only the branch stops that completed
+        vertex made; a vertex another source still holds stays inactive.
+        Inactivations with no recorded source (graphs cached or checkpointed
+        before ownership was tracked) keep the legacy behavior and are released
+        by any completion. Without a source, every inactivation is reset.
         """
-        if source_vertex_id is None or not self.branch_inactivation_sources:
-            vertices_to_activate = self.inactivated_vertices.copy()
+        if source_vertex_id is None:
             self.branch_inactivation_sources.clear()
         else:
-            owned_vertices = self.branch_inactivation_sources.pop(source_vertex_id, set())
-            still_owned = (
-                set().union(*self.branch_inactivation_sources.values()) if self.branch_inactivation_sources else set()
-            )
-            vertices_to_activate = owned_vertices - still_owned
-
-        for vertex_id in vertices_to_activate:
+            self.branch_inactivation_sources.pop(source_vertex_id, None)
+        for vertex_id in self.inactivated_vertices - self._held_branch_inactivations():
             self.mark_vertex(vertex_id, "ACTIVE")
 
     def mark_all_vertices(self, state: str) -> None:
         """Marks all vertices in the graph."""
+        # Every vertex now shares one state, so no earlier branch stop is held.
+        self.branch_inactivation_sources.clear()
         for vertex in self.vertices:
             vertex.set_state(state)
 
@@ -1488,26 +1490,7 @@ class Graph:
             output_name=output_name,
             protected_vertices=protected_vertices,
         )
-        branch_vertices = visited - {vertex_id}
-        if state == VertexStates.INACTIVE:
-            tracked_vertices = branch_vertices.intersection(self.inactivated_vertices)
-            if tracked_vertices:
-                self.branch_inactivation_sources.setdefault(vertex_id, set()).update(tracked_vertices)
-        elif state == VertexStates.ACTIVE:
-            owned_vertices = self.branch_inactivation_sources.get(vertex_id)
-            if owned_vertices is not None:
-                released_vertices = owned_vertices.intersection(branch_vertices)
-                owned_vertices.difference_update(released_vertices)
-                if not owned_vertices:
-                    self.branch_inactivation_sources.pop(vertex_id)
-
-                still_owned = (
-                    set().union(*self.branch_inactivation_sources.values())
-                    if self.branch_inactivation_sources
-                    else set()
-                )
-                for owned_vertex_id in released_vertices.intersection(still_owned):
-                    self.mark_vertex(owned_vertex_id, VertexStates.INACTIVE)
+        self._track_branch_inactivation(vertex_id, state, visited - {vertex_id})
         new_predecessor_map, _ = self.build_adjacency_maps(self.edges)
         new_predecessor_map = {k: v for k, v in new_predecessor_map.items() if k in visited}
         if vertex_id in self.cycle_vertices:
@@ -1520,6 +1503,22 @@ class Graph:
             run_predecessors=new_predecessor_map,
             vertices_to_run=self.vertices_to_run,
         )
+
+    def _track_branch_inactivation(self, source_vertex_id: str, state: str, branch_vertices: set[str]) -> None:
+        """Record which source holds each stopped vertex so a completion releases only its own stops."""
+        if state == VertexStates.INACTIVE:
+            stopped = branch_vertices & self.inactivated_vertices
+            if stopped:
+                held = self.branch_inactivation_sources.get(source_vertex_id, set())
+                self.branch_inactivation_sources[source_vertex_id] = held | stopped
+        elif state == VertexStates.ACTIVE:
+            remaining = self.branch_inactivation_sources.pop(source_vertex_id, set()) - branch_vertices
+            if remaining:
+                self.branch_inactivation_sources[source_vertex_id] = remaining
+            # start() releases only this source's stops; one another still-running
+            # vertex holds on a shared descendant stays in effect.
+            for held_vertex_id in branch_vertices & self._held_branch_inactivations():
+                self.mark_vertex(held_vertex_id, VertexStates.INACTIVE)
 
     def _replace_conditional_exclusions(self, vertex_id: str, excluded: set[str]) -> None:
         """Replace ``vertex_id``'s conditional exclusions with ``excluded``.

--- a/src/lfx/src/lfx/graph/graph/base.py
+++ b/src/lfx/src/lfx/graph/graph/base.py
@@ -195,6 +195,11 @@ class Graph:
         self.persist_messages: bool = True
         self._start_time = datetime.now(timezone.utc)
         self.inactivated_vertices: set = set()
+        # Branch stops are transient and must be released by the vertex that
+        # created them. The graph can execute sibling vertices concurrently, so
+        # a graph-wide reset when one sibling finishes would otherwise revive a
+        # branch stopped by another sibling that is still running.
+        self.branch_inactivation_sources: dict[str, set[str]] = {}
         self.activated_vertices: list[str] = []
         self.vertices_layers: list[list[str]] = []
         self.vertices_to_run: set[str] = set()
@@ -1378,12 +1383,25 @@ class Graph:
         self.in_degree_map = self.build_in_degree(edges)
         self.parent_child_map = self.build_parent_child_map(vertices)
 
-    def reset_inactivated_vertices(self) -> None:
-        """Resets the inactivated vertices in the graph."""
-        for vertex_id in self.inactivated_vertices.copy():
+    def reset_inactivated_vertices(self, source_vertex_id: str | None = None) -> None:
+        """Reset branch inactivations owned by a completed source vertex.
+
+        Passing no source preserves the graph-wide reset used when initializing
+        a run. Cached graphs written before source ownership was introduced also
+        fall back to that legacy behavior.
+        """
+        if source_vertex_id is None or not self.branch_inactivation_sources:
+            vertices_to_activate = self.inactivated_vertices.copy()
+            self.branch_inactivation_sources.clear()
+        else:
+            owned_vertices = self.branch_inactivation_sources.pop(source_vertex_id, set())
+            still_owned = (
+                set().union(*self.branch_inactivation_sources.values()) if self.branch_inactivation_sources else set()
+            )
+            vertices_to_activate = owned_vertices - still_owned
+
+        for vertex_id in vertices_to_activate:
             self.mark_vertex(vertex_id, "ACTIVE")
-        self.inactivated_vertices = set()
-        self.inactivated_vertices = set()
 
     def mark_all_vertices(self, state: str) -> None:
         """Marks all vertices in the graph."""
@@ -1470,6 +1488,26 @@ class Graph:
             output_name=output_name,
             protected_vertices=protected_vertices,
         )
+        branch_vertices = visited - {vertex_id}
+        if state == VertexStates.INACTIVE:
+            tracked_vertices = branch_vertices.intersection(self.inactivated_vertices)
+            if tracked_vertices:
+                self.branch_inactivation_sources.setdefault(vertex_id, set()).update(tracked_vertices)
+        elif state == VertexStates.ACTIVE:
+            owned_vertices = self.branch_inactivation_sources.get(vertex_id)
+            if owned_vertices is not None:
+                released_vertices = owned_vertices.intersection(branch_vertices)
+                owned_vertices.difference_update(released_vertices)
+                if not owned_vertices:
+                    self.branch_inactivation_sources.pop(vertex_id)
+
+                still_owned = (
+                    set().union(*self.branch_inactivation_sources.values())
+                    if self.branch_inactivation_sources
+                    else set()
+                )
+                for owned_vertex_id in released_vertices.intersection(still_owned):
+                    self.mark_vertex(owned_vertex_id, VertexStates.INACTIVE)
         new_predecessor_map, _ = self.build_adjacency_maps(self.edges)
         new_predecessor_map = {k: v for k, v in new_predecessor_map.items() if k in visited}
         if vertex_id in self.cycle_vertices:
@@ -1582,6 +1620,7 @@ class Graph:
             "raw_graph_data": self.raw_graph_data,
             "top_level_vertices": self.top_level_vertices,
             "inactivated_vertices": self.inactivated_vertices,
+            "branch_inactivation_sources": self.branch_inactivation_sources,
             "run_manager": self.run_manager.to_dict(),
             "_run_id": self._run_id,
             "in_degree_map": self.in_degree_map,
@@ -1724,6 +1763,7 @@ class Graph:
         # Graphs cached before source-flow provenance was introduced remain
         # loadable and simply have no additional trusted storage namespace.
         state.setdefault("source_flow_id", None)
+        state.setdefault("branch_inactivation_sources", {})
         run_manager = state["run_manager"]
         if isinstance(run_manager, RunnableVerticesManager):
             state["run_manager"] = run_manager
@@ -2191,7 +2231,7 @@ class Graph:
         if self.stop_vertex and self.stop_vertex in next_runnable_vertices:
             next_runnable_vertices = [self.stop_vertex]
         self.extend_run_queue(next_runnable_vertices)
-        self.reset_inactivated_vertices()
+        self.reset_inactivated_vertices(vertex_id)
         self.reset_activated_vertices()
 
         if chat_service is not None:

--- a/src/lfx/tests/unit/graph/checkpoint/test_resume.py
+++ b/src/lfx/tests/unit/graph/checkpoint/test_resume.py
@@ -99,12 +99,14 @@ async def test_resume_keeps_inactivated_branch_stopped():
     graph, _ = await _paused_checkpoint()
     # Simulate a ConditionalRouter having stopped the chat_output branch before the pause.
     graph.inactivated_vertices = {"chat_output"}
+    graph.branch_inactivation_sources = {"chat_input": {"chat_output"}}
     graph.get_vertex("chat_output").state = VertexStates.INACTIVE
     checkpoint = graph.build_checkpoint()
 
     resumed = Graph.resume_from_checkpoint(checkpoint)
     # The inactivated state survives resume and the dead branch is NOT queued to run again.
     assert resumed.inactivated_vertices == {"chat_output"}
+    assert resumed.branch_inactivation_sources == {"chat_input": {"chat_output"}}
     assert resumed.get_vertex("chat_output").state == VertexStates.INACTIVE
     assert "chat_output" not in resumed.resume_first_layer()
 

--- a/src/lfx/tests/unit/graph/checkpoint/test_schema.py
+++ b/src/lfx/tests/unit/graph/checkpoint/test_schema.py
@@ -36,6 +36,7 @@ def _checkpoint(**overrides) -> GraphCheckpoint:
         "vertices_layers": [["n1"], ["n2"]],
         "first_layer": ["n1"],
         "inactivated_vertices": {"n3"},
+        "branch_inactivation_sources": {"n1": {"n3"}},
         "activated_vertices": ["n2"],
         "vertex_results": {
             "n1": VertexCheckpointData(vertex_id="n1", built=True, results={"text": "hello"}),
@@ -62,6 +63,7 @@ def test_checkpoint_round_trips_via_json_with_sets_preserved():
     assert restored.vertices_being_run == {"n1"}
     assert restored.ran_at_least_once == {"n1"}
     assert restored.inactivated_vertices == {"n3"}
+    assert restored.branch_inactivation_sources == {"n1": {"n3"}}
     assert restored.run_queue == ["n2"]
     assert restored.call_order == ["n1"]
     assert restored.pause_context == {"reason": "human_input_required", "data": {"options": ["a", "b"]}}

--- a/src/lfx/tests/unit/graph/test_branch_inactivation.py
+++ b/src/lfx/tests/unit/graph/test_branch_inactivation.py
@@ -1,0 +1,94 @@
+from lfx.custom.custom_component.component import Component
+from lfx.graph.graph.base import Graph
+from lfx.graph.vertex.base import VertexStates
+from lfx.io import MessageTextInput, Output
+from lfx.schema.message import Message
+
+
+class Source(Component):
+    display_name = "Source"
+    name = "Source"
+    outputs = [Output(display_name="Done", name="done", method="run")]
+
+    def run(self) -> Message:
+        return Message(text="done")
+
+
+class Sink(Component):
+    display_name = "Sink"
+    name = "Sink"
+    inputs = [MessageTextInput(name="input_value", display_name="Input", required=False)]
+    outputs = [Output(display_name="Out", name="out", method="run")]
+
+    def run(self) -> Message:
+        return Message(text=str(self.input_value or ""))
+
+
+def _parallel_branches() -> Graph:
+    graph = Graph()
+    for component_id, component in (
+        ("stopper", Source(_id="stopper")),
+        ("sibling", Source(_id="sibling")),
+        ("victim", Sink(_id="victim")),
+        ("sibling_output", Sink(_id="sibling_output")),
+    ):
+        graph.add_component(component, component_id)
+    graph.add_component_edge("stopper", ("done", "input_value"), "victim")
+    graph.add_component_edge("sibling", ("done", "input_value"), "sibling_output")
+    graph.prepare()
+    return graph
+
+
+def test_completed_sibling_does_not_reset_another_sources_stopped_branch():
+    graph = _parallel_branches()
+
+    graph.mark_branch("stopper", VertexStates.INACTIVE, output_name="done")
+    graph.reset_inactivated_vertices("sibling")
+
+    assert graph.get_vertex("victim").state == VertexStates.INACTIVE
+    assert graph.inactivated_vertices == {"victim"}
+
+    graph.reset_inactivated_vertices("stopper")
+
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE
+    assert graph.inactivated_vertices == set()
+
+
+def test_start_releases_the_sources_branch_ownership():
+    graph = _parallel_branches()
+    graph.mark_branch("stopper", VertexStates.INACTIVE, output_name="done")
+
+    graph.mark_branch("stopper", VertexStates.ACTIVE, output_name="done")
+
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE
+    assert graph.inactivated_vertices == set()
+    assert graph.branch_inactivation_sources == {}
+
+
+def test_shared_descendant_stays_inactive_until_every_source_releases_it():
+    graph = Graph()
+    for component_id, component in (
+        ("first", Source(_id="first")),
+        ("second", Source(_id="second")),
+        ("first_branch", Sink(_id="first_branch")),
+        ("second_branch", Sink(_id="second_branch")),
+        ("merge", Sink(_id="merge")),
+        ("victim", Sink(_id="victim")),
+    ):
+        graph.add_component(component, component_id)
+    graph.add_component_edge("first", ("done", "input_value"), "first_branch")
+    graph.add_component_edge("second", ("done", "input_value"), "second_branch")
+    graph.add_component_edge("first_branch", ("out", "input_value"), "merge")
+    graph.add_component_edge("second_branch", ("out", "input_value"), "merge")
+    graph.add_component_edge("merge", ("out", "input_value"), "victim")
+    graph.prepare()
+
+    graph.mark_branch("first", VertexStates.INACTIVE, output_name="done")
+    graph.mark_branch("second", VertexStates.INACTIVE, output_name="done")
+    graph.reset_inactivated_vertices("first")
+
+    assert graph.get_vertex("victim").state == VertexStates.INACTIVE
+
+    graph.reset_inactivated_vertices("second")
+
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE

--- a/src/lfx/tests/unit/graph/test_branch_inactivation.py
+++ b/src/lfx/tests/unit/graph/test_branch_inactivation.py
@@ -65,7 +65,7 @@ def test_start_releases_the_sources_branch_ownership():
     assert graph.branch_inactivation_sources == {}
 
 
-def test_shared_descendant_stays_inactive_until_every_source_releases_it():
+def _shared_descendant() -> Graph:
     graph = Graph()
     for component_id, component in (
         ("first", Source(_id="first")),
@@ -82,6 +82,11 @@ def test_shared_descendant_stays_inactive_until_every_source_releases_it():
     graph.add_component_edge("second_branch", ("out", "input_value"), "merge")
     graph.add_component_edge("merge", ("out", "input_value"), "victim")
     graph.prepare()
+    return graph
+
+
+def test_shared_descendant_stays_inactive_until_every_source_releases_it():
+    graph = _shared_descendant()
 
     graph.mark_branch("first", VertexStates.INACTIVE, output_name="done")
     graph.mark_branch("second", VertexStates.INACTIVE, output_name="done")
@@ -92,3 +97,67 @@ def test_shared_descendant_stays_inactive_until_every_source_releases_it():
     graph.reset_inactivated_vertices("second")
 
     assert graph.get_vertex("victim").state == VertexStates.ACTIVE
+
+
+def test_start_does_not_override_a_stop_another_source_still_holds():
+    graph = _shared_descendant()
+    graph.mark_branch("first", VertexStates.INACTIVE, output_name="done")
+
+    # "second" never stopped anything, so it has nothing of its own to release.
+    graph.mark_branch("second", VertexStates.ACTIVE, output_name="done")
+
+    assert graph.get_vertex("second_branch").state == VertexStates.ACTIVE
+    assert graph.get_vertex("victim").state == VertexStates.INACTIVE
+    assert "victim" in graph.inactivated_vertices
+
+    graph.reset_inactivated_vertices("first")
+
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE
+
+
+def test_unowned_inactivation_keeps_legacy_release_alongside_owned_stops():
+    graph = _parallel_branches()
+    graph.mark_branch("stopper", VertexStates.INACTIVE, output_name="done")
+    # Graphs cached or checkpointed before ownership was tracked carry inactive
+    # vertices with no recorded source.
+    graph.mark_vertex("sibling_output", VertexStates.INACTIVE)
+
+    graph.reset_inactivated_vertices("sibling")
+
+    assert graph.get_vertex("sibling_output").state == VertexStates.ACTIVE
+    assert graph.get_vertex("victim").state == VertexStates.INACTIVE
+    assert graph.inactivated_vertices == {"victim"}
+
+
+def test_resorting_the_graph_drops_stale_branch_ownership():
+    graph = _shared_descendant()
+    graph.mark_branch("first", VertexStates.INACTIVE, output_name="done")
+
+    graph.sort_vertices()
+
+    assert graph.inactivated_vertices == set()
+    assert graph.branch_inactivation_sources == {}
+    # A stop left over from the previous run must not re-inactivate the branch.
+    graph.mark_branch("second", VertexStates.ACTIVE, output_name="done")
+    assert graph.get_vertex("victim").state == VertexStates.ACTIVE
+
+
+def test_branch_ownership_survives_the_graph_cache_round_trip():
+    graph = _parallel_branches()
+    graph.mark_branch("stopper", VertexStates.INACTIVE, output_name="done")
+
+    restored = Graph.__new__(Graph)
+    restored.__setstate__(graph.__getstate__())
+
+    assert restored.branch_inactivation_sources == {"stopper": {"victim"}}
+
+
+def test_graph_cached_before_branch_ownership_loads_without_it():
+    graph = _parallel_branches()
+    state = graph.__getstate__()
+    state.pop("branch_inactivation_sources")
+
+    restored = Graph.__new__(Graph)
+    restored.__setstate__(state)
+
+    assert restored.branch_inactivation_sources == {}


### PR DESCRIPTION
## Summary

Fixes #14966 on `release-1.12.2`: a branch stopped with `Component.stop()` could be reactivated, and then **executed**, when an unrelated sibling vertex finished first.

**Credit:** the core fix is @noooooooookro's #14980. Their commit is cherry-picked unchanged with authorship preserved, and they are credited as co-author (a `Co-authored-by` trailer on the final commit) so the credit survives the squash merge. A second commit closes three gaps found while reviewing it and adds an end-to-end regression test through the real build route.

## Root cause

`Component.stop(output)` marks the downstream branch `INACTIVE` in the graph-wide `Graph.inactivated_vertices` set. The streaming build driver (`api/build.py` → `build_vertices`) runs sibling vertices concurrently, and **every** completed vertex called `graph.reset_inactivated_vertices()`, which reactivated everything. So while a stopper was still running (awaiting), any sibling that completed first reactivated the stopper's branch. When the stopper then completed, `get_next_runnable_vertices` found the stopped vertex `ACTIVE` and scheduled it.

Reproduced on `release-1.12.2` with the issue's flow through `POST /api/v1/build`:

```text
[MRE_STOPPER_AFTER_STOP] inactivated=['StoppedBranchVictim-lNcTl'] victim_states={'StoppedBranchVictim-lNcTl': 'INACTIVE'}
[MRE_TRIGGER] completed
[MRE_STOPPER_BEFORE_RETURN] inactivated=[] victim_states={'StoppedBranchVictim-lNcTl': 'ACTIVE'}
[MRE_FINAL_GOAL] reached successfully
[MRE_VICTIM] ERROR: stopped branch executed
[MRE_VICTIM] received={'__stopped_branch_sentinel__': True, 'source': 'StopBranchRaceStopper'}
```

The stopper's own `end_vertex` also reported `inactivated_vertices: []`, so the canvas was never told the branch had been stopped.

The same pattern affects built-in components that use bare `stop()`: **Loop** (`item_output` calls `stop("item")` and then awaits the whole `_iterate()` loop body, a long window), **Guardrails**, **Data Conditional Router**, **Human Input**, and **LLM Conditional Router**. `ConditionalRouter` is partly protected by its separate, already source-owned `conditionally_excluded_vertices`.

## What changed

**Commit 1: cherry-pick of #14980** (`fix(graph): scope branch inactivation resets`)
- `Graph.branch_inactivation_sources: dict[source_vertex_id, set[vertex_id]]` records which vertex stopped which branch vertices.
- `reset_inactivated_vertices(source_vertex_id)` releases only that source's stops. It is called with the completed vertex id from `api/build.py`, the deprecated per-vertex endpoint in `api/v1/chat.py`, and `Graph.astep`.
- Ownership survives graph-cache pickling (`__getstate__`/`__setstate__`, defaulting to `{}` for older pickles) and HITL checkpoints (`GraphCheckpoint.branch_inactivation_sources`, defaulting to `{}`). Plain Pydantic ignores unknown fields, so older workers can still read newer checkpoints.

**Commit 2: hardening**
- **Ownerless inactivations keep the legacy release.** Graphs cached or checkpointed before this change carry inactive vertices with no recorded source. #14980 released those only when *no* source held anything, so they could stay stuck once any new stop was recorded. The reset now reactivates `inactivated_vertices - held`, which treats every ownerless entry the old way.
- **`start()` can't override another running source's stop.** #14980 re-applied other sources' holds only when the starting vertex had itself owned something; it now always does, for vertices in the started branch.
- **No stale ownership across runs.** `sort_vertices()` resets every state at run start via `mark_all_vertices()`, which now also clears the ownership map. Otherwise stale entries could re-inactivate vertices on a reused graph.
- Tests:
  - `src/lfx/tests/unit/graph/test_branch_inactivation.py` covers the cases above and the pickle round-trip, including pickles with no ownership field.
  - `src/backend/tests/unit/api/test_build_stopped_branch_race.py` drives the real `/api/v1/build` route with custom components that force the race deterministically. The sibling completes only after the stop is in place, and the stopper returns only after the sibling's completion path has run. Timing skew can only make it pass vacuously on unfixed code; it can't fail spuriously on fixed code.

## Pause/resume

Ownership is persisted in HITL checkpoints. If a pause snapshots the graph while a stopper is still running, that stopper has `built=False`, so `compute_resume_layer` re-runs it on resume and its completion releases the hold. A hold can outlive a resume only if its source had already finished building. Even then it covers only vertices in that source's stopped branch, which can legitimately run only if the source runs again, and re-running releases the hold.

## Deliberately not changed

- **`Graph.process()`** (`arun` / `lfx run`) has never reset inactivations: it gathers a whole layer before scheduling the next one, so it doesn't have this race. CodeRabbit's suggestion on #14980 to add a per-vertex reset there would be an unrelated behavior change.
- **Adjacent bug, separate follow-up:** in the same repro, Start Trigger and Delayed Reset Trigger each emit `end_vertex` twice. `mark_branch` re-seeds the *stopper's own* already-satisfied predecessors into `run_predecessors`, and a sibling's backward walk then re-queues them. Outputs with the default `cache=True` return the cached value, so component code doesn't re-run. That behavior is unchanged by this PR, and the new test doesn't depend on it.

## Test plan

- [x] Issue repro through `POST /api/v1/build`: on `release-1.12.2` the victim executes; with this PR it is never built, the stopper's `end_vertex` lists it in `inactivated_vertices`, and the final goal completes.
- [x] `test_build_stopped_branch_race.py` fails on `release-1.12.2` sources (`AssertionError: the stopped branch was reactivated and executed`) and passes with the fix.
- [x] New lfx unit tests fail against #14980 alone for the three gaps above and pass with commit 2.
- [x] lfx suites: `tests/unit/graph` (incl. checkpoint), `tests/unit/components/flow_controls`, `tests/unit/workflow/test_agui_translator.py`, `tests/unit/cli/test_serve_durable.py`: 523 passed, 6 skipped, 1 xfailed. The 2 failures (`test_graph.py::test_from_payload_checks_*catalog*policy*`) fail identically on pristine `release-1.12.2` in a local env without the component catalog.
- [x] Backend suites: build/pause/resume API tests, `background_execution`, `components/flow_controls` (Loop, ConditionalRouter, DataConditionalRouter, Human Input), Guardrails, LLM Conditional Router, `unit/graph`, `test_chat_endpoint.py`: 594 passed, 180 skipped, 1 xfailed under `-n 6`. The only error was an `alembic_version` setup race between xdist workers in `test_facade_real_services.py`; that module passes serially (47 passed, 47 skipped).
- [x] `ruff format --check` / `ruff check` clean on all changed files
- [ ] CI green
