### PR TITLE
fix(lfx): percent-encode "/" in database connection passwords

### DIFF
--- a/src/backend/base/langflow/utils/connection_string_parser.py
+++ b/src/backend/base/langflow/utils/connection_string_parser.py
@@ -1,8 +1,5 @@
-from urllib.parse import quote
+"""Connection string parser utilities for langflow - imports from lfx."""
 
+from lfx.utils.connection_string_parser import transform_connection_string
 
-def transform_connection_string(connection_string) -> str:
-    auth_part, db_url_name = connection_string.rsplit("@", 1)
-    protocol_user, password_string = auth_part.rsplit(":", 1)
-    encoded_password = quote(password_string)
-    return f"{protocol_user}:{encoded_password}@{db_url_name}"
+__all__ = ["transform_connection_string"]

--- a/src/backend/tests/unit/utils/test_connection_string_parser.py
+++ b/src/backend/tests/unit/utils/test_connection_string_parser.py
@@ -1,20 +1,8 @@
-import pytest
-from langflow.utils.connection_string_parser import transform_connection_string
+from langflow.utils import connection_string_parser as langflow_parser
+from lfx.utils import connection_string_parser as lfx_parser
 
 
-@pytest.mark.parametrize(
-    ("connection_string", "expected"),
-    [
-        ("protocol:user:password@host", "protocol:user:password@host"),
-        ("protocol:user@host", "protocol:user@host"),
-        ("protocol:user:pass@word@host", "protocol:user:pass%40word@host"),
-        ("protocol:user:pa:ss:word@host", "protocol:user:pa:ss:word@host"),
-        ("user:password@host", "user:password@host"),
-        ("protocol::password@host", "protocol::password@host"),
-        ("protocol:user:password@", "protocol:user:password@"),
-        ("protocol:user:pa@ss@word@host", "protocol:user:pa%40ss%40word@host"),
-    ],
-)
-def test_transform_connection_string(connection_string, expected):
-    result = transform_connection_string(connection_string)
-    assert result == expected
+def test_langflow_reexports_lfx_helper():
+    """The langflow module is a shim; behavior is tested in src/lfx/tests/unit/utils."""
+    assert langflow_parser.transform_connection_string is lfx_parser.transform_connection_string
+    assert langflow_parser.transform_connection_string("protocol:user:p/ss@host") == "protocol:user:p%2Fss@host"

--- a/src/lfx/src/lfx/utils/connection_string_parser.py
+++ b/src/lfx/src/lfx/utils/connection_string_parser.py
@@ -7,5 +7,5 @@ def transform_connection_string(connection_string) -> str:
     """Transform connection string by encoding the password part."""
     auth_part, db_url_name = connection_string.rsplit("@", 1)
     protocol_user, password_string = auth_part.rsplit(":", 1)
-    encoded_password = quote(password_string)
+    encoded_password = quote(password_string, safe="")
     return f"{protocol_user}:{encoded_password}@{db_url_name}"

--- a/src/lfx/src/lfx/utils/connection_string_parser.py
+++ b/src/lfx/src/lfx/utils/connection_string_parser.py
@@ -7,5 +7,8 @@ def transform_connection_string(connection_string) -> str:
     """Transform connection string by encoding the password part."""
     auth_part, db_url_name = connection_string.rsplit("@", 1)
     protocol_user, password_string = auth_part.rsplit(":", 1)
+    if password_string.startswith("//") and "://" not in protocol_user:
+        # "scheme://user@host" carries no password; the only ':' is the scheme separator.
+        return connection_string
     encoded_password = quote(password_string, safe="")
     return f"{protocol_user}:{encoded_password}@{db_url_name}"

