### PR TITLE
feat(jobs): opt-in retention for terminal background jobs

### DIFF
--- a/src/backend/base/langflow/services/background_execution/service.py
+++ b/src/backend/base/langflow/services/background_execution/service.py
@@ -21,6 +21,7 @@ import contextlib
 import json
 import math
 import os
+import random
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -61,6 +62,13 @@ if TYPE_CHECKING:
 # Durable statuses that mean the run is over. ``events()`` keys off these (not the
 # process-local live bus) so a reattach to a finished job replays and returns
 # instead of tailing a bus that will never produce another frame.
+# Retention sweep cadence. Purging is never urgent, so it runs hourly in
+# chunks: 5k jobs a batch, up to 50 batches a tick, which clears 250k terminal
+# jobs an hour without any single DELETE holding a long lock.
+_RETENTION_INTERVAL_S = 3600.0
+_RETENTION_BATCH_SIZE = 5000
+_RETENTION_MAX_BATCHES_PER_TICK = 50
+
 _TERMINAL_STATUSES = frozenset({JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.TIMED_OUT})
 _REQUEST_OVERRIDES_FORMAT_KEY = "request_overrides_format"
 _REQUEST_OVERRIDES_KEY = "request_overrides"
@@ -139,6 +147,7 @@ class BackgroundExecutionService(Service):
         self._bus = InMemoryLiveBus()
         self._frame_source_factory = frame_source_factory
         self._deadline_task: asyncio.Task | None = None
+        self._retention_task: asyncio.Task | None = None
         self.set_ready()
 
     @property
@@ -165,15 +174,19 @@ class BackgroundExecutionService(Service):
         # it is a pure-DB sweep, and the worker fleet does not run it.
         if self._scaled:
             self._start_deadline_watchdog()
+            self._start_retention_sweep()
             return
         await self._executor.start()
         self._start_deadline_watchdog()
+        self._start_retention_sweep()
 
     async def stop(self) -> None:
-        if self._deadline_task is not None:
-            self._deadline_task.cancel()
-            task, self._deadline_task = self._deadline_task, None
-            await asyncio.gather(task, return_exceptions=True)
+        for attr in ("_deadline_task", "_retention_task"):
+            task = getattr(self, attr)
+            if task is not None:
+                task.cancel()
+                setattr(self, attr, None)
+                await asyncio.gather(task, return_exceptions=True)
         # Mirror start(): scaled mode never started the executor.
         if not self._scaled:
             await self._executor.stop()
@@ -196,6 +209,43 @@ class BackgroundExecutionService(Service):
                     await self.sweep_input_deadlines()
 
         self._deadline_task = asyncio.create_task(_loop())
+
+    def _start_retention_sweep(self) -> None:
+        """Purge terminal jobs past the retention window, hourly, until caught up.
+
+        Periodic rather than startup-only on purpose: a fleet that never
+        restarts would otherwise never purge, which is the same "requires a
+        restart to reconcile" failure the lease watchdog exists to avoid. Each
+        tick deletes in chunks and keeps going while a chunk comes back full,
+        so an install that enables retention against a large backlog catches up
+        over a few ticks instead of issuing one enormous DELETE.
+
+        Skipped entirely when ``background_retention_days`` is 0 (the default),
+        so deployments that have not opted in spawn no extra task.
+        """
+        retention_days = self._settings.background_retention_days
+        if not retention_days or self._retention_task is not None:
+            return
+
+        async def _loop() -> None:
+            job_service = get_job_service()
+            while True:
+                # Jitter so replicas running this loop do not all purge at once.
+                await asyncio.sleep(_RETENTION_INTERVAL_S * random.uniform(0.75, 1.25))  # noqa: S311
+                for _ in range(_RETENTION_MAX_BATCHES_PER_TICK):
+                    try:
+                        deleted = await job_service.purge_terminal_jobs(
+                            older_than_days=retention_days, limit=_RETENTION_BATCH_SIZE
+                        )
+                    except Exception:  # noqa: BLE001
+                        # Log and stop this tick: a purge that cannot run must be
+                        # visible, not silently skipped until the table is huge.
+                        await logger.aexception("Background job retention sweep failed")
+                        break
+                    if deleted < _RETENTION_BATCH_SIZE:
+                        break
+
+        self._retention_task = asyncio.create_task(_loop())
 
     async def teardown(self) -> None:
         await self.stop()

--- a/src/backend/base/langflow/services/database/models/jobs/model.py
+++ b/src/backend/base/langflow/services/database/models/jobs/model.py
@@ -94,8 +94,9 @@ class Job(JobBase, table=True):  # type: ignore[call-arg]
     __tablename__ = "job"
     # The scaled backend's claim poll (claim_next_queued_lease) filters on
     # status + type and sorts by created_timestamp on every worker poll; the
