### PR TITLE
fix(api): stop 500 responses from echoing response-validation input

### DIFF
--- a/src/backend/base/langflow/main.py
+++ b/src/backend/base/langflow/main.py
@@ -1095,6 +1095,33 @@ def create_app():
             },
         )
 
+    from fastapi.exceptions import ResponseValidationError
+
+    @app.exception_handler(ResponseValidationError)
+    async def response_validation_exception_handler(_request: Request, exc: ResponseValidationError):
+        """A route returned what its response_model rejects: log it in full, answer generically.
+
+        str(exc) lists each pydantic error with its ``input`` -- the server-side value
+        that failed to serialize, or for a missing field the whole object -- then the
+        endpoint's file, line and function. The catch-all below sent all of it to the
+        client and to telemetry.
+        """
+        # exc_info renders the full errors to the console and log file; the message is the
+        # field OTel log export can carry, so it names the failure without the values.
+        await logger.aerror("Response validation failed", exc_info=exc)
+        # Telemetry leaves the server. Send a copy that keeps the type, the traceback and
+        # the route template, and reduces each error to its type and location. A location
+        # is field names, list indexes and dict keys, never the value.
+        located = ResponseValidationError(
+            [{"type": error.get("type"), "loc": error.get("loc")} for error in exc.errors()],
+            endpoint_ctx={"path": exc.endpoint_path} if exc.endpoint_path else None,
+        )
+        await log_exception_to_telemetry(located.with_traceback(exc.__traceback__), "handler")
+        return JSONResponse(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content={"message": "Internal server error: the response failed validation"},
+        )
+
     @app.exception_handler(Exception)
     async def exception_handler(_request: Request, exc: Exception):
         if isinstance(exc, HTTPException):

