### PR TITLE
fix(assistant): validate component params before applying any of them

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1163,7 +1163,7 @@
         "filename": "src/backend/tests/unit/agentic/flows/test_flow_builder_assistant.py",
         "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
         "is_verified": false,
-        "line_number": 630,
+        "line_number": 636,
         "is_secret": false
       }
     ],
@@ -7417,5 +7417,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-10T23:04:46Z"
+  "generated_at": "2026-09-11T17:58:39Z"
 }

--- a/src/backend/base/langflow/agentic/flows/flow_builder_assistant.py
+++ b/src/backend/base/langflow/agentic/flows/flow_builder_assistant.py
@@ -40,6 +40,15 @@ on the user's canvas. Components appear in real time as you add them.
 - **describe_component** - Get a component TYPE's inputs, outputs, fields.
 - **get_field_value** - Read field values from a component on the canvas (by ID). No field_name = list all.
 
+Treat configuration metadata from `describe_component` as authoritative:
+- For closed scalar `options`, use exact, case-sensitive values. For `list` fields,
+  select each item from the options. A `combobox` allows free-text values; preserve
+  structured values (such as duration objects) and structured options in their declared shape.
+- Keep numeric values within `range_spec` bounds. When an optional field has a
+  `default`, omit it unless the user requests another value.
+- If configuration fails validation, correct the invalid parameter before retrying;
+  the rejected configuration call does not apply any of its parameter changes.
+
 **Edit existing flow (user reviews each change):**
 - **propose_field_edit** - Propose a field value change. User sees a diff card and accepts/rejects.
 

--- a/src/backend/tests/unit/agentic/flows/test_flow_builder_assistant.py
+++ b/src/backend/tests/unit/agentic/flows/test_flow_builder_assistant.py
@@ -15,6 +15,12 @@ from tests.api_keys import has_api_key
 
 
 class TestFlowBuilderPrompt:
+    def test_should_use_declared_configuration_constraints(self):
+        assert "exact, case-sensitive values" in FLOW_BUILDER_PROMPT
+        assert "`combobox` allows free-text" in FLOW_BUILDER_PROMPT
+        assert "within `range_spec` bounds" in FLOW_BUILDER_PROMPT
+        assert "does not apply any of its parameter changes" in FLOW_BUILDER_PROMPT
+
     def test_should_mention_search_components_tool(self):
         assert "search_components" in FLOW_BUILDER_PROMPT
 

--- a/src/lfx/src/lfx/graph/flow_builder/component.py
+++ b/src/lfx/src/lfx/graph/flow_builder/component.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 import secrets
 import string
+from numbers import Real
 from typing import Any
 
 import yaml
 
+from lfx.graph.edge.base import TYPE_MIGRATIONS
 from lfx.graph.flow_builder._utils import node_id as _node_id
 
 # Canvas type for user-authored code components. The frontend resolves this in
@@ -275,12 +278,84 @@ def _coerce_model_value(value: Any) -> Any:
     return value
 
 