-    # watchdog scans status + type on its interval. The job table has no
-    # retention, so without this composite the hottest query degrades into an
+    # watchdog scans status + type on its interval. Retention is opt-in
+    # (background_retention_days, off by default), so without this composite an
+    # install that never sets a window degrades the hottest query into an
     # ever-growing scan+sort over terminal rows.
     __table_args__ = (Index("ix_job_claim_scan", "status", "type", "created_timestamp"),)
 

--- a/src/backend/base/langflow/services/jobs/service.py
+++ b/src/backend/base/langflow/services/jobs/service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 from lfx.graph.exceptions import GraphPausedException
@@ -36,6 +36,12 @@ from langflow.services.jobs.exceptions import HUMAN_INPUT_REQUIRED_EVENT, Duplic
 # Bounded retries for append_event's optimistic seq assignment — contention is at most a
 # couple of concurrent appenders per job (worker + orphan sweep, or scaled-out processes).
 _APPEND_EVENT_MAX_RETRIES = 50
+
+# Statuses that mean the run is over and the row is retention-eligible. Every
+# other status (QUEUED, IN_PROGRESS, SUSPENDED) is live work: a SUSPENDED run
+# is waiting on a human who may answer weeks later, so age never makes it
+# eligible.
+_RETAINABLE_STATUSES = (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.TIMED_OUT)
 
 
 def _unwrap_pause_payload(payload: dict | None) -> dict | None:
@@ -821,6 +827,44 @@ class JobService(Service):
 
         msg = f"fail_queued_job exhausted {_APPEND_EVENT_MAX_RETRIES} retries for job {job_id} (event seq contention)"
         raise RuntimeError(msg) from last_exc