--- a/src/backend/tests/unit/api/test_response_validation_redaction.py
+++ b/src/backend/tests/unit/api/test_response_validation_redaction.py
@@ -1,0 +1,166 @@
+"""A 500 from a response-model mismatch never echoes the value that failed to serialize.
+
+When a route returns something its ``response_model`` rejects, FastAPI raises
+``ResponseValidationError``. It had no handler of its own, so it reached the
+catch-all in ``create_app()``, which answers ``{"message": str(exc)}``. That
+string lists every pydantic error with its ``input`` -- the server-side value
+that failed, or for a missing field the whole object -- followed by the
+endpoint's file, line and function. A mismatch on a route that handles secrets
+put them in the 500 body, and from there into proxy logs, browser devtools and
+error trackers. This is the server-side counterpart of LE-2462 O1.
+
+The probe routes are added to the real app through ``create_app()``'s
+plugin-route hook, so each request crosses the production middleware and
+exception handlers.
+"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, status
+from fastapi.exceptions import ResponseValidationError
+from httpx import ASGITransport, AsyncClient
+from langflow import main as langflow_main
+from langflow.services.database.models.variable.model import VariableRead
+from langflow.services.deps import get_telemetry_service
+from langflow.services.telemetry.schema import ExceptionPayload
+from langflow.services.variable.constants import CREDENTIAL_TYPE
+from pydantic import BaseModel
+
+CANARY = "lf-canary-5b7e2d9c41fa"  # pragma: allowlist secret
+GENERIC_BODY = {"message": "Internal server error: the response failed validation"}
+
+VARIABLE_PROBE = "/__probe__/variable-missing-id"
+COUNT_PROBE = "/__probe__/count-not-int"
+RUNTIME_ERROR_PROBE = "/__probe__/runtime-error"
+
+
+class CountRead(BaseModel):
+    count: int
+
+
+async def variable_missing_id() -> dict[str, Any]:
+    # VariableRead nulls a Credential's value once validation succeeds. A failure
+    # hands pydantic the raw object instead, credential included, as the input of
+    # the missing-field error.
+    return {"name": "OPENAI_API_KEY", "type": CREDENTIAL_TYPE, "value": CANARY}
+
+
+async def count_not_int() -> dict[str, Any]:
+    return {"count": CANARY}
+
+
+async def runtime_error() -> None:
+    msg = "probe failure"
+    raise RuntimeError(msg)
+
+
+@pytest.fixture(autouse=True)
+def probe_app(monkeypatch) -> dict[str, FastAPI]:
+    """Register the probes while create_app() builds the app, and keep a handle on that app.
+
+    Autouse, so the hook is patched before the ``client`` fixture calls create_app().
+    """
+    captured: dict[str, FastAPI] = {}
+    load_plugin_routes = langflow_main.load_plugin_routes
+
+    def load_plugin_routes_and_probes(app: FastAPI) -> None:
+        load_plugin_routes(app)
+        app.add_api_route(VARIABLE_PROBE, variable_missing_id, response_model=VariableRead)
+        app.add_api_route(COUNT_PROBE, count_not_int, response_model=CountRead)
+        app.add_api_route(RUNTIME_ERROR_PROBE, runtime_error)
+        captured["app"] = app
+
+    monkeypatch.setattr(langflow_main, "load_plugin_routes", load_plugin_routes_and_probes)
+    return captured
+
+
+@pytest.fixture
+async def app_client(probe_app: dict[str, FastAPI], client: AsyncClient) -> AsyncIterator[AsyncClient]:  # noqa: ARG001
+    """A client on the ``client`` fixture's app that returns a 500 instead of raising it.
+
+    The ``client`` transport re-raises any exception that escapes the app, and the
+    catch-all re-raises after answering, so only this client shows the body a caller
+    receives from that path.
+    """
+    transport = ASGITransport(app=probe_app["app"], raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as raw_client:
+        yield raw_client
+
+
+@pytest.mark.parametrize("path", [VARIABLE_PROBE, COUNT_PROBE], ids=["missing-field", "wrong-type"])
+async def test_response_validation_500_does_not_echo_the_failing_value(app_client: AsyncClient, path: str):
+    response = await app_client.get(path)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert CANARY not in response.text
+    # No pydantic errors, no input, and no endpoint file, line or function.
+    assert response.json() == GENERIC_BODY
+
+
+async def test_response_validation_is_handled_rather_than_escaping_the_app(app_client: AsyncClient, client):  # noqa: ARG001
+    # The ``client`` transport raises whatever escapes the app. A handled error
+    # comes back as a response, through the middleware stack like any other.
+    response = await client.get(VARIABLE_PROBE)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json() == GENERIC_BODY
+
+
+async def test_response_validation_logs_the_full_errors_server_side(app_client: AsyncClient, monkeypatch):
+    real_logger = langflow_main.logger
+    logged: list[tuple[str, dict[str, Any]]] = []
+
+    class RecordingLogger:
+        async def aerror(self, event: str, *args: Any, **kwargs: Any) -> None:
+            logged.append((event, kwargs))
+            await real_logger.aerror(event, *args, **kwargs)
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(real_logger, name)
+
+    monkeypatch.setattr(langflow_main, "logger", RecordingLogger())
+
+    await app_client.get(VARIABLE_PROBE)
+
+    assert len(logged) == 1
+    event, kwargs = logged[0]
+    # The full error rides on exc_info, which the console and log file render and OTel
+    # log export never carries. The message can be exported, so it holds no values.
+    assert isinstance(kwargs["exc_info"], ResponseValidationError)
+    assert CANARY in str(kwargs["exc_info"])
+    assert CANARY not in event
+
+
+async def test_response_validation_telemetry_names_locations_not_values(app_client: AsyncClient, monkeypatch):
+    # Telemetry leaves the server (DO_NOT_TRACK only stops the send), so the event
+    # carries the error types, their locations and the route, not str(exc).
+    queued: list[Any] = []
+
+    async def record(event: Any) -> None:
+        queued.append(event)
+
+    monkeypatch.setattr(get_telemetry_service(), "_queue_event", record)
+
+    await app_client.get(VARIABLE_PROBE)
+
+    payloads = [event[1] for event in queued if isinstance(event[1], ExceptionPayload)]
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload.exception_type == "ResponseValidationError"
+    assert payload.exception_context == "handler"
+    assert CANARY not in payload.exception_message
+    assert "'missing'" in payload.exception_message
+    assert "('response', 'id')" in payload.exception_message
+    assert f"GET {VARIABLE_PROBE}" in payload.exception_message
+    # The endpoint's source file is a server path; the probe is defined in this file.
+    assert __file__ not in payload.exception_message
+
+
+async def test_other_unhandled_errors_keep_their_500_shape(app_client: AsyncClient):
+    # Scope check: only ResponseValidationError has a handler of its own.
+    response = await app_client.get(RUNTIME_ERROR_PROBE)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json() == {"message": "probe failure"}


### PR DESCRIPTION
## Summary

When a route returns something its `response_model` rejects, FastAPI raises `ResponseValidationError`. Langflow registered no handler for it, so it reached the catch-all in `create_app()`, which answers `{"message": str(exc)}`. That string lists every pydantic error with its `input`, meaning the server-side value that failed to serialize (for a missing field, the whole object). It then adds the endpoint's absolute file path, line and function.

Reproduced against the real `create_app()` with a probe route using the real `VariableRead` model and a `Credential` value. `VariableRead` nulls credential values when validation succeeds, but a failure handed the raw object to pydantic, and the 500 body carried it:

```
{"message":"1 validation error:\n  {'type': 'missing', 'loc': ('response', 'id'), 'msg': 'Field required', 'input': {'name': 'OPENAI_API_KEY', 'type': 'Credential', 'value': 'lf-canary-5b7e2d9c41fa'}}\n\n  File \"/…/test_response_validation_redaction.py\", line 43, in variable_missing_id\n    GET /__probe__/variable-missing-id"}
```

The catch-all also passed the same exception to `log_exception_to_telemetry`, which sends `str(exc)[:500]` as `exceptionMessage` to the telemetry endpoint (`https://langflow.gateway.scarf.sh` unless `DO_NOT_TRACK` is set).

This is the server-side counterpart of LE-2462 O1. #15038 fixes the request side (422).

**Base:** `release-1.12.2`, because v1.12.x ships this: the catch-all, the telemetry call and FastAPI 0.139.2 are the same there. `main.py` is byte-identical on `release-1.13.0`, so the release back-merge carries the fix forward unchanged.

## Change

`create_app()` now registers a dedicated `ResponseValidationError` handler. Because it has its own handler, Starlette dispatches it from `ExceptionMiddleware`, and it no longer reaches the catch-all. The handler:

- logs the full error server-side: `logger.aerror("Response validation failed", exc_info=exc)`. The console and log file render `exc_info` in full. The message deliberately carries no values: it is the field lfx's OTel log export can send when the operator sets the body policy to `all`, and `exc_info` is never exported (only `error.type` is derived from it). This follows `scripts/lint/check_logged_exception_text.py`;
- still sends the telemetry event, as a copy reduced to each error's `type` and `loc` plus the route template (e.g. `GET /api/v1/variables/{variable_id}`). It keeps the original traceback so the stack-trace hash still groups;
- returns `500 {"message": "Internal server error: the response failed validation"}`: no pydantic errors, no `input`, no endpoint repr.

Every other exception type keeps the catch-all's existing 500 shape.

The `ResponseValidationError` import is local to `create_app()`, next to the handler, as the `TweakRefusedError` and `RateLimitExceeded` handlers already do. This also keeps it clear of the top-level `fastapi.exceptions` import that #15038 adds.

## Not changed (reported separately)

The catch-all still returns `{"message": str(exc)}` and sends `str(exc)[:500]` to telemetry for every other unhandled exception. At least two common types carry server-side values in `str()`:

- `pydantic.ValidationError` raised from route code (`Model.model_validate(...)`) includes `input_value=...`;
- SQLAlchemy `StatementError`/`IntegrityError` include `[parameters: (...)]`.

The catch-all also logs `f"unhandled error: {exc}"`, which puts the same text in the log message. With the OTel log body policy set to `all`, that message is exported.

Whether to make the catch-all generic is a broader decision, so it is left out of this PR.

## Test plan

- [x] `src/backend/tests/unit/api/test_response_validation_redaction.py`: probe routes are registered on the real app through `create_app()`'s plugin-route hook and served through the `client` fixture. Against `release-1.12.2`'s unfixed `main.py`, 5 of these 6 tests fail; with the fix all 6 pass.
  - [x] a missing-field error on `VariableRead` and a wrong-type error on an `int` field both return the generic 500 with no canary (before the fix, the canary was in both bodies);
  - [x] the error is handled, not re-raised out of the app (before the fix, the `client` transport raised `ResponseValidationError`);
  - [x] the server log gets the full error as `exc_info`, and the log message holds no values (before the fix, the catch-all's `unhandled error: {exc}` message carried the canary);
  - [x] the telemetry payload holds the types, locations and route, with no canary and no endpoint file (before the fix, the canary was in it);
  - [x] other unhandled errors keep `{"message": str(exc)}`.
- [x] Checked `src/backend/tests` for assertions on 500 `message` contents that depend on `str(ResponseValidationError)`: none.
- [x] Mutation checks. Each of these fails the named test: telemetry sent the raw `exc` (telemetry test); telemetry copy without the route (telemetry test); `{exc}` rendered into the log message (logging test).
- [x] On this base: `test_exception_telemetry` (unit and integration), `test_lifespan_startup_cleanup`, `api/v1/test_variable`, `test_endpoints`, plus the new file: 136 passed, 1 skipped.
- [x] `src/backend/tests/unit/api/` in full, on the `release-1.13.0` base (same `main.py`): 2656 passed, 20 skipped, 1 failed (`test_workflow_facade.py::TestIdempotentSubmit::test_no_idempotency_key_creates_distinct_jobs`). That test failed only under the full 6-worker run, passes alone and 3/3 on file re-runs, and never reaches this handler.
- [ ] CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Response validation failures now return a generic 500 error without exposing sensitive validation details or input values.
  * Validation errors are safely summarized for telemetry while full diagnostic details remain available in server logs.
  * Other unhandled errors retain their existing 500 response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->