+def _is_scalar_option_value(value: Any) -> bool:
+    """Return whether a registry value can participate in direct option matching."""
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+# Field types whose ``options`` are scalar but whose value is structured
+# (DurationInput: unit options, ``{"unit", "value"}`` value). Gated by type, not
+# by the current value, so the decision cannot flip after a write.
+_STRUCTURED_VALUE_TYPES = frozenset({"duration"})
+
+
+def _validate_configured_value(field_name: str, field: dict[str, Any], value: Any) -> None:
+    """Validate closed options and numeric bounds before mutating a flow."""
+    if value is None or value == field.get("value"):
+        # Re-setting what the field already holds is always acceptable, including
+        # shipped defaults that sit outside their own range_spec (max_tokens=0).
+        return
+
+    options = field.get("options")
+    # Model selectors and sortable lists carry dict options and keep their
+    # existing structured semantics; duration keeps its structured value.
+    has_direct_options = (
+        isinstance(options, list)
+        and options
+        and all(_is_scalar_option_value(option) for option in options)
+        and field.get("type") not in _STRUCTURED_VALUE_TYPES
+    )
+    if has_direct_options and field.get("list") and not isinstance(value, list):
+        msg = f"Invalid value for parameter '{field_name}': {value!r}. Expected a list"
+        raise ValueError(msg)
+    if has_direct_options and not field.get("combobox"):
+        values = value if field.get("list") and isinstance(value, list) else [value]
+        accepted_values = list(options)
+        if field.get("type") == "tab":
+            # TabInput accepts an empty selection in addition to its options.
+            accepted_values.append("")
+            # Saved flows may still carry the pre-migration type names; accept
+            # them the same way edge type checks do.
+            for alias, canonical in TYPE_MIGRATIONS.items():
+                if canonical in options:
+                    accepted_values.append(alias)
+        invalid_values = [item for item in values if item not in accepted_values]
+        if invalid_values:
+            msg = f"Invalid value for parameter '{field_name}': {invalid_values[0]!r}. Expected one of: {options!r}"
+            raise ValueError(msg)
+
+    range_spec = field.get("range_spec")
+    if not isinstance(range_spec, dict):
+        return
+
+    if not isinstance(value, Real) or isinstance(value, bool):
+        msg = f"Invalid value for parameter '{field_name}': {value!r}. Expected a number"
+        raise ValueError(msg)  # noqa: TRY004
+
+    # Integers are always finite; converting a very large int to float can overflow.
+    if not isinstance(value, int) and not math.isfinite(value):
+        msg = f"Invalid value for parameter '{field_name}': {value!r}. Expected a finite number"
+        raise ValueError(msg)
+
+    minimum = range_spec.get("min")
+    maximum = range_spec.get("max")
+    if (minimum is not None and value < minimum) or (maximum is not None and value > maximum):
+        bounds = f"{minimum}..{maximum}" if minimum is not None and maximum is not None else "the configured range"
+        msg = f"Invalid value for parameter '{field_name}': {value!r}. Expected a value in {bounds}"
+        raise ValueError(msg)
+
+
 def configure_component(
     flow: dict,
     component_id: str,
     params: dict[str, Any],
 ) -> None:
     """Set parameters on a component (pure version — no server calls).
+
+    Every parameter is validated first (known field, closed ``options``,
+    ``range_spec`` bounds, numeric type) and only then applied, so a
+    rejected call raises ``ValueError`` and leaves the flow, including
+    ``load_from_db`` flags, exactly as it was.
 
     Model-typed fields (``template[field].type == "model"``) accept the
     canonical ``[{"provider": X, "name": Y}]`` shape. Some flow-builder
@@ -299,8 +374,9 @@ def configure_component(
         msg = f"Component not found: {component_id}"
         raise ValueError(msg)
 
-    template = node["data"].setdefault("node", {}).setdefault("template", {})
-    for key, value in params.items():
+    template = node["data"].get("node", {}).get("template", {})
+    normalized_params: dict[str, Any] = {}
+    for key, raw_value in params.items():
         if key not in template:
             available = [k for k in template if isinstance(template[k], dict)]
             msg = f"Unknown parameter '{key}' on component '{component_id}'. Available: {available}"
@@ -317,12 +393,16 @@ def configure_component(
             # error (see sibling check + test_configure_unknown_field_raises);
             # callers catch ValueError. TypeError would break that contract.
             raise ValueError(msg)  # noqa: TRY004
+        value = raw_value
         if template[key].get("type") == "model":
-            coerced = _coerce_model_value(value)
-            params[key] = coerced
-            template[key]["value"] = coerced
-        else:
-            template[key]["value"] = value
+            value = _coerce_model_value(value)
+        _validate_configured_value(key, template[key], value)
+        normalized_params[key] = value
+
+    # Validate every parameter before changing either the flow or caller's params.
+    params.update(normalized_params)
+    for key, value in normalized_params.items():
+        template[key]["value"] = value
         # Values supplied through the configure API are explicit literals, just
         # like values set through Component.set_input_value(). Do not reinterpret
         # them as global-variable names merely because the field defaults to

--- a/src/lfx/src/lfx/mcp/registry.py
+++ b/src/lfx/src/lfx/mcp/registry.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from lfx.mcp.redact import is_sensitive_field
+
 if TYPE_CHECKING:
     from lfx.mcp.client import LangflowClient
 
@@ -83,6 +85,39 @@ def search_registry(
     return results
 
 
+def _field_description(field_name: str, field_data: dict[str, Any]) -> dict[str, Any]:
+    """Return the safe, useful configuration metadata for one field."""
+    field_info: dict[str, Any] = {
+        "name": field_name,
+        "type": field_data.get("type", ""),
+    }
+    if field_data.get("required"):
+        field_info["required"] = True
+
+    options = field_data.get("options")
+    if isinstance(options, list) and options:
+        field_info["options"] = options
+    for flag in ("combobox", "list"):
+        if field_data.get(flag):
+            field_info[flag] = True
+
+    # Defaults help the Assistant omit optional fields safely, but never expose
+    # a credential through discovery metadata. A load_from_db value is a global
+    # variable *name*, not a default: advertising it invites the Assistant to
+    # send it back as a literal, which would sever the variable binding.
+    is_secret = is_sensitive_field(field_name) or field_data.get("password") is True
+    if "value" in field_data and not is_secret and not field_data.get("load_from_db"):
+        field_info["default"] = field_data["value"]
+
+    range_spec = field_data.get("range_spec")
+    if isinstance(range_spec, dict):
+        field_info["range_spec"] = {
+            key: range_spec[key] for key in ("min", "max", "step", "step_type") if key in range_spec
+        }
+
+    return field_info
+
+
 def describe_component(registry: dict[str, dict], component_type: str) -> dict[str, Any]:
     """Describe a component type's inputs, outputs, and fields. Pure function."""
     if component_type not in registry:
@@ -156,14 +191,12 @@ def describe_component(registry: dict[str, dict], component_type: str) -> dict[s
         elif fdata.get("show", True) and fdata.get("type") and fname != "code":
             if is_advanced:
                 advanced_fields.append(fname)
+                # configure_component enforces options/range_spec on advanced
+                # fields too, so the Assistant must be able to discover them.
+                if fdata.get("options") or fdata.get("range_spec"):
+                    fields.append({**_field_description(fname, fdata), "advanced": True})
             else:
-                field_info: dict[str, Any] = {
-                    "name": fname,
-                    "type": fdata.get("type", ""),
-                }
-                if fdata.get("required"):
-                    field_info["required"] = True
-                fields.append(field_info)
+                fields.append(_field_description(fname, fdata))
 
     # Template wins on a name collision (mirrors connect.py's priority):
     # never describe the same port twice.

--- a/src/lfx/tests/unit/mcp/test_registry.py
+++ b/src/lfx/tests/unit/mcp/test_registry.py
@@ -2,7 +2,78 @@
 
 from __future__ import annotations
 
+import pytest
 from lfx.mcp.registry import describe_component, load_registry, search_registry
+
+
+class TestDescribeConfigurationMetadata:
+    def test_exposes_options_defaults_and_bounds(self):
+        registry = {
+            "Example": {
+                "template": {
+                    "operator": {"type": "str", "options": ["equals", "contains"], "value": "equals", "required": True},
+                    "temperature": {
+                        "type": "float",
+                        "value": 0.0,
+                        "range_spec": {"min": 0.0, "max": 1.0, "step": 0.01, "step_type": "float", "other": "omit"},
+                    },
+                    "choice": {"type": "str", "options": ["known"], "combobox": True, "list": True, "value": []},
+                    "timeout": {"type": "duration", "options": ["Days"], "value": {"unit": "Days", "value": 3}},
+                }
+            }
+        }
+        fields = {field["name"]: field for field in describe_component(registry, "Example")["fields"]}
+        assert fields["operator"] == {
+            "name": "operator",
+            "type": "str",
+            "required": True,
+            "options": ["equals", "contains"],
+            "default": "equals",
+        }
+        assert fields["temperature"]["default"] == 0.0
+        assert fields["temperature"]["range_spec"] == {"min": 0.0, "max": 1.0, "step": 0.01, "step_type": "float"}
+        assert fields["choice"]["combobox"] is True
+        assert fields["choice"]["list"] is True
+        assert fields["timeout"]["default"] == {"unit": "Days", "value": 3}
+
+    def test_constrained_advanced_fields_are_described(self):
+        registry = {
+            "Example": {
+                "template": {
+                    "temperature": {
+                        "type": "slider",
+                        "advanced": True,
+                        "value": 0.1,
+                        "range_spec": {"min": 0, "max": 1},
+                    },
+                    "sender": {"type": "str", "advanced": True, "options": ["Machine", "User"], "value": "User"},
+                    "verbose": {"type": "bool", "advanced": True, "value": False},
+                }
+            }
+        }
+        described = describe_component(registry, "Example")
+        assert described["advanced_fields"] == ["sender", "temperature", "verbose"]
+        fields = {field["name"]: field for field in described["fields"]}
+        assert set(fields) == {"temperature", "sender"}
+        assert fields["temperature"] == {
+            "name": "temperature",
+            "type": "slider",
+            "default": 0.1,
+            "range_spec": {"min": 0, "max": 1},
+            "advanced": True,
+        }
+        assert fields["sender"]["options"] == ["Machine", "User"]
+
+    @pytest.mark.parametrize(
+        ("name", "metadata"),
+        [("api_key", {}), ("credential", {"password": True}), ("endpoint", {"load_from_db": True})],
+    )
+    def test_omits_secret_defaults(self, name, metadata):
+        registry = {"Example": {"template": {name: {"type": "str", "value": "test-only-placeholder", **metadata}}}}
+        field = describe_component(registry, "Example")["fields"][0]
+        assert field["name"] == name
+        assert "default" not in field
+        assert "value" not in field
 
 
 class _StubClient:

--- a/src/lfx/tests/unit/test_flow_builder.py
+++ b/src/lfx/tests/unit/test_flow_builder.py
@@ -5,6 +5,7 @@ no I/O, no network.
 """
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -121,6 +122,147 @@ def _fresh_flow(name="Test Flow"):
 # ---------------------------------------------------------------------------
 # Flow
 # ---------------------------------------------------------------------------
+
+
+class TestConfigureValidation:
+    @pytest.fixture
+    def configured_flow(self):
+        registry = {
+            "Configurable": _make_template(
+                "Configurable",
+                template_fields={
+                    "_type": "CustomComponent",
+                    "operator": {"type": "str", "options": ["equals", "contains"], "value": "equals"},
+                    "temperature": {"type": "float", "range_spec": {"min": 0.0, "max": 1.0}, "value": 0.1},
+                    # Shipped default below its own range (Agent.max_tokens: 0 = no limit).
+                    "max_tokens": {"type": "int", "range_spec": {"min": 1, "max": 10}, "value": 0},
+                    "model": {"type": "model", "value": [], "options": []},
+                    "input_value": {"type": "str", "value": "EXISTING_GLOBAL", "load_from_db": True},
+                },
+            ),
+        }
+        flow = _fresh_flow()
+        component_id = add_component(flow, "Configurable", registry)["id"]
+        return flow, component_id
+
+    @pytest.mark.parametrize(
+        ("invalid_params", "message"),
+        [
+            ({"operator": "greater_than"}, "Expected one of"),
+            ({"temperature": -0.1}, "temperature"),
+            ({"temperature": 42.0}, "temperature"),
+            ({"temperature": 10**400}, "temperature"),
+            ({"temperature": "0.5"}, "Expected a number"),
+            ({"temperature": True}, "Expected a number"),
+            ({"temperature": float("nan")}, "temperature"),
+            ({"temperature": float("inf")}, "temperature"),
+            ({"max_tokens": 11}, "max_tokens"),
+            ({"not_a_field": "x"}, "Unknown parameter"),
+            ({"_type": "x"}, "reserved template entry"),
+        ],
+    )
+    def test_rejects_invalid_params_atomically(self, configured_flow, invalid_params, message):
+        flow, component_id = configured_flow
+        params = {"input_value": "literal", "model": '{"provider": "OpenAI", "name": "gpt-4o"}', **invalid_params}
+        before = deepcopy(flow)
+        original_model = params["model"]
+
+        with pytest.raises(ValueError, match=message):
+            configure_component(flow, component_id, params)
+
+        assert flow == before
+        assert params["model"] == original_model
+
+    @pytest.mark.parametrize("temperature", [0.0, 0.5, 1.0])
+    def test_accepts_valid_values_and_normalizes_model(self, configured_flow, temperature):
+        flow, component_id = configured_flow
+        params = {
+            "operator": "contains",
+            "temperature": temperature,
+            "input_value": "literal",
+            "model": '{"provider": "OpenAI", "name": "gpt-4o"}',
+        }
+        configure_component(flow, component_id, params)
+
+        fields = flow["data"]["nodes"][0]["data"]["node"]["template"]
+        assert fields["operator"]["value"] == "contains"
+        assert fields["temperature"]["value"] == temperature
+        assert fields["input_value"]["load_from_db"] is False
+        assert fields["model"]["value"] == params["model"] == [{"provider": "OpenAI", "name": "gpt-4o"}]
+
+    def test_accepts_current_value_even_outside_range(self, configured_flow):
+        flow, component_id = configured_flow
+        fields = flow["data"]["nodes"][0]["data"]["node"]["template"]
+        configure_component(flow, component_id, {"max_tokens": 0})
+        assert fields["max_tokens"]["value"] == 0
+        configure_component(flow, component_id, {"max_tokens": 5})
+        with pytest.raises(ValueError, match="max_tokens"):
+            configure_component(flow, component_id, {"max_tokens": 0})
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ({"type": "str", "options": ["known"], "value": "known", "combobox": True}, "custom"),
+            ({"type": "str", "options": ["a", "b"], "value": ["a"], "list": True}, ["a", "b"]),
+            ({"type": "str", "options": [], "value": ""}, "custom"),
+            ({"type": "str", "options": ["a"], "value": "a"}, None),
+            (
+                {"type": "duration", "options": ["Minutes", "Hours", "Days"], "value": {"unit": "Days", "value": 3}},
+                {"unit": "Hours", "value": 2},
+            ),
+            # Gate is by type: a structured value is accepted even after a scalar was written.
+            (
+                {"type": "duration", "options": ["Minutes", "Hours", "Days"], "value": "Hours"},
+                {"unit": "Hours", "value": 2},
+            ),
+            (
+                {"type": "sortableList", "options": [{"name": "Local"}, {"name": "AWS"}], "value": [{"name": "Local"}]},
+                [{"name": "AWS"}],
+            ),
+            ({"type": "tab", "options": ["JSON", "Table"], "value": "JSON"}, "Data"),
+            ({"type": "tab", "options": ["JSON", "Table"], "value": "JSON"}, "DataFrame"),
+            ({"type": "tab", "options": ["JSON", "Table"], "value": "JSON"}, ""),
+        ],
+    )
+    def test_preserves_option_compatibility(self, configured_flow, field, value):
+        flow, component_id = configured_flow
+        fields = flow["data"]["nodes"][0]["data"]["node"]["template"]
+        fields["choice"] = field
+        configure_component(flow, component_id, {"choice": value})
+        assert fields["choice"]["value"] == value
+
+    def test_rejects_invalid_list_selection(self, configured_flow):
+        flow, component_id = configured_flow
+        fields = flow["data"]["nodes"][0]["data"]["node"]["template"]
+        fields["choice"] = {"type": "str", "options": ["a", "b"], "value": ["a"], "list": True}
+        before = deepcopy(flow)
+        with pytest.raises(ValueError, match="Expected one of"):
+            configure_component(flow, component_id, {"choice": ["a", "invalid"]})
+        assert flow == before
+
+    @pytest.mark.parametrize("combobox", [False, True])
+    def test_rejects_scalar_for_list_options(self, configured_flow, combobox):
+        flow, component_id = configured_flow
+        fields = flow["data"]["nodes"][0]["data"]["node"]["template"]
+        fields["choice"] = {
+            "type": "str",
+            "options": ["a", "b"],
+            "value": ["a"],
+            "list": True,
+            "combobox": combobox,
+        }
+        before = deepcopy(flow)
+        with pytest.raises(ValueError, match="Expected a list"):
+            configure_component(flow, component_id, {"choice": "a"})
+        assert flow == before
+
+    @pytest.mark.parametrize("node_data", [{}, {"node": {}}])
+    def test_unknown_field_does_not_create_template(self, node_data):
+        flow = {"data": {"nodes": [{"id": "test", "data": node_data}]}}
+        before = deepcopy(flow)
+        with pytest.raises(ValueError, match="Unknown parameter"):
+            configure_component(flow, "test", {"unknown": "value"})
+        assert flow == before
 
 
 class TestFlow:


### PR DESCRIPTION
The Assistant's `configure_component` accepted values that no dropdown or slider would let a user pick. `operator: "greater_than"` went straight into a closed dropdown whose real option is `"greater than"`, `temperature: 42.0` landed on a slider bounded 0 to 1, and even `temperature: "hot"` was stored. It also wrote parameters one at a time, so a call that failed on a later key had already changed earlier ones, including flipping a credential field's `load_from_db` flag off.

Every parameter is now validated before anything is written: unknown or reserved keys, closed options, list-versus-scalar shape, numeric type, and `range_spec` bounds. A rejected call raises a clear `ValueError` naming the accepted values and leaves the flow and the caller's params exactly as they were. Free-text comboboxes, list selections, structured option entries, the duration field's structured value, tab aliases from saved flows, and model-value normalization all keep working.

For the Assistant to pick valid values it has to be able to see them, so `describe_component` now exposes `options`, `default`, and `range_spec` per field, including advanced fields that carry constraints. Defaults are withheld for sensitive names, password fields, and fields bound to a global variable, since echoing a variable name back as a literal would sever the binding. The prompt tells the Assistant to use exact options, respect bounds, keep defaults, and retry after a rejection.

One deliberate rule: a value equal to what the field already holds is always accepted, even outside its range. Several shipped defaults sit below their own minimum (`max_tokens` is 0, meaning no limit, with a minimum of 1), and discovery advertises those defaults, so the validator must not reject them on a fresh node.

Not covered here: the other paths that write template values directly (live `propose_field_edit`, accepted-proposal apply, the legacy flow_component tool, and the MCP server's own configure loop) remain unvalidated and are a separate change.

Fixes #15000. Supersedes #15001, whose validation logic and tests this builds on, with the structured-value gate made type-based, constrained advanced fields made discoverable, and the default-below-minimum contradiction resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved component configuration guidance using declared options, field types, defaults, and numeric limits.
  * Added richer configuration metadata, including advanced fields and validation constraints.
* **Bug Fixes**
  * Invalid component parameters are now rejected without partially applying changes.
  * Added safer handling for sensitive defaults, unsupported values, and numeric limits.
* **Tests**
  * Expanded coverage for configuration metadata, validation, atomic updates, and flow integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->