+
+    async def purge_terminal_jobs(self, *, older_than_days: float, limit: int = 5000) -> int:
+        """Delete terminal jobs older than the window plus their child rows. Returns rows deleted.
+
+        Retention for the durable queue: the job table IS the work queue in the
+        scaled backend, so terminal rows accumulate under every claim scan and
+        ``job_events`` grows a row per durable milestone forever. Only terminal
+        runs are eligible (see ``_RETAINABLE_STATUSES``); live work is never
+        purged at any age.
+
+        The child tables (``job_events``, ``execution_signals``,
+        ``job_checkpoints``) carry ``job_id`` as a plain indexed column with NO
+        foreign key, so nothing cascades: they are deleted explicitly here, or
+        they survive as orphans no query can reach again.
+
+        Age comes from the terminal timestamp, falling back to creation for a
+        row that reached a terminal status without one. Deletes are chunked by
+        ``limit`` so a pass never takes a long lock or bloats one transaction;
+        a caller with a backlog loops until a pass returns fewer than ``limit``.
+        Concurrent callers are safe: the delete is keyed by id, so a racer
+        simply finds fewer rows.
+        """
+        from sqlmodel import delete
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=older_than_days)
+        aged_at = func.coalesce(col(Job.finished_timestamp), col(Job.created_timestamp))
+        async with session_scope() as session:
+            result = await session.exec(
+                select(Job.job_id).where(col(Job.status).in_(_RETAINABLE_STATUSES), aged_at < cutoff).limit(limit)
+            )
+            job_ids = list(result.all())
+            if not job_ids:
+                return 0
+            for child in (JobEvent, ExecutionSignal, JobCheckpoint):
+                await session.exec(delete(child).where(col(child.job_id).in_(job_ids)))  # type: ignore[call-overload]
+            await session.exec(delete(Job).where(col(Job.job_id).in_(job_ids)))  # type: ignore[call-overload]
+            await session.flush()
+            return len(job_ids)
 
     async def requeue_resumed_job(self, job_id: UUID, *, owner: str) -> bool:
         """Hand this owner's resumed IN_PROGRESS claim back to the queue. True iff we won.

--- a/src/backend/tests/unit/services/background_execution/test_service.py
+++ b/src/backend/tests/unit/services/background_execution/test_service.py
@@ -190,3 +190,35 @@ async def test_stop_cancels_job(active_user):
         assert st["status"] == JobStatus.CANCELLED
     finally:
         await svc.stop()
+
+
+async def test_retention_sweep_is_opt_in(monkeypatch):
+    """No retention window configured means no sweep task at all.
+
+    Retention deletes run history, so it stays off until an operator sets a
+    window: a default deployment must spawn no purge loop.
+    """
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "background_retention_days", 0)
+
+    svc = BackgroundExecutionService(settings_service, frame_source_factory=lambda **_kw: _scripted_source)
+    await svc.start()
+    try:
+        assert svc._retention_task is None
+    finally:
+        await svc.stop()
+
+
+async def test_retention_sweep_starts_when_a_window_is_set(monkeypatch):
+    """A configured window starts the periodic purge, and stop() tears it down."""
+    settings_service = get_settings_service()
+    monkeypatch.setattr(settings_service.settings, "background_retention_days", 30)
+
+    svc = BackgroundExecutionService(settings_service, frame_source_factory=lambda **_kw: _scripted_source)
+    await svc.start()
+    try:
+        assert svc._retention_task is not None
+        assert not svc._retention_task.done()
+    finally:
+        await svc.stop()
+    assert svc._retention_task is None

--- a/src/backend/tests/unit/services/jobs/test_jobs_retention.py
+++ b/src/backend/tests/unit/services/jobs/test_jobs_retention.py
@@ -1,0 +1,115 @@
+"""Retention: age-based purge of terminal background jobs and their child rows.
+
+The durable job table is the scaled backend's work queue, so it grows forever
+without a purge: terminal rows accumulate under the claim scan and job_events
+adds a row per durable milestone. The child tables carry job_id as a plain
+indexed column with NO foreign key, so nothing cascades and a purge that
+forgets them leaves orphans no query will ever reach again.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from langflow.services.database.models.jobs.model import JobStatus, JobType, SignalType
+from langflow.services.jobs.service import JobService
+
+pytestmark = pytest.mark.usefixtures("client")
+
+_LIVE_STATUSES = [JobStatus.QUEUED, JobStatus.IN_PROGRESS, JobStatus.SUSPENDED]
+
+
+async def _aged_job(service: JobService, *, status: JobStatus, age_days: float, with_children: bool = False):
+    """Create a job whose finished/created timestamps sit ``age_days`` in the past."""
+    from langflow.services.database.models.jobs.model import Job
+    from langflow.services.deps import session_scope
+    from sqlmodel import update
+
+    job_id = uuid4()
+    await service.create_job(job_id=job_id, flow_id=uuid4(), job_type=JobType.WORKFLOW, user_id=uuid4())
+    if with_children:
+        await service.append_event(job_id, "run_end", {"ok": True})
+        await service.write_signal(job_id, SignalType.STOP)
+        await service.save_checkpoint(job_id, "graph", "{}")
+    stamp = datetime.now(timezone.utc) - timedelta(days=age_days)
+    async with session_scope() as session:
+        await session.exec(
+            update(Job)
+            .where(Job.job_id == job_id)
+            .values(
+                status=status,
+                created_timestamp=stamp,
+                finished_timestamp=stamp if status not in _LIVE_STATUSES else None,
+            )
+        )
+    return job_id
+
+
+async def _child_counts(service: JobService, job_id) -> tuple[int, int, int]:
+    events = await service.read_events(job_id)
+    signals = await service.unconsumed_signals(job_id)
+    checkpoint = await service.load_checkpoint(job_id, "graph")
+    return len(events), len(signals), 0 if checkpoint is None else 1
+
+
+async def test_purge_removes_old_terminal_jobs_and_all_their_child_rows():
+    """A purged job leaves nothing behind: no events, signals, or checkpoints."""
+    service = JobService()
+    job_id = await _aged_job(service, status=JobStatus.COMPLETED, age_days=40, with_children=True)
+    assert await _child_counts(service, job_id) == (1, 1, 1)
+
+    deleted = await service.purge_terminal_jobs(older_than_days=30, limit=100)
+
+    assert deleted >= 1
+    assert await service.get_job_by_job_id(job_id) is None
+    assert await _child_counts(service, job_id) == (0, 0, 0)
+
+
+@pytest.mark.parametrize("status", _LIVE_STATUSES)
+async def test_purge_never_touches_live_jobs_however_old(status):
+    """QUEUED, IN_PROGRESS and SUSPENDED rows are untouchable at any age.
+
+    A SUSPENDED run is waiting on a human who may answer next month; purging it
+    would silently destroy pending work.
+    """
+    service = JobService()
+    job_id = await _aged_job(service, status=status, age_days=400)
+
+    await service.purge_terminal_jobs(older_than_days=1, limit=100)
+
+    job = await service.get_job_by_job_id(job_id)
+    assert job is not None
+    assert job.status == status
+
+
+async def test_purge_keeps_terminal_jobs_inside_the_window():
+    service = JobService()
+    fresh = await _aged_job(service, status=JobStatus.FAILED, age_days=2)
+    old = await _aged_job(service, status=JobStatus.FAILED, age_days=90)
+
+    await service.purge_terminal_jobs(older_than_days=30, limit=100)
+
+    assert await service.get_job_by_job_id(fresh) is not None
+    assert await service.get_job_by_job_id(old) is None
+
+
+async def test_purge_respects_its_batch_limit():
+    """Chunked deletes keep the transaction small; the caller loops to catch up."""
+    service = JobService()
+    job_ids = [await _aged_job(service, status=JobStatus.CANCELLED, age_days=60) for _ in range(3)]
+
+    first = await service.purge_terminal_jobs(older_than_days=30, limit=2)
+    assert first == 2
+
+    second = await service.purge_terminal_jobs(older_than_days=30, limit=2)
+    assert second >= 1
+    assert [jid for jid in job_ids if await service.get_job_by_job_id(jid) is not None] == []
+
+
+async def test_purge_is_a_noop_when_nothing_is_old_enough():
+    service = JobService()
+    await _aged_job(service, status=JobStatus.COMPLETED, age_days=1)
+
+    assert await service.purge_terminal_jobs(older_than_days=30, limit=100) == 0

