### PR TITLE
fix(lfx): import Graph/Vertex at runtime so Flow as Tool can build

### DIFF
--- a/src/backend/tests/unit/components/flow_controls/test_flow_tool.py
+++ b/src/backend/tests/unit/components/flow_controls/test_flow_tool.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
+from lfx.base.tools.flow_tool import FlowTool
 from lfx.components.flow_controls.flow_tool import FlowToolComponent
+from lfx.components.input_output import ChatInput, ChatOutput
+from lfx.graph import Graph
 from lfx.schema.data import Data
 
 from tests.base import ComponentTestBaseWithClient
@@ -29,6 +33,14 @@ class TestFlowToolComponent(ComponentTestBaseWithClient):
     def file_names_mapping(self):
         """Return an empty list since this component doesn't have version-specific files."""
         return []
+
+    @pytest.fixture
+    def flow_graph(self):
+        """A small real graph (Chat Input -> Chat Output) standing in for the loaded flow."""
+        chat_input = ChatInput(_id="chat_input")
+        chat_output = ChatOutput(_id="chat_output")
+        chat_output.set(input_value=chat_input.message_response)
+        return Graph(chat_input, chat_output)
 
     async def test_component_initialization(self, component_class, default_kwargs):
         """Test proper initialization of FlowToolComponent."""
@@ -165,11 +177,9 @@ class TestFlowToolComponent(ComponentTestBaseWithClient):
     async def test_build_tool_no_flow_name(self, component_class, default_kwargs):
         """Test build_tool raises error when flow_name is not provided."""
         component = await self.component_setup(component_class, default_kwargs)
-        from lfx.base.tools.flow_tool import FlowTool
 
         with (
             patch.object(component, "_attributes", {}),
-            patch.object(FlowTool, "model_rebuild"),  # Mock to avoid Graph annotation error
             pytest.raises(ValueError, match="Flow name is required"),
         ):
             await component.build_tool()
@@ -178,11 +188,9 @@ class TestFlowToolComponent(ComponentTestBaseWithClient):
     async def test_build_tool_empty_flow_name(self, component_class, default_kwargs):
         """Test build_tool raises error when flow_name is empty."""
         component = await self.component_setup(component_class, default_kwargs)
-        from lfx.base.tools.flow_tool import FlowTool
 
         with (
             patch.object(component, "_attributes", {"flow_name": ""}),
-            patch.object(FlowTool, "model_rebuild"),  # Mock to avoid Graph annotation error
             pytest.raises(ValueError, match="Flow name is required"),
         ):
             await component.build_tool()
@@ -191,15 +199,68 @@ class TestFlowToolComponent(ComponentTestBaseWithClient):
     async def test_build_tool_flow_not_found(self, component_class, default_kwargs):
         """Test build_tool raises error when flow is not found."""
         component = await self.component_setup(component_class, default_kwargs)
-        from lfx.base.tools.flow_tool import FlowTool
 
         with (
             patch.object(component, "_attributes", {"flow_name": "Nonexistent Flow"}),
             patch.object(component, "get_flow", return_value=None),
-            patch.object(FlowTool, "model_rebuild"),  # Mock to avoid Graph annotation error
             pytest.raises(ValueError, match="Flow not found"),
         ):
             await component.build_tool()
