### PR TITLE
fix(api): stop 422 responses from echoing submitted values

### DIFF
--- a/src/backend/base/langflow/api/validation_errors.py
+++ b/src/backend/base/langflow/api/validation_errors.py
@@ -1,0 +1,131 @@
+"""Request-validation (422) responses that name the failing field without echoing its value.
+
+FastAPI's default handler returns ``jsonable_encoder(exc.errors())``. Every
+pydantic error in that list carries ``input`` -- the raw value that failed, or
+for a missing field the whole enclosing object -- and some carry a ``ctx`` or a
+``msg`` that quotes it. A 422 therefore reflected whatever the caller sent,
+credential material included, into proxy logs, browser devtools and error
+trackers (LE-2462, O1). The caller learns nothing it did not send; the fix is
+about where the body ends up.
+
+The handler keeps the response shape, ``{"detail": [{"type", "loc", "msg"}]}``,
+so a client still sees which field failed and why, and removes the values:
+
+* ``input`` is dropped from every entry.
+* ``ctx`` keeps only keys pydantic fills from the schema (``min_length``,
+  ``pattern``, ``expected``...). Keys filled from the submitted value
+  (``error``, ``tag``, ``tz_actual``...) and unknown keys are dropped, and a
+  custom (non-pydantic) error type keeps no ``ctx`` at all.
+* ``msg`` is rewritten only when it can quote the input: the error carried an
+  input-derived ctx key, or it is not a built-in pydantic type (a validator's
+  own message). Submitted strings of at least ``MIN_REDACTED_LENGTH``
+  characters are replaced with ``REDACTED`` there.
+
+Response-model validation is untouched: FastAPI raises ``ResponseValidationError``
+for that, a different exception this handler is not registered for.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, get_args
+
+from fastapi import Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from pydantic_core.core_schema import ErrorType
+
+if TYPE_CHECKING:
+    from fastapi.exceptions import RequestValidationError
+
+REDACTED = "[redacted]"
+# Shorter submitted strings stay in a message: redacting "a" or "id" would shred
+# the validator's own wording, and a value that short is not a credential.
+MIN_REDACTED_LENGTH = 8
+
+# ctx keys pydantic fills from the field's schema, never from the submitted value.
+_SCHEMA_CTX_KEYS = frozenset(
+    {
+        "class",
+        "class_name",
+        "decimal_places",
+        "discriminator",
+        "encoding",
+        "expected",
+        "expected_schemes",
+        "expected_tags",
+        "expected_version",
+        "field_type",
+        "ge",
+        "gt",
+        "le",
+        "lt",
+        "max_digits",
+        "max_length",
+        "method_name",
+        "min_length",
+        "multiple_of",
+        "pattern",
+        "tz_expected",
+        "whole_digits",
+    }
+)
+_BUILTIN_ERROR_TYPES = frozenset(get_args(ErrorType))
+
+
+def _submitted_strings(value: object) -> set[str]:
+    """Every string and number in a submitted value. Mapping keys are field names, not values."""
+    found: set[str] = set()
+    # Iterative, so a deeply nested body cannot exhaust the recursion limit here.
+    pending = [value]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, str):
+            found.add(item)
+        elif isinstance(item, Mapping):
+            pending.extend(item.values())
+        elif isinstance(item, list | tuple | set | frozenset):
+            pending.extend(item)
+        elif isinstance(item, int | float) and not isinstance(item, bool):
+            found.add(str(item))
+    return found
+
+
+def _scrub_msg(msg: str, submitted: object) -> str:
+    fragments = [fragment for fragment in _submitted_strings(submitted) if len(fragment) >= MIN_REDACTED_LENGTH]
+    # Longest first, so a value containing a shorter one is replaced whole.
+    for fragment in sorted(fragments, key=len, reverse=True):
+        msg = msg.replace(fragment, REDACTED)
+    return msg
+
+
+def _redact_error(error: Mapping[str, Any]) -> dict[str, Any]:
+    raw_ctx = error.get("ctx")
+    ctx: Mapping[str, Any] = raw_ctx if isinstance(raw_ctx, Mapping) else {}
+    # A built-in message is rendered from its ctx, so it quotes input only through
+    # an input-derived key. A custom error's message and ctx are the author's own:
+    # nothing says which of its keys hold input, so none are kept.
+    builtin = error.get("type") in _BUILTIN_ERROR_TYPES
+    msg = str(error.get("msg", ""))
+    if not builtin or any(key not in _SCHEMA_CTX_KEYS for key in ctx):
+        msg = _scrub_msg(msg, error.get("input"))
+    kept_ctx = {key: value for key, value in ctx.items() if key in _SCHEMA_CTX_KEYS} if builtin else {}
+    return {
+        "type": error.get("type"),
+        "loc": error.get("loc", ()),
+        "msg": msg,
+        **({"ctx": kept_ctx} if kept_ctx else {}),
+    }
+
+
+def redact_validation_errors(errors: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return copies of pydantic error entries without the values the caller submitted."""
+    return [_redact_error(error) for error in errors]
+
+
+async def request_validation_exception_handler(_request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Drop-in for FastAPI's default handler: same status and shape, no submitted values."""
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        content={"detail": jsonable_encoder(redact_validation_errors(exc.errors()))},
+    )