--- a/src/lfx/src/lfx/services/settings/groups/runtime.py
+++ b/src/lfx/src/lfx/services/settings/groups/runtime.py
@@ -136,6 +136,18 @@ class RuntimeSettings(BaseModel):
     lease-racing them in order. Size it roughly to the worker fleet: with more
     workers than candidates the extras lose every race and back off a full idle
     window. Must be > 0."""
+    background_retention_days: int = Field(default=0, ge=0)
+    """How many days to keep TERMINAL background job rows (and their events,
+    signals and checkpoints) before deleting them. ``0``, the default, disables
+    retention entirely and keeps every row forever.
+
+    Enable this on any long-lived deployment, and especially with
+    ``background_backend=scaled``, where the job table IS the work queue: every
+    terminal row sits under the claim scan and ``job_events`` grows a row per
+    durable milestone, so an install with no window set grows without bound.
+    Live runs are never deleted at any age: QUEUED, IN_PROGRESS and SUSPENDED
+    rows are excluded (a suspended run is waiting on a human who may answer
+    weeks later)."""
     background_backend: Literal["default", "scaled"] = "default"
     """Which background-execution backend runs v2 background workflow jobs.
 

--- a/src/lfx/tests/unit/services/settings/test_settings_composition.py
+++ b/src/lfx/tests/unit/services/settings/test_settings_composition.py
@@ -251,6 +251,7 @@ EXPECTED_FIELDS = {
     "background_backend",
     "background_poll_interval_s",
     "background_claim_candidates",
+    "background_retention_days",
     # ---- Added in 1.10.1 ----
     # SecuritySettings
     "allow_public_custom_components",


### PR DESCRIPTION
Stacked on #13508. Closes the retention gap that review flagged as the blocker before anyone enables the scaled background backend in production.

## Retention is off by default

`LANGFLOW_BACKGROUND_RETENTION_DAYS` defaults to `0`, which means no purging at all and every row kept forever, exactly as today. Retention deletes user-visible run history, so an operator opts in rather than discovering it after the fact.

To enable it, set a window:

```
LANGFLOW_BACKGROUND_RETENTION_DAYS=30
```

That keeps 30 days of terminal runs and deletes older ones on an hourly sweep. Anyone running `LANGFLOW_BACKGROUND_BACKEND=scaled` on a long-lived deployment should set this, because there the job table IS the work queue: every terminal row sits under the claim scan, and `job_events` grows a row per durable milestone, so an install with no window set grows without bound.

## What gets deleted, and what never does

Eligible: `COMPLETED`, `FAILED`, `CANCELLED`, `TIMED_OUT` runs whose terminal timestamp (falling back to creation) is older than the window.

Never eligible at any age: `QUEUED`, `IN_PROGRESS`, and `SUSPENDED`. A suspended run is parked waiting on a human who may answer weeks later, so purging it would destroy pending work. There is a test per live status pinning this.

The child tables (`job_events`, `execution_signals`, `job_checkpoints`) carry `job_id` as a plain indexed column with no foreign key, so nothing cascades. They are deleted explicitly alongside the job, or they would survive as orphans no query can reach again.

## How it runs

Periodic, not startup-only: a fleet that never restarts would otherwise never purge, which is the same "needs a restart to reconcile" failure the lease watchdog exists to avoid. Each tick purges in chunks of 5000 and keeps going while a chunk comes back full, so enabling retention against a large backlog catches up over a few ticks instead of issuing one enormous `DELETE`. Ticks are jittered so replicas do not all purge at once, and a failed pass logs loudly rather than being silently skipped.

## Tests

258 passing across the jobs, background-execution and facade suites, including the purge semantics (child rows removed, live statuses untouched at any age, window boundary, batch limit) and the sweep's opt-in behavior.