+
+    @pytest.mark.asyncio
+    async def test_build_tool_returns_flow_tool(self, component_class, default_kwargs, flow_graph):
+        """build_tool returns a FlowTool wired to the loaded flow's graph and inputs.
+
+        Regression: FlowTool's ``graph``/``inputs`` annotations name ``Graph``/``Vertex``, which were
+        TYPE_CHECKING-only imports, so ``build_tool`` always raised ``PydanticUndefinedAnnotation``.
+        """
+        component = await self.component_setup(component_class, default_kwargs)
+        run_id = str(uuid4())
+        user_id = str(uuid4())
+        component.graph.run_id = run_id
+        component.graph.user_id = user_id
+        flow_id = uuid4()
+        flow_data = Data(data={"id": flow_id, "name": "test_flow", "description": "Flow description"})
+
+        with (
+            patch.object(component, "get_flow", return_value=flow_data) as get_flow,
+            patch.object(component, "load_flow", return_value=flow_graph) as load_flow,
+        ):
+            tool = await component.build_tool()
+
+        get_flow.assert_awaited_once_with("test_flow")
+        load_flow.assert_awaited_once_with(str(flow_id))
+        assert isinstance(tool, FlowTool)
+        assert tool.name == "test_tool"
+        assert tool.description == "Test tool description"
+        assert tool.return_direct is False
+        assert tool.graph is flow_graph
+        assert [vertex.id for vertex in tool.inputs] == ["chat_input"]
+        assert tool.flow_id == str(flow_id)
+        assert tool.user_id == user_id
+        assert tool.session_id == component.graph.session_id
+        assert flow_graph.run_id == run_id
+        assert set(tool.args) == {"chat_input"}
+        assert tool.args["chat_input"]["type"] == "string"
+        assert tool.args["chat_input"]["description"] == "Get chat inputs from the Playground."
+        assert component.status == (
+            "Test tool description\nArguments:\n- chat_input: Get chat inputs from the Playground."
+        )
+
+    @pytest.mark.asyncio
+    async def test_build_tool_falls_back_to_flow_description(self, component_class, default_kwargs, flow_graph):
+        """A blank tool_description falls back to the selected flow's description."""
+        component = await self.component_setup(component_class, {**default_kwargs, "tool_description": "  "})
+        flow_data = Data(data={"id": uuid4(), "name": "test_flow", "description": "Flow description"})
+
+        with (
+            patch.object(component, "get_flow", return_value=flow_data),
+            patch.object(component, "load_flow", return_value=flow_graph),
+        ):
+            tool = await component.build_tool()
+
+        assert isinstance(tool, FlowTool)
+        assert tool.description == "Flow description"
 
     async def test_component_inheritance(self, component_class, default_kwargs):
         """Test that component properly inherits from LCToolComponent."""

--- a/src/lfx/src/lfx/base/tools/flow_tool.py
+++ b/src/lfx/src/lfx/base/tools/flow_tool.py
@@ -6,6 +6,12 @@ from langchain_core.tools import BaseTool, ToolException
 from typing_extensions import override
 
 from lfx.base.flow_processing.utils import build_data_from_result_data, format_flow_output_data
+
+# FlowTool is a pydantic model, so its `graph`/`inputs` field annotations are resolved at runtime.
+# Under TYPE_CHECKING the class is left incomplete and FlowTool.model_rebuild() raises
+# PydanticUndefinedAnnotation. lfx.graph is already loaded by the import above, so no cycle.
+from lfx.graph.graph.base import Graph  # noqa: TC001
+from lfx.graph.vertex.base import Vertex  # noqa: TC001
 from lfx.helpers import build_schema_from_inputs, get_arg_names, get_flow_inputs, run_flow
 from lfx.log.logger import logger
 from lfx.utils.async_helpers import run_until_complete
@@ -13,9 +19,6 @@ from lfx.utils.async_helpers import run_until_complete
 if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
     from pydantic.v1 import BaseModel
-
-    from lfx.graph.graph.base import Graph
-    from lfx.graph.vertex.base import Vertex
 
 
 class FlowTool(BaseTool):


### PR DESCRIPTION
## Summary

The legacy **Flow as Tool** component (`FlowToolComponent`) can't build a tool: `build_tool()` starts with `FlowTool.model_rebuild()`, which always raises

```
pydantic.errors.PydanticUndefinedAnnotation: name 'Graph' is not defined
```

This PR makes `FlowTool` fully defined at import time, so the component builds and runs again, including in flows that were already saved.

## Root cause