--- a/src/lfx/tests/unit/utils/test_connection_string_parser.py
+++ b/src/lfx/tests/unit/utils/test_connection_string_parser.py
@@ -1,0 +1,26 @@
+import pytest
+from lfx.utils.connection_string_parser import transform_connection_string
+
+
+@pytest.mark.parametrize(
+    ("connection_string", "expected"),
+    [
+        ("protocol:user:password@host", "protocol:user:password@host"),
+        ("protocol:user@host", "protocol:user@host"),
+        ("protocol:user:pass@word@host", "protocol:user:pass%40word@host"),
+        ("protocol:user:pa:ss:word@host", "protocol:user:pa:ss:word@host"),
+        ("user:password@host", "user:password@host"),
+        ("protocol::password@host", "protocol::password@host"),
+        ("protocol:user:password@", "protocol:user:password@"),
+        ("protocol:user:pa@ss@word@host", "protocol:user:pa%40ss%40word@host"),
+        # '/' is left alone by quote()'s default safe='/' and must be encoded explicitly
+        ("protocol:user:p/ss@host", "protocol:user:p%2Fss@host"),
+        ("protocol:user:a/b/c@host", "protocol:user:a%2Fb%2Fc@host"),
+        (
+            "postgresql://user:p@ss/w0rd@host:5432/db",  # pragma: allowlist secret
+            "postgresql://user:p%40ss%2Fw0rd@host:5432/db",  # pragma: allowlist secret
+        ),
+    ],
+)
+def test_transform_connection_string(connection_string, expected):
+    assert transform_connection_string(connection_string) == expected

--- a/src/lfx/tests/unit/utils/test_connection_string_parser.py
+++ b/src/lfx/tests/unit/utils/test_connection_string_parser.py
@@ -20,6 +20,15 @@ from lfx.utils.connection_string_parser import transform_connection_string
             "postgresql://user:p@ss/w0rd@host:5432/db",  # pragma: allowlist secret
             "postgresql://user:p%40ss%2Fw0rd@host:5432/db",  # pragma: allowlist secret
         ),
+        # no password: the last ':' is the scheme separator, so there is nothing to encode
+        ("postgresql://user@host:5432/db", "postgresql://user@host:5432/db"),
+        ("postgresql+psycopg://user@host:5432/db", "postgresql+psycopg://user@host:5432/db"),
+        ("postgresql://@host:5432/db", "postgresql://@host:5432/db"),
+        # a password that starts with '//' is still encoded
+        (
+            "postgresql://user://pw@host:5432/db",  # pragma: allowlist secret
+            "postgresql://user:%2F%2Fpw@host:5432/db",  # pragma: allowlist secret
+        ),
     ],
 )
 def test_transform_connection_string(connection_string, expected):


### PR DESCRIPTION
A database password containing `/` reached the PGVector connection string unencoded. `transform_connection_string` percent-encodes the password with `urllib.parse.quote()`, and its default `safe="/"` leaves slashes alone while `@`, `:`, `?` and the rest get encoded. Generic PostgreSQL URI parsers (libpq, `urlparse`) then read the slash as the start of the path and lose the host.

The helper now calls `quote(password, safe="")`, so every reserved character is encoded and any valid password survives the trip. The duplicate copy in `langflow.utils` is collapsed into a re-export of the lfx implementation, and the case table moves to the lfx test suite so the package that ships the behavior also tests it.

Worth knowing: the PGVector component hands the URL to SQLAlchemy, which already tolerated a raw slash and decomposed it into the right driver kwargs, so that specific path was not failing on current dependencies. This is contract hardening for the helper and for any consumer that parses the URI directly.

Not covered here: a password containing both `@` and `:` (for example `p@ss:word`) is still mis-split by the last-colon parse in the same function. That is a pre-existing separate defect and will get its own change.

Fixes #15012. Supersedes #15013 with lfx-side test coverage and the de-duplicated helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-string handling when passwords contain special characters.
  * Password characters such as `/` and `@` are now encoded consistently, preventing malformed connection strings and connection failures.
  * Preserved support for connection strings without credentials, empty passwords, and complex password values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->