--- a/src/backend/base/langflow/api/validation_errors.py
+++ b/src/backend/base/langflow/api/validation_errors.py
@@ -21,6 +21,12 @@ so a client still sees which field failed and why, and removes the values:
   own message). Submitted strings of at least ``MIN_REDACTED_LENGTH``
   characters are replaced with ``REDACTED`` there.
 
+The ``msg`` scrub is a backstop, not a licence. It matches submitted strings
+verbatim, so a validator that quotes a transformed value (lower-cased,
+stripped, sliced) is not caught, and neither is a value shorter than
+``MIN_REDACTED_LENGTH``. Validators must not put submitted values in their
+messages.
+
 Response-model validation is untouched: FastAPI raises ``ResponseValidationError``
 for that, a different exception this handler is not registered for.
 """

--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -16,6 +16,7 @@ import anyio
 import httpx
 import sqlalchemy
 from fastapi import FastAPI, HTTPException, Request, Response, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi_pagination import add_pagination
@@ -37,6 +38,7 @@ from langflow.api import log_router
 from langflow.api.health_check_router import health_check_router
 from langflow.api.router import router
 from langflow.api.v1.mcp_projects import init_mcp_servers
+from langflow.api.validation_errors import request_validation_exception_handler
 from langflow.api.warm_graph import is_warm_registry_enabled
 from langflow.cli.preflight import PreflightAbortError, ensure_production_preflight
 from langflow.initial_setup.setup import (
@@ -1036,6 +1038,10 @@ def create_app():
 
     # Discover and register additional routers from plugins (langflow.plugins entry-point)
     load_plugin_routes(app)
+
+    # Replaces FastAPI's default 422 handler, which echoes each submitted value
+    # (credentials included) back in the error body.
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
 
     @app.exception_handler(DeploymentGuardError)
     async def deployment_guard_exception_handler(_request: Request, exc: DeploymentGuardError):

--- a/src/backend/tests/unit/api/test_request_validation_redaction.py
+++ b/src/backend/tests/unit/api/test_request_validation_redaction.py
@@ -10,7 +10,7 @@ but 422 bodies land in proxy logs, browser devtools and error trackers.
 from typing import Annotated, Literal
 
 import pytest
-from fastapi import FastAPI, status
+from fastapi import FastAPI, Header, Query, status
 from fastapi.exceptions import RequestValidationError
 from httpx import ASGITransport, AsyncClient
 from langflow.api.validation_errors import redact_validation_errors, request_validation_exception_handler
@@ -66,6 +66,13 @@ async def connection_client():
     async def create_connection(connection: _ConnectionCreate) -> dict:
         return {"provider_key": connection.provider_key}
 
+    @app.get("/api/v1/connections")
+    async def list_connections(
+        limit: Annotated[int, Query()] = 50,
+        x_api_key: Annotated[str | None, Header(max_length=64)] = None,
+    ) -> list:
+        return [limit, x_api_key]
+
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client:
         yield client
 
@@ -115,6 +122,33 @@ async def test_connection_422_does_not_echo_credential_material(connection_clien
     response = await connection_client.post("/api/v1/connections", json=body)
 
     _assert_redacted(response, canary, loc=loc, error_type=error_type)
+
+
+@pytest.mark.parametrize(
+    ("params", "headers", "loc", "error_type"),
+    [
+        pytest.param({"limit": CANARY}, {}, ["query", "limit"], "int_parsing", id="query-param"),
+        pytest.param({}, {"x-api-key": CANARY * 4}, ["header", "x-api-key"], "string_too_long", id="header"),
+    ],
+)
+async def test_parameter_422_does_not_echo_the_value(connection_client, params, headers, loc, error_type):
+    response = await connection_client.get("/api/v1/connections", params=params, headers=headers)
+
+    _assert_redacted(response, CANARY, loc=loc, error_type=error_type)
+
+
+async def test_malformed_json_body_is_still_a_422(connection_client):
+    # FastAPI builds this entry itself: an int position in loc and a str in ctx["error"].
+    truncated = f'{{"credentials": {{"access_token": "{CANARY}"'.encode()
+
+    response = await connection_client.post(
+        "/api/v1/connections", content=truncated, headers={"Content-Type": "application/json"}
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert CANARY not in response.text
+    [error] = response.json()["detail"]
+    assert error == {"type": "json_invalid", "loc": ["body", len(truncated)], "msg": "JSON decode error"}
 
 
 async def test_connection_422_keeps_schema_constraints_in_ctx(connection_client):
@@ -196,6 +230,13 @@ def test_validator_message_that_quotes_the_value_is_scrubbed():
         "loc": ("token",),
         "msg": "Value error, token [redacted] is not recognised",
     }
+
+
+def test_short_submitted_values_stay_in_the_message():
+    # Redacting a two-letter value would shred the validator's own wording; see MIN_REDACTED_LENGTH.
+    [error] = redact_validation_errors(_errors_for(_TokenInterpolatingModel, {"token": "id"}))
+
+    assert error["msg"] == "Value error, token id is not recognised"
 
 
 def test_input_derived_ctx_is_dropped_and_schema_ctx_kept():

--- a/src/backend/tests/unit/api/test_request_validation_redaction.py
+++ b/src/backend/tests/unit/api/test_request_validation_redaction.py
@@ -1,0 +1,272 @@
+"""A 422 names the field that failed; it never echoes the value submitted for it.
+
+FastAPI's default handler returns every pydantic error with ``input`` -- the raw
+value that failed -- and a ``ctx`` that can quote it. QA (LE-2462, O1) showed a
+422 reflecting token material from POST /api/v1/connections and Credential
+values from POST /api/v1/variables/. The caller gains nothing it did not send,
+but 422 bodies land in proxy logs, browser devtools and error trackers.
+"""
+
+from typing import Annotated, Literal
+
+import pytest
+from fastapi import FastAPI, status
+from fastapi.exceptions import RequestValidationError
+from httpx import ASGITransport, AsyncClient
+from langflow.api.validation_errors import redact_validation_errors, request_validation_exception_handler
+from langflow.services.variable.constants import CREDENTIAL_TYPE
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, StrictStr, ValidationError, field_validator
+
+CANARY = "lf-canary-9d1f4e7a2c8b"  # pragma: allowlist secret
+NUMERIC_CANARY = 5550123987
+
+
+def _assert_redacted(response, canary: object, *, loc: list, error_type: str) -> None:
+    """The body keeps loc/msg/type for every error and quotes the canary nowhere."""
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, response.text
+    assert str(canary) not in response.text
+    detail = response.json()["detail"]
+    assert detail, "a 422 must still say what failed"
+    for error in detail:
+        assert {"loc", "msg", "type"} <= error.keys()
+        assert "input" not in error
+    assert any(error["loc"] == loc and error["type"] == error_type for error in detail), detail
+
+
+# Mirrors ConnectionCreate / ConnectionCredentialWrite from the INT-4 connection
+# API (#14921, fix/int-4-connection-api), which is not on this branch yet. Same
+# config (extra="forbid") and the same credential field types, so the three QA
+# shapes produce the errors they produce on the real route.
+class _ConnectionCredentialWrite(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    access_token: SecretStr = Field(min_length=1)
+    refresh_token: SecretStr | None = None
+    token_type: StrictStr = Field(default="Bearer", min_length=1, max_length=32)
+
+
+class _ConnectionCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider_key: StrictStr = Field(max_length=120)
+    name: StrictStr = Field(max_length=64)
+    display_name: StrictStr = Field(min_length=1, max_length=255)
+    credentials: _ConnectionCredentialWrite | None = None
+
+
+_VALID_CONNECTION = {"provider_key": "google", "name": "work-gmail", "display_name": "Work Gmail"}
+
+
+@pytest.fixture
+async def connection_client():
+    app = FastAPI()
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+
+    @app.post("/api/v1/connections")
+    async def create_connection(connection: _ConnectionCreate) -> dict:
+        return {"provider_key": connection.provider_key}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.parametrize(
+    ("body", "canary", "loc", "error_type"),
+    [
+        pytest.param(
+            {**_VALID_CONNECTION, "credentials": {"access_token": NUMERIC_CANARY}},
+            NUMERIC_CANARY,
+            ["body", "credentials", "access_token"],
+            "string_type",
+            id="wrong-type-access-token-number",
+        ),
+        pytest.param(
+            {**_VALID_CONNECTION, "credentials": {"access_token": {"token": CANARY}}},
+            CANARY,
+            ["body", "credentials", "access_token"],
+            "string_type",
+            id="wrong-type-access-token-object",
+        ),
+        pytest.param(
+            {**_VALID_CONNECTION, "credentials": {"access_token": "valid-token-value", "client_secret": CANARY}},
+            CANARY,
+            ["body", "credentials", "client_secret"],
+            "extra_forbidden",
+            id="unknown-key-inside-credentials",
+        ),
+        pytest.param(
+            {**_VALID_CONNECTION, "api_key": CANARY},
+            CANARY,
+            ["body", "api_key"],
+            "extra_forbidden",
+            id="unknown-top-level-key",
+        ),
+        pytest.param(
+            # A *valid* token is echoed too: a missing field's input is the whole body.
+            {"credentials": {"access_token": CANARY}},
+            CANARY,
+            ["body", "provider_key"],
+            "missing",
+            id="valid-token-beside-missing-field",
+        ),
+    ],
+)
+async def test_connection_422_does_not_echo_credential_material(connection_client, body, canary, loc, error_type):
+    response = await connection_client.post("/api/v1/connections", json=body)
+
+    _assert_redacted(response, canary, loc=loc, error_type=error_type)
+
+
+async def test_connection_422_keeps_schema_constraints_in_ctx(connection_client):
+    response = await connection_client.post("/api/v1/connections", json={**_VALID_CONNECTION, "display_name": ""})
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "string_too_short",
+                "loc": ["body", "display_name"],
+                "msg": "String should have at least 1 character",
+                "ctx": {"min_length": 1},
+            }
+        ]
+    }
+
+
+@pytest.mark.usefixtures("active_user")
+@pytest.mark.parametrize(
+    ("body", "loc", "error_type"),
+    [
+        pytest.param(
+            {"value": CANARY, "type": CREDENTIAL_TYPE, "default_fields": []},
+            ["body", "name"],
+            "missing",
+            id="credential-value-beside-missing-name",
+        ),
+        pytest.param(
+            {"name": "OPENAI_API_KEY", "value": {"secret": CANARY}, "type": CREDENTIAL_TYPE, "default_fields": []},
+            ["body", "value"],
+            "string_type",
+            id="credential-in-wrong-typed-value",
+        ),
+    ],
+)
+async def test_variables_422_does_not_echo_credential_value(
+    client: AsyncClient, logged_in_headers, body, loc, error_type
+):
+    """Goes through create_app(), so it also proves the handler is registered on the real app."""
+    response = await client.post("api/v1/variables/", json=body, headers=logged_in_headers)
+
+    _assert_redacted(response, CANARY, loc=loc, error_type=error_type)
+
+
+def _errors_for(model: type[BaseModel], data: dict) -> list[dict]:
+    with pytest.raises(ValidationError) as exc_info:
+        model.model_validate(data)
+    return exc_info.value.errors()
+
+
+class _TokenInterpolatingModel(BaseModel):
+    token: str
+
+    @field_validator("token")
+    @classmethod
+    def _reject(cls, value: str) -> str:
+        msg = f"token {value} is not recognised"
+        raise ValueError(msg)
+
+
+class _Cat(BaseModel):
+    kind: Literal["cat"]
+
+
+class _Dog(BaseModel):
+    kind: Literal["dog"]
+
+
+class _Pet(BaseModel):
+    pet: Annotated[_Cat | _Dog, Field(discriminator="kind")]
+
+
+def test_validator_message_that_quotes_the_value_is_scrubbed():
+    [error] = redact_validation_errors(_errors_for(_TokenInterpolatingModel, {"token": CANARY}))
+
+    assert error == {
+        "type": "value_error",
+        "loc": ("token",),
+        "msg": "Value error, token [redacted] is not recognised",
+    }
+
+
+def test_input_derived_ctx_is_dropped_and_schema_ctx_kept():
+    [error] = redact_validation_errors(_errors_for(_Pet, {"pet": {"kind": CANARY}}))
+
+    assert error["type"] == "union_tag_invalid"
+    assert error["ctx"] == {"discriminator": "'kind'", "expected_tags": "'cat', 'dog'"}
+    assert CANARY not in str(error)
+
+
+def test_fixed_template_message_is_left_alone():
+    # A missing field's input is the whole body, and "required" is both one of its
+    # values and a substring of pydantic's wording. A fixed-template message cannot
+    # quote input, so it comes back exactly as pydantic wrote it.
+    errors = _errors_for(_ConnectionCreate, {"provider_key": "required", "display_name": "Work Gmail"})
+
+    [error] = redact_validation_errors(errors)
+
+    assert error == {"type": "missing", "loc": ("name",), "msg": "Field required"}
+
+
+def test_unknown_ctx_key_on_builtin_error_is_dropped():
+    errors = [
+        {
+            "type": "string_too_long",
+            "loc": ("body", "token"),
+            "msg": f"String should have at most 8 characters, got {CANARY}",
+            "input": CANARY,
+            "ctx": {"max_length": 8, "submitted": CANARY},
+        }
+    ]
+
+    [error] = redact_validation_errors(errors)
+
+    assert error == {
+        "type": "string_too_long",
+        "loc": ("body", "token"),
+        "msg": "String should have at most 8 characters, got [redacted]",
+        "ctx": {"max_length": 8},
+    }
+
+
+def test_custom_error_type_keeps_no_ctx():
+    # Nothing says which keys of a custom error's ctx were filled from input.
+    errors = [
+        {
+            "type": "custom_token_error",
+            "loc": ("body", "token"),
+            "msg": f"custom check rejected {CANARY}",
+            "input": CANARY,
+            "ctx": {"expected": CANARY, "max_length": 8},
+        }
+    ]
+
+    [error] = redact_validation_errors(errors)
+
+    assert error == {"type": "custom_token_error", "loc": ("body", "token"), "msg": "custom check rejected [redacted]"}
+
+
+def test_malformed_entry_is_redacted_not_crashed():
+    # A plugin can raise RequestValidationError by hand; a crash here would turn
+    # the 422 into a 500 whose body is str(exc).
+    [error] = redact_validation_errors([{"msg": f"bad {CANARY}", "input": [CANARY], "ctx": ["not", "a", "mapping"]}])
+
+    assert error == {"type": None, "loc": (), "msg": "bad [redacted]"}
+
+
+def test_redaction_does_not_mutate_the_original_errors():
+    errors = _errors_for(_TokenInterpolatingModel, {"token": CANARY})
+    snapshot = [dict(error) for error in errors]
+
+    redact_validation_errors(errors)
+
+    assert errors == snapshot


### PR DESCRIPTION
## Summary

LE-2462, observation O1: a 422 from request validation echoed the submitted values back to the caller. Langflow registered no `RequestValidationError` handler, so FastAPI's default was in use. The default returns `jsonable_encoder(exc.errors())`, and every pydantic error in that list carries `input`. For a `missing` field, `input` is the **whole enclosing object**, so a perfectly valid `access_token` came back whenever a sibling field was missing. The caller gains nothing it didn't send, but 422 bodies end up in proxy logs, browser devtools and error trackers.

This PR adds `langflow/api/validation_errors.py` and registers its handler in `create_app()`. Status and shape are unchanged (`422`, `{"detail": [{"type", "loc", "msg"}]}`), so clients still see which field failed and why:

- **`input`** is dropped from every entry.
- **`ctx`** keeps only keys pydantic fills from the schema (`min_length`, `max_length`, `pattern`, `expected`, `discriminator`, …). Keys filled from the submitted value (`error`, `tag`, `tz_actual`, `encoding_error`, `actual_length`, …) and unknown keys are dropped. A custom (non-pydantic) error type keeps no `ctx`.
- **`msg`** is left exactly as pydantic wrote it for fixed-template errors (`Field required`, `Extra inputs are not permitted`, `Input should be a valid string`). It is rewritten only when it *can* quote input: a validator's own message such as `f"token {value} is not recognised"`, a discriminator tag, or a custom error. In those, submitted strings of 8 or more characters become `[redacted]`.

`ResponseValidationError` (response-model validation) is a different exception and is not touched.

**Known limits of the `msg` scrub** (documented in the module). It matches submitted strings verbatim, so a validator that quotes a *transformed* value (`value.lower()`, a slice) is not caught, and values under 8 characters are kept so validator wording isn't shredded. Validators must not interpolate submitted values; none in the repo interpolate credentials today. Dropping `input` doesn't depend on any of this: it's unconditional.

### Before / after (POST /api/v1/connections on #14921)

```text
# before: an unknown key inside credentials
{"type":"extra_forbidden","loc":["body","credentials","client_secret"],"msg":"Extra inputs are not permitted","input":"lf-canary-9d1f4e7a2c8b"}
# before: a valid token next to a missing field
{"type":"missing","loc":["body","name"],"msg":"Field required","input":{"provider_key":"google_workspace", ..., "credentials":{"access_token":"lf-canary-9d1f4e7a2c8b", ...}}}

# after
{"type":"extra_forbidden","loc":["body","credentials","client_secret"],"msg":"Extra inputs are not permitted"}
{"type":"missing","loc":["body","name"],"msg":"Field required"}
```

### The connections route

`/api/v1/connections` is not on `release-1.13.0` yet; it lives on #14921 (`fix/int-4-connection-api`). So this PR's tests cover:

- **`POST /api/v1/variables/` through `create_app()`**, which also proves the handler is registered on the real app: a Credential value next to a missing `name`, and a credential inside a wrong-typed `value`.
- **The three QA shapes plus the missing-field shape**, against a model that copies `ConnectionCreate` / `ConnectionCredentialWrite` from #14921 (same `extra="forbid"`, same `SecretStr` / `StrictStr` field types).

Verified on the real route as well. I applied this change to `fix/int-4-connection-api` @ `fbcce913ba` in a scratch worktree and ran a route-level test with 5 shapes, including QA's literal `{"credentials": {"access_token": 123}}`:

- **With the handler:** all 5 pass, and #14921's own `test_connections.py` passes with it (13 passed).
- **Without it:** all 5 fail with the token in `input`.

I'll add that route-level test to #14921 once this lands.

### Not covered here (follow-ups)

- **`ResponseValidationError` → 500 body.** A response-model mismatch falls through to the catch-all `Exception` handler in `main.py`, which returns `{"message": str(exc)}`. That string includes each error's server-side `input`. Tracked separately.
- **`WebSocketRequestValidationError`.** The voice-mode websocket routes still use FastAPI's default, which puts `jsonable_encoder(exc.errors())` into the close frame.
- **`lfx serve`.** It builds its own FastAPI app and still uses the default 422 handler.

## Test plan

- [x] `uv run pytest src/backend/tests/unit/api/test_request_validation_redaction.py`: 19 passed. This includes query/header parameter echoes and FastAPI's own `json_invalid` entry.
- [x] Mutation check: with the registration removed, or FastAPI's default handler swapped in, all 11 HTTP-level tests fail. 9 fail with the canary in the body; the other 2 fail on the exact response shape.
- [x] Worst-case `msg` scrub (a body-level validator error over a 6.8 MB body with 200k unique strings): 61 ms
- [x] Every unit test file that asserts on a 422 (36 files, `-m 'not api_key_required'`): 1490 passed, 1 skipped. None asserted on `input` or `ctx`.
- [x] `test_user.py::test_patch_user_wrong_id` (asserts 422 `loc`/`type`, `api_key_required`): passes. Its sibling `test_delete_user_wrong_id` errors in the `test_user` fixture with or without this change; that failure is pre-existing and CI deselects `api_key_required`.
- [x] `test_admin_cli.py::test_api_validation_errors_do_not_reflect_secret_inputs` still passes
- [x] Real-route check on #14921 (above)
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation error responses no longer echo submitted credentials, tokens, or other sensitive input values.
  * Request validation errors continue to use the standard 422 response structure while redacting sensitive content across query parameters, headers, and request bodies.
  * Response-model validation behavior remains unchanged.

* **Tests**
  * Added coverage for sensitive-value redaction across malformed requests and nested validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->