`FlowTool` is a pydantic model (through langchain's `BaseTool`) with the fields `graph: Graph | None` and `inputs: list[Vertex]`. `src/lfx/src/lfx/base/tools/flow_tool.py` uses `from __future__ import annotations` and imported `Graph`/`Vertex` only under `if TYPE_CHECKING:`. That left the class incomplete (`FlowTool.__pydantic_complete__ is False`). `model_rebuild()` resolves names from the module globals plus the caller's frame, and neither has `Graph` at runtime.

This is a regression. #4054 fixed the same bug in Oct 2024 by importing both at runtime with `# noqa: TC001`. When the file was ported to lfx in #9133, the imports moved back under `TYPE_CHECKING` and the `noqa` was dropped. The component has been broken since then.

The existing tests hid it: each `build_tool` test patched `FlowTool.model_rebuild` out ("Mock to avoid Graph annotation error"), and only error paths were covered.

## Fix

- `lfx/base/tools/flow_tool.py`: import `Graph` and `Vertex` at runtime again, with `# noqa: TC001` and a comment. Pre-commit runs `ruff check --fix`, which would otherwise move them back under `TYPE_CHECKING`.
  - **No circular import.** The line just before, `from lfx.base.flow_processing.utils import ...`, already imports `lfx.graph.schema`, and that runs `lfx/graph/__init__.py`, which imports `Graph` and `Vertex`. So the new imports add no import edge. `lfx.graph` has no module-level import of `lfx.components` or `lfx.base.tools`.
  - **`RunnableConfig` and `pydantic.v1.BaseModel` stay under `TYPE_CHECKING`.** They only annotate `get_input_schema()`. Pydantic doesn't evaluate method annotations, and langchain's `get_type_hints()` at invoke time only reads `_run`/`_arun`, which use `Any`/`str`. Ruff's `TC004` check agrees: with `BaseTool` registered as runtime-evaluated, it flags only `Graph` and `Vertex`. That probe covered `lfx`, `langflow-base` and every bundle, and `FlowTool` was the only tool affected.

### Why fix the model and not `build_tool()`

The alternative was to call `FlowTool.model_rebuild(_types_namespace={...})` inside `build_tool()`. That only fixes nodes whose code gets updated. Saved flows embed the component's source, and `instantiate_class()` runs the node's stored code as-is in the default permissive mode. Every existing Flow as Tool node therefore still runs a `build_tool()` that calls bare `FlowTool.model_rebuild()`.

With the model now complete when the class is created, that embedded call is a no-op (`returns None`), so existing flows work with no component update. For the same reason the component file is unchanged: no `component_index.json` churn, and no "update available" badge for a no-op edit.

## Tests

`src/backend/tests/unit/components/flow_controls/test_flow_tool.py`:
- Removed the three `patch.object(FlowTool, "model_rebuild")` workarounds.
- Added `test_build_tool_returns_flow_tool`. It runs `build_tool()` without patching `model_rebuild`, using a real Chat Input → Chat Output `Graph` returned by mocked `get_flow` / `load_flow`. It checks the returned `FlowTool`'s name, description, `return_direct`, graph, input vertices, `flow_id`, `user_id`, `session_id`, the propagated `run_id`, `args`, and the component status text.
- Added `test_build_tool_falls_back_to_flow_description`: a blank `tool_description` falls back to the flow's description.

Mutation checks, run against the committed test file:
- **Original model module:** all five `build_tool` tests fail with `pydantic.errors.PydanticUndefinedAnnotation: name 'Graph' is not defined`.
- **Original model module and the component's `model_rebuild()` line deleted:** both happy-path tests fail with ``pydantic.errors.PydanticUserError: `FlowTool` is not fully defined``. So the tests still catch the regression if someone later removes that now-no-op call.

## Test plan

- [x] `uv run pytest src/backend/tests/unit/components/flow_controls/test_flow_tool.py`: 20 passed, 4 skipped. The 4 are the base class's version-mapping tests, which were already skipped.
- [x] Mutation checks (both above): the tests fail on the original `flow_tool.py` and pass with the fix.
- [x] Full lfx unit suite in an lfx-only venv (`src/lfx/tests/unit`): 8307 passed, 51 skipped, 5 xfailed, 2 xpassed.
- [x] Neighbouring backend suites (`components/flow_controls/`, `base/tools/`, `helpers/test_nested_provider_policy_scope.py`, `agentic/services/test_run_flow_tool.py`): 390 passed, 34 skipped, 1 xfailed.
- [x] Import-order matrix in fresh interpreters, with langflow installed (12 entry points, including `lfx.graph`, `lfx.helpers`, `lfx.custom`, `lfx.interface.components` and `langflow.main`) and in an lfx-only venv (11 entry points). Every order imports cleanly, `FlowTool.__pydantic_complete__` is `True`, bare `FlowTool.model_rebuild()` returns `None`, and the `lfx.helpers` `try/except ImportError` dispatch doesn't fall back to the lfx implementation.
- [x] End to end in both environments: `build_tool()` → `convert_to_openai_tool(tool)` → `await tool.ainvoke({"chat_input": ...})`. In the lfx-only env the real `run_flow` executed the graph and returned the flow output.
- [ ] CI green (backend unit groups + lfx unit suite)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow-based tool handling so valid flows are recognized and correctly connected.
  * Improved fallback behavior when a flow description is unavailable.
  * Resolved an issue that could prevent flow tool configuration from being interpreted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->