### PR TITLE
docs(openai-compatible): add Nebius Serverless Endpoint example

### DIFF
--- a/src/bundles/openai-compatible/README.md
+++ b/src/bundles/openai-compatible/README.md
@@ -129,7 +129,10 @@ Saved provider settings can take precedence over the environment. If a change
 does not take effect, check the executing user's settings, restart the backend
 when changing its environment, and refresh models. Keep tokens out of exported
 flows, source control, screenshots, and logs. The example contains no Endpoint
-URL or token and disables chat-history storage on its input/output nodes.
+URL or token. Its input/output nodes keep Langflow's default chat-history
+storage enabled so Playground receives message events. Prompts and responses
+are saved in Langflow; delete test sessions after validation. Disabling Chat
+Output's **Store Messages** can prevent replies from appearing in Playground.
 
 ### Capabilities and troubleshooting
 

--- a/src/bundles/openai-compatible/README.md
+++ b/src/bundles/openai-compatible/README.md
@@ -52,6 +52,117 @@ The bundle is registered automatically via the `langflow.extensions`
 entry-point. Restart your Langflow server and select **OpenAI Compatible** in
 any Language Model or Embedding Model field.
 
+## Nebius Serverless Endpoint
+
+Use this provider to connect Langflow to a model you deploy on a
+[Nebius Serverless Endpoint](https://docs.nebius.com/serverless/overview).
+This example uses a vLLM container serving `Qwen/Qwen3-0.6B`. Langflow runs
+separately and sends inference requests to the Endpoint's managed HTTPS URL.
+It does not create, start, stop, or delete cloud resources.
+
+This configuration is for user-deployed Serverless Endpoints. Nebius Token
+Factory / AI Studio managed model APIs use different credentials and URLs.
+Serverless Jobs are finite workloads without a public inference URL, so they
+cannot be used as this provider's Base URL.
+
+### Prepare the Endpoint
+
+1. Follow the [vLLM Nebius Serverless guide](https://docs.vllm.ai/en/latest/deployment/frameworks/nebius/)
+   to deploy the model. It includes image/model versions, GPU requirements,
+   readiness checks, and cleanup instructions. Creating an Endpoint allocates
+   billable resources; use your own project and resource limits.
+2. Configure token authentication with one HTTP port. Save the Endpoint ID and
+   its authentication token. The Endpoint token is separate from your Nebius
+   CLI/IAM credentials and from a Langflow API key.
+3. Wait for the model to load. Copy the managed HTTPS URL from the Endpoint's
+   **Public endpoints** field, rather than a VM IP address. A `RUNNING` status
+   or an assigned URL alone does not prove the model is ready.
+
+For example, check readiness from a machine that can reach the Endpoint:
+
+```bash
+export ENDPOINT_URL="https://<your-endpoint-host>"
+# Set AUTH_TOKEN securely to the token configured on this Endpoint.
+
+curl --fail-with-body --silent --show-error --max-time 10 \
+  "${ENDPOINT_URL%/}/health" -H "Authorization: Bearer $AUTH_TOKEN"
+curl --fail-with-body --silent --show-error --max-time 10 \
+  "${ENDPOINT_URL%/}/v1/models" -H "Authorization: Bearer $AUTH_TOKEN"
+```
+
+Wait until both requests succeed and the model list includes
+`Qwen/Qwen3-0.6B`. If you deployed a different model or served-name alias, use
+the exact `id` returned by `/v1/models` instead. Verify that requests without
+the token and with an incorrect token are rejected. The managed ingress
+provides authentication; restrict any direct subnet access separately.
+
+### Configure Langflow and run the flow
+
+Install the bundle as described above if it is not already included in your
+Langflow installation. Restart the backend after installing it.
+
+1. Open **Settings → Model Providers → OpenAI Compatible**.
+2. Set **Base URL** to the managed HTTPS URL and **API Key** to the Endpoint
+   token. The provider accepts a URL with or without a final `/v1`, including
+   a trailing slash; it uses exactly one `/v1` for these forms. Do not append
+   `/models` or `/chat/completions` to Base URL.
+3. Validate the settings, refresh the model list, and enable the served model.
+4. Download and import [Nebius Endpoint Chat](examples/nebius-serverless-chat.json)
+   into Langflow. It connects **Chat Input → Language Model → Chat Output**.
+   Select your enabled **OpenAI Compatible** model in the Language Model node;
+   leave its API Key override blank to use the provider settings.
+5. Open Playground and send `Say hello in one short sentence. /no_think`.
+   The example uses temperature `0` and a `512` token limit. `/no_think` is
+   specific to the example Qwen model; adapt the prompt for other models.
+6. After a successful response, enable **Stream** on the Language Model node
+   and repeat. Check that output arrives incrementally and completes.
+
+Alternatively, set these variables in the **Langflow backend's** environment
+before starting it:
+
+```bash
+export OPENAI_COMPATIBLE_BASE_URL="$ENDPOINT_URL"
+export OPENAI_COMPATIBLE_API_KEY="$AUTH_TOKEN"
+```
+
+Saved provider settings can take precedence over the environment. If a change
+does not take effect, check the executing user's settings, restart the backend
+when changing its environment, and refresh models. Keep tokens out of exported
+flows, source control, screenshots, and logs. The example contains no Endpoint
+URL or token and disables chat-history storage on its input/output nodes.
+
+### Capabilities and troubleshooting
+
+- **Empty model picker:** discovery has a five-second timeout and can return
+  an empty list on connection, authentication, or parsing errors. Check the
+  Endpoint's status/logs and authenticated `/v1/models` response. Discovery
+  does not follow redirects. Configure Langflow after the model is ready.
+- **Authentication errors:** use the Endpoint token, not an IAM token or
+  managed model API key. A successful settings check probes `/v1/models`;
+  test chat separately.
+- **Wrong model or unsupported operation:** model discovery does not prove
+  tool-calling or embedding support. This Qwen example is for chat. Models
+  appear in both Language Model and Embedding Model pickers, but embeddings
+  require an independently validated embedding model/server. The provider
+  holds only one endpoint at a time; see [Configure](#configure) for options
+  when chat and embeddings use different URLs.
+- **Interrupted stream:** a partial response is incomplete. Inspect the
+  inference server and ingress logs before retrying; cancelling a request
+  does not stop the Endpoint.
+
+### Stop serving and preserve application state
+
+Stop or delete the Endpoint explicitly using the linked deployment guide.
+Closing Langflow does not stop billing for a running Endpoint. After starting
+a stopped Endpoint, retrieve its current URL and repeat readiness checks
+before refreshing Langflow's provider configuration. This example does not
+configure autoscaling or automatic scale-to-zero.
+
+Keep Langflow's database/configuration on persistent storage independently of
+the model Endpoint. Do not rely on the Endpoint's container disk to preserve
+model downloads across stop/start. See [Endpoint management](https://docs.nebius.com/serverless/endpoints/manage)
+for lifecycle and storage options.
+
 ## Develop
 
 ```bash

--- a/src/bundles/openai-compatible/examples/nebius-serverless-chat.json
+++ b/src/bundles/openai-compatible/examples/nebius-serverless-chat.json
@@ -1,0 +1,1105 @@
+{
+  "data": {
+    "nodes": [
+      {
+        "data": {
+          "node": {
+            "template": {
+              "_type": "Component",
+              "files": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "file_path": "",
+                "fileTypes": [
+                  "csv",
+                  "json",
+                  "pdf",
+                  "txt",
+                  "md",
+                  "mdx",
+                  "yaml",
+                  "yml",
+                  "xml",
+                  "html",
+                  "htm",
+                  "docx",
+                  "py",
+                  "sh",
+                  "sql",
+                  "js",
+                  "ts",
+                  "tsx",
+                  "jpg",
+                  "jpeg",
+                  "png",
+                  "bmp",
+                  "image"
+                ],
+                "temp_file": true,
+                "list": true,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "files",
+                "value": "",
+                "display_name": "Files",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Files to be sent with the message.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "file",
+                "_input_type": "FileInput"
+              },
+              "code": {
+                "type": "code",
+                "required": true,
+                "placeholder": "",
+                "list": false,
+                "show": true,
+                "multiline": true,
+                "value": "from lfx.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.inputs.inputs import BoolInput\nfrom lfx.io import (\n    DropdownInput,\n    FileInput,\n    MessageTextInput,\n    MultilineInput,\n    Output,\n)\nfrom lfx.schema.image import get_file_paths\nfrom lfx.schema.message import Message\nfrom lfx.services.deps import get_settings_service\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_USER,\n    MESSAGE_SENDER_USER,\n)\nfrom lfx.utils.file_path_security import (\n    component_file_access_scopes,\n    enforce_local_file_access,\n    is_local_file_access_restricted,\n)\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatInput\"\n    minimized = True\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Input Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n            input_types=[],\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_USER,\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_USER,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n            temp_file=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Chat Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    async def message_response(self) -> Message:\n        # Ensure files is a list and filter out empty/None values\n        files = self.files if self.files else []\n        if files and not isinstance(files, list):\n            files = [files]\n        # Filter out None/empty values\n        files = [f for f in files if f is not None and f != \"\"]\n\n        # Build endpoints inject caller-controlled file references directly into\n        # ChatInput. Resolve and validate local references before the Message can\n        # later read them while constructing model attachment content.\n        if files:\n            settings_service = get_settings_service()\n            storage_type = getattr(getattr(settings_service, \"settings\", None), \"storage_type\", \"local\")\n            # The storage factory falls back to local storage for unsupported\n            # values, so only the explicitly configured S3 backend may bypass\n            # filesystem containment.\n            if str(storage_type).lower() != \"s3\" and is_local_file_access_restricted():\n                scope_ids = list(component_file_access_scopes(self))\n                # Public executions replace graph.flow_id with a per-visitor\n                # virtual ID. Only the server-populated source provenance may\n                # restore the already-validated public attachment namespace.\n                source_flow_id = getattr(self.graph, \"source_flow_id\", None)\n                if source_flow_id:\n                    scope_ids.append(source_flow_id)\n                for file_path in get_file_paths(files):\n                    enforce_local_file_access(file_path, scope_ids=scope_ids)\n\n        session_id = self.session_id or self.graph.session_id or \"\"\n        message = await Message.create(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=session_id,\n            context_id=self.context_id,\n            files=files,\n        )\n        if session_id and isinstance(message, Message) and self.should_store_message:\n            stored_message = await self.send_message(\n                message,\n            )\n            self.message.value = stored_message\n            message = stored_message\n\n        self.status = message\n        return message\n",
+                "fileTypes": [],
+                "file_path": "",
+                "password": false,
+                "name": "code",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": true,
+                "info": "",
+                "load_from_db": false,
+                "title_case": false
+              },
+              "context_id": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "context_id",
+                "value": "",
+                "display_name": "Context ID",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "input_value": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "multiline": true,
+                "ai_enabled": false,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "input_value",
+                "value": "",
+                "display_name": "Input Text",
+                "advanced": false,
+                "api_editable": false,
+                "input_types": [],
+                "dynamic": false,
+                "info": "Message to be passed as input.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "copy_field": false,
+                "password": false,
+                "type": "str",
+                "_input_type": "MultilineInput"
+              },
+              "sender": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "options_metadata": [],
+                "combobox": false,
+                "dialog_inputs": {},
+                "toggle": false,
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "sender",
+                "value": "User",
+                "display_name": "Sender Type",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Type of sender.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "external_options": {},
+                "type": "str",
+                "_input_type": "DropdownInput"
+              },
+              "sender_name": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "sender_name",
+                "value": "User",
+                "display_name": "Sender Name",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "session_id": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "session_id",
+                "value": "",
+                "display_name": "Session ID",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "should_store_message": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "should_store_message",
+                "value": false,
+                "display_name": "Store Messages",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "_input_type": "BoolInput"
+              }
+            },
+            "description": "Get chat inputs from the Playground.",
+            "icon": "MessagesSquare",
+            "base_classes": [
+              "Message"
+            ],
+            "display_name": "Chat Input",
+            "documentation": "https://docs.langflow.org/chat-input-and-output",
+            "minimized": true,
+            "custom_fields": {},
+            "output_types": [],
+            "pinned": false,
+            "conditional_paths": [],
+            "frozen": false,
+            "outputs": [
+              {
+                "types": [
+                  "Message"
+                ],
+                "selected": "Message",
+                "name": "message",
+                "display_name": "Chat Message",
+                "method": "message_response",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "allows_loop": false,
+                "group_outputs": false,
+                "tool_mode": true
+              }
+            ],
+            "field_order": [],
+            "beta": false,
+            "legacy": false,
+            "edited": false,
+            "metadata": {},
+            "tool_mode": false
+          },
+          "type": "ChatInput",
+          "id": "ChatInput-nebius"
+        },
+        "id": "ChatInput-nebius",
+        "position": {
+          "x": 0,
+          "y": 300
+        },
+        "type": "genericNode"
+      },
+      {
+        "data": {
+          "node": {
+            "template": {
+              "_type": "Component",
+              "input_value": {
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": true,
+                "placeholder": "",
+                "show": true,
+                "name": "input_value",
+                "value": "",
+                "display_name": "Inputs",
+                "advanced": false,
+                "api_editable": false,
+                "input_types": [
+                  "Data",
+                  "JSON",
+                  "DataFrame",
+                  "Table",
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "Message to be passed as output.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "other",
+                "_input_type": "HandleInput"
+              },
+              "clean_data": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "clean_data",
+                "value": true,
+                "display_name": "Basic Clean Data",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Whether to clean data before converting to string.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "_input_type": "BoolInput"
+              },
+              "code": {
+                "type": "code",
+                "required": true,
+                "placeholder": "",
+                "list": false,
+                "show": true,
+                "multiline": true,
+                "value": "from collections.abc import Generator\nfrom typing import Any\n\nimport orjson\nfrom fastapi.encoders import jsonable_encoder\n\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.helpers.data import safe_convert\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, HandleInput, MessageTextInput\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.schema.properties import Source\nfrom lfx.template.field.base import Output\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_AI,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatOutput\"\n    minimized = True\n\n    inputs = [\n        HandleInput(\n            name=\"input_value\",\n            display_name=\"Inputs\",\n            info=\"Message to be passed as output.\",\n            input_types=[\"Data\", \"JSON\", \"DataFrame\", \"Table\", \"Message\"],\n            required=True,\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_AI,\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_AI,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n        BoolInput(\n            name=\"clean_data\",\n            display_name=\"Basic Clean Data\",\n            value=True,\n            advanced=True,\n            info=\"Whether to clean data before converting to string.\",\n        ),\n    ]\n    outputs = [\n        Output(\n            display_name=\"Output Message\",\n            name=\"message\",\n            method=\"message_response\",\n        ),\n    ]\n\n    def _build_source(self, id_: str | None, display_name: str | None, source: str | None) -> Source:\n        source_dict = {}\n        if id_:\n            source_dict[\"id\"] = id_\n        if display_name:\n            source_dict[\"display_name\"] = display_name\n        if source:\n            # Handle case where source is a ChatOpenAI object\n            if hasattr(source, \"model_name\"):\n                source_dict[\"source\"] = source.model_name\n            elif hasattr(source, \"model\"):\n                source_dict[\"source\"] = str(source.model)\n            else:\n                source_dict[\"source\"] = str(source)\n        return Source(**source_dict)\n\n    async def message_response(self) -> Message:\n        # First convert the input to string if needed\n        text = self.convert_to_string()\n\n        # Get source properties\n        source, _, display_name, source_id = self.get_properties_from_source_component()\n\n        # Create or use existing Message object\n        if isinstance(self.input_value, Message) and not self.is_connected_to_chat_input():\n            message = self.input_value\n            # Update message properties\n            message.text = text\n            # Preserve existing session_id from the incoming message if it exists\n            existing_session_id = message.session_id\n        else:\n            message = Message(text=text)\n            existing_session_id = None\n\n        # Set message properties\n        message.sender = self.sender\n        message.sender_name = self.sender_name\n        # Preserve session_id from incoming message, or use component/graph session_id\n        message.session_id = (\n            self.session_id or existing_session_id or (self.graph.session_id if hasattr(self, \"graph\") else None) or \"\"\n        )\n        message.context_id = self.context_id\n        message.flow_id = self.graph.flow_id if hasattr(self, \"graph\") else None\n        message.properties.source = self._build_source(source_id, display_name, source)\n\n        # Store message if needed\n        if message.session_id and self.should_store_message:\n            stored_message = await self.send_message(message)\n            self.message.value = stored_message\n            message = stored_message\n\n        # Set accumulated token usage from all upstream LLM vertices.\n        # This must happen AFTER send_message() because streaming captures\n        # usage from chunks and would overwrite accumulated totals.\n        if hasattr(self, \"_vertex\") and self._vertex is not None:\n            accumulated_usage = self._vertex._accumulate_upstream_token_usage()  # noqa: SLF001\n            if accumulated_usage:\n                message.properties.usage = accumulated_usage\n                if self.should_store_message and message.get_id():\n                    message = await self._update_stored_message(message)\n                    await self._send_message_event(message, id_=message.get_id())\n\n        self.status = message\n        return message\n\n    def _serialize_data(self, data: Data) -> str:\n        \"\"\"Serialize Data object to JSON string.\"\"\"\n        # Convert data.data to JSON-serializable format\n        serializable_data = jsonable_encoder(data.data)\n        # Serialize with orjson, enabling pretty printing with indentation\n        json_bytes = orjson.dumps(serializable_data, option=orjson.OPT_INDENT_2)\n        # Convert bytes to string and wrap in Markdown code blocks\n        return \"```json\\n\" + json_bytes.decode(\"utf-8\") + \"\\n```\"\n\n    def _validate_input(self) -> None:\n        \"\"\"Validate the input data and raise ValueError if invalid.\"\"\"\n        if self.input_value is None:\n            msg = \"Input data cannot be None\"\n            raise ValueError(msg)\n        if isinstance(self.input_value, list) and not all(\n            isinstance(item, Message | Data | DataFrame | str) for item in self.input_value\n        ):\n            invalid_types = [\n                type(item).__name__\n                for item in self.input_value\n                if not isinstance(item, Message | Data | DataFrame | str)\n            ]\n            msg = f\"Expected Data or DataFrame or Message or str, got {invalid_types}\"\n            raise TypeError(msg)\n        if not isinstance(\n            self.input_value,\n            Message | Data | DataFrame | str | list | Generator | type(None),\n        ):\n            type_name = type(self.input_value).__name__\n            msg = f\"Expected Data or DataFrame or Message or str, Generator or None, got {type_name}\"\n            raise TypeError(msg)\n\n    def convert_to_string(self) -> str | Generator[Any, None, None]:\n        \"\"\"Convert input data to string with proper error handling.\"\"\"\n        self._validate_input()\n        if isinstance(self.input_value, list):\n            clean_data: bool = getattr(self, \"clean_data\", False)\n            return \"\\n\".join([safe_convert(item, clean_data=clean_data) for item in self.input_value])\n        if isinstance(self.input_value, Generator):\n            return self.input_value\n        return safe_convert(self.input_value)\n",
+                "fileTypes": [],
+                "file_path": "",
+                "password": false,
+                "name": "code",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": true,
+                "info": "",
+                "load_from_db": false,
+                "title_case": false
+              },
+              "context_id": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "context_id",
+                "value": "",
+                "display_name": "Context ID",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "data_template": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "data_template",
+                "value": "{text}",
+                "display_name": "Data Template",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "sender": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "options_metadata": [],
+                "combobox": false,
+                "dialog_inputs": {},
+                "toggle": false,
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "sender",
+                "value": "Machine",
+                "display_name": "Sender Type",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Type of sender.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "external_options": {},
+                "type": "str",
+                "_input_type": "DropdownInput"
+              },
+              "sender_name": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "sender_name",
+                "value": "AI",
+                "display_name": "Sender Name",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "session_id": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "session_id",
+                "value": "",
+                "display_name": "Session ID",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "should_store_message": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "should_store_message",
+                "value": false,
+                "display_name": "Store Messages",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "_input_type": "BoolInput"
+              }
+            },
+            "description": "Display a chat message in the Playground.",
+            "icon": "MessagesSquare",
+            "base_classes": [
+              "Message"
+            ],
+            "display_name": "Chat Output",
+            "documentation": "https://docs.langflow.org/chat-input-and-output",
+            "minimized": true,
+            "custom_fields": {},
+            "output_types": [],
+            "pinned": false,
+            "conditional_paths": [],
+            "frozen": false,
+            "outputs": [
+              {
+                "types": [
+                  "Message"
+                ],
+                "selected": "Message",
+                "name": "message",
+                "display_name": "Output Message",
+                "method": "message_response",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "allows_loop": false,
+                "group_outputs": false,
+                "tool_mode": true
+              }
+            ],
+            "field_order": [],
+            "beta": false,
+            "legacy": false,
+            "edited": false,
+            "metadata": {},
+            "tool_mode": false
+          },
+          "type": "ChatOutput",
+          "id": "ChatOutput-nebius"
+        },
+        "id": "ChatOutput-nebius",
+        "position": {
+          "x": 900,
+          "y": 300
+        },
+        "type": "genericNode"
+      },
+      {
+        "data": {
+          "node": {
+            "template": {
+              "_type": "Component",
+              "api_key": {
+                "load_from_db": true,
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "api_key",
+                "value": "",
+                "display_name": "API Key",
+                "advanced": true,
+                "api_editable": false,
+                "input_types": [],
+                "dynamic": false,
+                "info": "Overrides global provider settings. Leave blank to use your pre-configured API Key.",
+                "real_time_refresh": true,
+                "title_case": false,
+                "track_in_telemetry": false,
+                "password": true,
+                "type": "str",
+                "_input_type": "SecretStrInput"
+              },
+              "base_url_ibm_watsonx": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "options": [
+                  "https://us-south.ml.cloud.ibm.com",
+                  "https://eu-de.ml.cloud.ibm.com",
+                  "https://eu-gb.ml.cloud.ibm.com",
+                  "https://au-syd.ml.cloud.ibm.com",
+                  "https://jp-tok.ml.cloud.ibm.com",
+                  "https://ca-tor.ml.cloud.ibm.com"
+                ],
+                "options_metadata": [],
+                "combobox": true,
+                "dialog_inputs": {},
+                "toggle": false,
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": false,
+                "name": "base_url_ibm_watsonx",
+                "value": "https://us-south.ml.cloud.ibm.com",
+                "display_name": "watsonx API Endpoint",
+                "advanced": false,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "The base URL of the API (IBM watsonx.ai only)",
+                "real_time_refresh": true,
+                "title_case": false,
+                "track_in_telemetry": true,
+                "external_options": {},
+                "type": "str",
+                "_input_type": "DropdownInput"
+              },
+              "code": {
+                "type": "code",
+                "required": true,
+                "placeholder": "",
+                "list": false,
+                "show": true,
+                "multiline": true,
+                "value": "from lfx.base.models.model import LCModelComponent\nfrom lfx.base.models.unified_models import (\n    get_language_model_options,\n    get_llm,\n    handle_model_input_update,\n)\nfrom lfx.base.models.watsonx_constants import IBM_WATSONX_URLS\nfrom lfx.components.models_and_agents.model_selection import apply_model_overrides\nfrom lfx.field_typing.constants import LanguageModel\nfrom lfx.field_typing.range_spec import RangeSpec\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, StrInput\nfrom lfx.io import IntInput, MessageInput, ModelInput, MultilineInput, SecretStrInput, SliderInput\n\n\nclass LanguageModelComponent(LCModelComponent):\n    model_provider_policy_mode = \"delegate\"\n    display_name = \"Language Model\"\n    description = \"Runs a language model given a specified provider.\"\n    documentation: str = \"https://docs.langflow.org/components-models\"\n    icon = \"brain-circuit\"\n    category = \"models\"\n\n    inputs = [\n        ModelInput(\n            name=\"model\",\n            display_name=\"Language Model\",\n            info=\"Select your model provider\",\n            real_time_refresh=True,\n            required=True,\n        ),\n        StrInput(\n            name=\"model_name\",\n            display_name=\"Model Name Override\",\n            info=(\n                \"Optional model name to use instead of the selected model. \"\n                \"Can be set from a global variable for runtime model selection.\"\n            ),\n            advanced=True,\n            load_from_db=False,\n        ),\n        StrInput(\n            name=\"provider\",\n            display_name=\"Provider Override\",\n            info=(\n                \"Optional provider to use with Model Name Override. Leave blank to use the selected model's provider.\"\n            ),\n            advanced=True,\n            load_from_db=False,\n        ),\n        SecretStrInput(\n            name=\"api_key\",\n            display_name=\"API Key\",\n            info=\"Overrides global provider settings. Leave blank to use your pre-configured API Key.\",\n            required=False,\n            show=True,\n            real_time_refresh=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"base_url_ibm_watsonx\",\n            display_name=\"watsonx API Endpoint\",\n            info=\"The base URL of the API (IBM watsonx.ai only)\",\n            options=IBM_WATSONX_URLS,\n            value=IBM_WATSONX_URLS[0],\n            combobox=True,\n            show=False,\n            real_time_refresh=True,\n        ),\n        StrInput(\n            name=\"project_id\",\n            display_name=\"watsonx Project ID\",\n            info=\"The project ID associated with the foundation model (IBM watsonx.ai only)\",\n            show=False,\n            required=False,\n        ),\n        StrInput(\n            name=\"ollama_base_url\",\n            display_name=\"Ollama API URL\",\n            info=\"Endpoint of the Ollama API (Ollama only)\",\n            show=False,\n            real_time_refresh=True,\n        ),\n        MessageInput(\n            name=\"input_value\",\n            display_name=\"Input\",\n            info=\"The input text to send to the model\",\n        ),\n        MultilineInput(\n            name=\"system_message\",\n            display_name=\"System Message\",\n            info=\"A system message that helps set the behavior of the assistant\",\n            advanced=False,\n        ),\n        BoolInput(\n            name=\"stream\",\n            display_name=\"Stream\",\n            info=\"Whether to stream the response\",\n            value=False,\n            advanced=True,\n        ),\n        SliderInput(\n            name=\"temperature\",\n            display_name=\"Temperature\",\n            value=0.1,\n            info=\"Controls randomness in responses\",\n            range_spec=RangeSpec(min=0, max=1, step=0.01),\n            advanced=True,\n        ),\n        IntInput(\n            name=\"max_tokens\",\n            display_name=\"Max Tokens\",\n            info=\"Maximum number of tokens to generate. Field name varies by provider.\",\n            advanced=True,\n            range_spec=RangeSpec(min=1, max=128000, step=1, step_type=\"int\"),\n        ),\n    ]\n\n    def build_model(self) -> LanguageModel:\n        model = apply_model_overrides(\n            self.model,\n            model_name=getattr(self, \"model_name\", None),\n            provider=getattr(self, \"provider\", None),\n            user_id=self.user_id,\n            get_options=get_language_model_options,\n        )\n        return get_llm(\n            model=model,\n            user_id=self.user_id,\n            api_key=self.api_key,\n            temperature=self.temperature,\n            stream=self.stream,\n            max_tokens=getattr(self, \"max_tokens\", None),\n            watsonx_url=getattr(self, \"base_url_ibm_watsonx\", None),\n            watsonx_project_id=getattr(self, \"project_id\", None),\n            ollama_base_url=getattr(self, \"ollama_base_url\", None),\n        )\n\n    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None):\n        \"\"\"Dynamically update build config with user-filtered model options.\"\"\"\n        return handle_model_input_update(self, build_config, field_value, field_name)\n",
+                "fileTypes": [],
+                "file_path": "",
+                "password": false,
+                "name": "code",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": true,
+                "info": "",
+                "load_from_db": false,
+                "title_case": false
+              },
+              "input_value": {
+                "trace_as_input": true,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "input_value",
+                "value": {
+                  "text_key": "text",
+                  "data": {
+                    "text": "",
+                    "files": [],
+                    "sender": null,
+                    "sender_name": null,
+                    "session_id": "",
+                    "context_id": "",
+                    "run_id": null,
+                    "timestamp": "2026-09-12 19:10:19.809347 UTC",
+                    "flow_id": null,
+                    "error": false,
+                    "edit": false,
+                    "properties": {
+                      "edited": false,
+                      "source": {
+                        "id": null,
+                        "display_name": null,
+                        "source": null
+                      },
+                      "allow_markdown": false,
+                      "state": "complete",
+                      "targets": []
+                    },
+                    "category": "message",
+                    "content_blocks": [],
+                    "duration": null,
+                    "session_metadata": null
+                  },
+                  "default_value": "",
+                  "files": [],
+                  "session_id": "",
+                  "context_id": "",
+                  "timestamp": "2026-09-12 19:10:19.809347 UTC",
+                  "error": false,
+                  "edit": false,
+                  "properties": {
+                    "edited": false,
+                    "source": {
+                      "id": null,
+                      "display_name": null,
+                      "source": null
+                    },
+                    "allow_markdown": false,
+                    "state": "complete",
+                    "targets": []
+                  },
+                  "category": "message",
+                  "content_blocks": [],
+                  "text": ""
+                },
+                "display_name": "Input",
+                "advanced": false,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The input text to send to the model",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageInput"
+              },
+              "max_tokens": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "range_spec": {
+                  "step_type": "int",
+                  "min": 1.0,
+                  "max": 128000.0,
+                  "step": 1.0
+                },
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "max_tokens",
+                "value": 512,
+                "display_name": "Max Tokens",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Maximum number of tokens to generate. Field name varies by provider.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "int",
+                "_input_type": "IntInput"
+              },
+              "model": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "model_type": "language",
+                "external_options": {
+                  "fields": {
+                    "data": {
+                      "node": {
+                        "name": "connect_other_models",
+                        "display_name": "Connect other models",
+                        "icon": "CornerDownLeft"
+                      }
+                    }
+                  }
+                },
+                "override_skip": false,
+                "required": true,
+                "placeholder": "Setup Provider",
+                "show": true,
+                "name": "model",
+                "value": [
+                  {
+                    "name": "Qwen/Qwen3-0.6B",
+                    "provider": "OpenAI Compatible",
+                    "metadata": {},
+                    "category": "OpenAI Compatible"
+                  }
+                ],
+                "display_name": "Language Model",
+                "advanced": false,
+                "api_editable": false,
+                "input_types": [
+                  "LanguageModel"
+                ],
+                "dynamic": false,
+                "info": "Select your model provider",
+                "real_time_refresh": true,
+                "refresh_button": true,
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "model",
+                "_input_type": "ModelInput"
+              },
+              "model_name": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "model_name",
+                "value": "",
+                "display_name": "Model Name Override",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Optional model name to use instead of the selected model. Can be set from a global variable for runtime model selection.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "StrInput"
+              },
+              "ollama_base_url": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": false,
+                "name": "ollama_base_url",
+                "value": "",
+                "display_name": "Ollama API URL",
+                "advanced": false,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Endpoint of the Ollama API (Ollama only)",
+                "real_time_refresh": true,
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "StrInput"
+              },
+              "project_id": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": false,
+                "name": "project_id",
+                "value": "",
+                "display_name": "watsonx Project ID",
+                "advanced": false,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "The project ID associated with the foundation model (IBM watsonx.ai only)",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "StrInput"
+              },
+              "provider": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "provider",
+                "value": "",
+                "display_name": "Provider Override",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Optional provider to use with Model Name Override. Leave blank to use the selected model's provider.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "StrInput"
+              },
+              "stream": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "stream",
+                "value": false,
+                "display_name": "Stream",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Whether to stream the response",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "_input_type": "BoolInput"
+              },
+              "system_message": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "multiline": true,
+                "ai_enabled": false,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "system_message",
+                "value": "Answer briefly and clearly.",
+                "display_name": "System Message",
+                "advanced": false,
+                "api_editable": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "A system message that helps set the behavior of the assistant",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "copy_field": false,
+                "password": false,
+                "type": "str",
+                "_input_type": "MultilineInput"
+              },
+              "temperature": {
+                "tool_mode": false,
+                "min_label": "",
+                "max_label": "",
+                "min_label_icon": "",
+                "max_label_icon": "",
+                "slider_buttons": false,
+                "slider_buttons_options": [],
+                "slider_input": false,
+                "range_spec": {
+                  "step_type": "float",
+                  "min": 0.0,
+                  "max": 1.0,
+                  "step": 0.01
+                },
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "temperature",
+                "value": 0,
+                "display_name": "Temperature",
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": false,
+                "info": "Controls randomness in responses",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "slider",
+                "_input_type": "SliderInput"
+              }
+            },
+            "description": "Runs a language model given a specified provider.",
+            "icon": "brain-circuit",
+            "base_classes": [
+              "LanguageModel",
+              "Message"
+            ],
+            "display_name": "Language Model",
+            "documentation": "https://docs.langflow.org/components-models",
+            "minimized": false,
+            "custom_fields": {},
+            "output_types": [],
+            "pinned": false,
+            "conditional_paths": [],
+            "frozen": false,
+            "outputs": [
+              {
+                "types": [
+                  "Message"
+                ],
+                "selected": "Message",
+                "name": "text_output",
+                "display_name": "Model Response",
+                "method": "text_response",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "allows_loop": false,
+                "group_outputs": false,
+                "tool_mode": true
+              },
+              {
+                "types": [
+                  "LanguageModel"
+                ],
+                "selected": "LanguageModel",
+                "name": "model_output",
+                "display_name": "Language Model",
+                "method": "build_model",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "allows_loop": false,
+                "group_outputs": false,
+                "tool_mode": true
+              }
+            ],
+            "field_order": [],
+            "beta": false,
+            "legacy": false,
+            "edited": false,
+            "metadata": {
+              "keywords": [
+                "model",
+                "llm",
+                "language model",
+                "large language model"
+              ]
+            },
+            "tool_mode": false
+          },
+          "type": "LanguageModelComponent",
+          "id": "LanguageModelComponent-nebius"
+        },
+        "id": "LanguageModelComponent-nebius",
+        "position": {
+          "x": 450,
+          "y": 300
+        },
+        "type": "genericNode"
+      },
+      {
+        "id": "note-nebius",
+        "type": "noteNode",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "width": 1000,
+        "height": 240,
+        "style": {
+          "width": 1000,
+          "height": 240
+        },
+        "data": {
+          "id": "note-nebius",
+          "node": {
+            "display_name": "",
+            "documentation": "",
+            "description": "# Nebius Endpoint Chat\nUse an existing token-authenticated Nebius Serverless Endpoint serving an OpenAI-compatible model. This flow does not provision or stop cloud resources.\n\n1. Wait for authenticated `/v1/models` to list your model.\n2. In **Settings \u2192 Model Providers \u2192 OpenAI Compatible**, set the managed HTTPS Base URL and Endpoint token, then enable your model.\n3. Select that model below. Open **Playground** and send a message. The example selection is `Qwen/Qwen3-0.6B`.\n\nKeep tokens out of exported flows. Stop/delete the Endpoint separately when finished. Chat-history storage is disabled in this example. See the [bundle README](https://github.com/langflow-ai/langflow/tree/main/src/bundles/openai-compatible#nebius-serverless-endpoint) for setup and capability limitations.",
+            "template": {
+              "backgroundColor": "neutral"
+            }
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "ChatInput-nebius",
+        "target": "LanguageModelComponent-nebius",
+        "data": {
+          "sourceHandle": {
+            "dataType": "ChatInput",
+            "id": "ChatInput-nebius",
+            "name": "message",
+            "output_types": [
+              "Message"
+            ]
+          },
+          "targetHandle": {
+            "fieldName": "input_value",
+            "id": "LanguageModelComponent-nebius",
+            "inputTypes": [
+              "Message"
+            ],
+            "type": "str"
+          }
+        }
+      },
+      {
+        "source": "LanguageModelComponent-nebius",
+        "target": "ChatOutput-nebius",
+        "data": {
+          "sourceHandle": {
+            "dataType": "LanguageModelComponent",
+            "id": "LanguageModelComponent-nebius",
+            "name": "text_output",
+            "output_types": [
+              "Message"
+            ]
+          },
+          "targetHandle": {
+            "fieldName": "input_value",
+            "id": "ChatOutput-nebius",
+            "inputTypes": [
+              "Data",
+              "JSON",
+              "DataFrame",
+              "Table",
+              "Message"
+            ],
+            "type": "other"
+          }
+        }
+      }
+    ],
+    "viewport": {
+      "x": 0,
+      "y": 0,
+      "zoom": 0.75
+    }
+  },
+  "is_component": false,
+  "name": "Nebius Endpoint Chat",
+  "description": "Chat with a model deployed on a Nebius Serverless Endpoint using the OpenAI Compatible provider.",
+  "tags": [
+    "Q&A"
+  ]
+}

--- a/src/bundles/openai-compatible/examples/nebius-serverless-chat.json
+++ b/src/bundles/openai-compatible/examples/nebius-serverless-chat.json
@@ -217,7 +217,7 @@
                 "placeholder": "",
                 "show": true,
                 "name": "should_store_message",
-                "value": false,
+                "value": true,
                 "display_name": "Store Messages",
                 "advanced": true,
                 "api_editable": false,
@@ -271,7 +271,7 @@
         "id": "ChatInput-nebius",
         "position": {
           "x": 0,
-          "y": 300
+          "y": 430
         },
         "type": "genericNode"
       },
@@ -489,7 +489,7 @@
                 "placeholder": "",
                 "show": true,
                 "name": "should_store_message",
-                "value": false,
+                "value": true,
                 "display_name": "Store Messages",
                 "advanced": true,
                 "api_editable": false,
@@ -543,7 +543,7 @@
         "id": "ChatOutput-nebius",
         "position": {
           "x": 900,
-          "y": 300
+          "y": 430
         },
         "type": "genericNode"
       },
@@ -1010,7 +1010,7 @@
         "id": "LanguageModelComponent-nebius",
         "position": {
           "x": 450,
-          "y": 300
+          "y": 430
         },
         "type": "genericNode"
       },
@@ -1022,17 +1022,17 @@
           "y": 0
         },
         "width": 1000,
-        "height": 240,
+        "height": 360,
         "style": {
           "width": 1000,
-          "height": 240
+          "height": 360
         },
         "data": {
           "id": "note-nebius",
           "node": {
             "display_name": "",
             "documentation": "",
-            "description": "# Nebius Endpoint Chat\nUse an existing token-authenticated Nebius Serverless Endpoint serving an OpenAI-compatible model. This flow does not provision or stop cloud resources.\n\n1. Wait for authenticated `/v1/models` to list your model.\n2. In **Settings \u2192 Model Providers \u2192 OpenAI Compatible**, set the managed HTTPS Base URL and Endpoint token, then enable your model.\n3. Select that model below. Open **Playground** and send a message. The example selection is `Qwen/Qwen3-0.6B`.\n\nKeep tokens out of exported flows. Stop/delete the Endpoint separately when finished. Chat-history storage is disabled in this example. See the [bundle README](https://github.com/langflow-ai/langflow/tree/main/src/bundles/openai-compatible#nebius-serverless-endpoint) for setup and capability limitations.",
+            "description": "### Nebius Endpoint Chat\nUse an existing token-authenticated Nebius Endpoint serving an OpenAI-compatible model.\n\n1. Wait for authenticated `/v1/models` to list your model.\n2. In **Settings → Model Providers → OpenAI Compatible**, set the managed HTTPS Base URL and Endpoint token, then enable your model.\n3. Select the model below. Open **Playground** and send a message. This example uses `Qwen/Qwen3-0.6B`.\n\nKeep tokens out of exported flows. Stop/delete the Endpoint separately when finished. Playground messages are saved in Langflow. See the [bundle README](https://github.com/langflow-ai/langflow/tree/main/src/bundles/openai-compatible#nebius-serverless-endpoint).",
             "template": {
               "backgroundColor": "neutral"
             }
@@ -1061,7 +1061,10 @@
             ],
             "type": "str"
           }
-        }
+        },
+        "id": "nebius-edge-1",
+        "sourceHandle": "{œdataTypeœ: œChatInputœ, œidœ: œChatInput-nebiusœ, œnameœ: œmessageœ, œoutput_typesœ: [œMessageœ]}",
+        "targetHandle": "{œfieldNameœ: œinput_valueœ, œidœ: œLanguageModelComponent-nebiusœ, œinputTypesœ: [œMessageœ], œtypeœ: œstrœ}"
       },
       {
         "source": "LanguageModelComponent-nebius",
@@ -1087,7 +1090,10 @@
             ],
             "type": "other"
           }
-        }
+        },
+        "id": "nebius-edge-2",
+        "sourceHandle": "{œdataTypeœ: œLanguageModelComponentœ, œidœ: œLanguageModelComponent-nebiusœ, œnameœ: œtext_outputœ, œoutput_typesœ: [œMessageœ]}",
+        "targetHandle": "{œfieldNameœ: œinput_valueœ, œidœ: œChatOutput-nebiusœ, œinputTypesœ: [œDataœ, œJSONœ, œDataFrameœ, œTableœ, œMessageœ], œtypeœ: œotherœ}"
       }
     ],
     "viewport": {

--- a/src/bundles/openai-compatible/tests/integration/test_nebius_serverless_endpoint.py
+++ b/src/bundles/openai-compatible/tests/integration/test_nebius_serverless_endpoint.py
@@ -1,0 +1,223 @@
+"""Run the exported example against a local authenticated OpenAI-compatible API.
+
+These tests exercise real graph loading, provider configuration, HTTP clients,
+and SSE parsing. They do not provision or contact Nebius resources.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import pytest
+from lfx.base.models import provider_registry
+from lfx.extension import load_extension
+from lfx.graph import Graph
+from lfx.services.manager import get_service_manager
+from lfx.services.schema import ServiceType
+from lfx.services.variable.service import VariableService
+from lfx_openai_compatible.discovery import (
+    fetch_live_openai_compatible_models,
+    validate_openai_compatible_credentials,
+)
+
+pytestmark = pytest.mark.integration
+
+_BUNDLE_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE = _BUNDLE_ROOT / "examples" / "nebius-serverless-chat.json"
+_MODEL = "Qwen/Qwen3-0.6B"
+_TOKEN = "example-test-token"  # noqa: S105 - only used by the local test server
+_USER_ID = "11111111-1111-4111-8111-111111111111"
+
+
+@contextmanager
+def _example_provider():
+    """Reuse an existing provider and unregister only a registration we create."""
+    already_registered = provider_registry.is_registered("OpenAI Compatible")
+    try:
+        if not already_registered:
+            result = load_extension(_BUNDLE_ROOT / "src" / "lfx_openai_compatible")
+            assert result.ok, (result.errors, result.warnings)
+        yield
+    finally:
+        if not already_registered:
+            provider_registry.unregister_provider("OpenAI Compatible")
+
+
+@pytest.fixture
+def endpoint(monkeypatch):
+    """Serve a small authenticated API on loopback, with real HTTP/SSE framing."""
+    requests = []
+    # Standalone graph tests do not initialize Langflow's application services.
+    # Use LFX's real environment-backed variable service for user-scoped discovery.
+    monkeypatch.setitem(get_service_manager().services, ServiceType.VARIABLE_SERVICE, VariableService())
+
+    class Handler(BaseHTTPRequestHandler):
+        """Implement the authenticated discovery, chat and SSE test API."""
+
+        def log_message(self, *_args):
+            """Suppress routine HTTP access logs in test output."""
+
+        def respond(self, status, data, content_type="application/json"):
+            """Send a complete JSON or SSE response with its content length."""
+            body = data.encode() if isinstance(data, str) else json.dumps(data).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def authorized(self):
+            """Accept the fixture bearer token or return an authentication error."""
+            if self.headers.get("Authorization") == f"Bearer {_TOKEN}":
+                return True
+            self.respond(401, {"error": {"message": "Invalid token", "type": "authentication_error"}})
+            return False
+
+        def do_GET(self):
+            """Serve authenticated model discovery and record the request."""
+            requests.append(("GET", self.path, self.headers.get("Authorization"), None))
+            if not self.authorized():
+                return
+            if self.path != "/v1/models":
+                self.respond(404, {})
+                return
+            self.respond(200, {"data": [{"id": _MODEL, "object": "model"}]})
+
+        def do_POST(self):
+            """Serve authenticated chat completion or SSE and record the request."""
+            data = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests.append(("POST", self.path, self.headers.get("Authorization"), data))
+            if not self.authorized():
+                return
+            if self.path != "/v1/chat/completions":
+                self.respond(404, {})
+                return
+            if data["model"] != _MODEL:
+                self.respond(400, {"error": {"message": "Unknown model"}})
+                return
+            common = {"id": "chatcmpl-example", "created": 0, "model": _MODEL}
+            if data.get("stream"):
+                chunks = [
+                    {"delta": {"role": "assistant", "content": "Hello"}, "finish_reason": None},
+                    {"delta": {"content": " from the endpoint."}, "finish_reason": None},
+                    {"delta": {}, "finish_reason": "stop"},
+                ]
+                frames = [
+                    "data: "
+                    + json.dumps({**common, "object": "chat.completion.chunk", "choices": [{"index": 0, **chunk}]})
+                    + "\n\n"
+                    for chunk in chunks
+                ]
+                self.respond(200, "".join(frames) + "data: [DONE]\n\n", "text/event-stream")
+            else:
+                self.respond(
+                    200,
+                    {
+                        **common,
+                        "object": "chat.completion",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "Hello from the endpoint."},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
+                    },
+                )
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", f"http://127.0.0.1:{server.server_port}")
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", _TOKEN)
+        # Local connector access is explicitly limited to this test's loopback server.
+        monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "true")
+        with _example_provider():
+            yield requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_imported_example_runs_with_authenticated_provider(endpoint, stream):
+    """Execute the exported graph through real authenticated HTTP or SSE."""
+    assert [model["name"] for model in fetch_live_openai_compatible_models(_USER_ID)] == [_MODEL]
+    payload = json.loads(_EXAMPLE.read_text())
+    for node in payload["data"]["nodes"]:
+        if node["id"] == "LanguageModelComponent-nebius":
+            node["data"]["node"]["template"]["stream"]["value"] = stream
+        if node["id"] == "ChatInput-nebius":
+            node["data"]["node"]["template"]["input_value"]["value"] = "Say hello."
+
+    # Serialize/reload again to check that no live component objects are needed.
+    graph = Graph.from_payload(json.loads(json.dumps(payload)))
+
+    async def run_graph():
+        """Consume every graph result so all connected components execute."""
+        return [result async for result in graph.async_start()]
+
+    asyncio.run(asyncio.wait_for(run_graph(), timeout=20))
+    message = graph.get_vertex("ChatOutput-nebius").results["message"]
+    assert message.text == "Hello from the endpoint."
+    posts = [request for request in endpoint if request[0] == "POST"]
+    assert len(posts) == 1
+    _, path, authorization, body = posts[0]
+    assert path == "/v1/chat/completions"
+    assert authorization == f"Bearer {_TOKEN}"
+    assert body["model"] == _MODEL
+    assert body["stream"] is stream
+    assert body["messages"][-1]["content"] == "Say hello."
+
+
+def test_wrong_endpoint_token_is_rejected(endpoint, monkeypatch):
+    """Reject incorrect credentials in both discovery and provider validation."""
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "incorrect-test-token")
+    assert fetch_live_openai_compatible_models(_USER_ID) == []
+    url = os.environ["OPENAI_COMPATIBLE_BASE_URL"]
+    with pytest.raises(ValueError, match="Authentication failed"):
+        validate_openai_compatible_credentials(
+            "OpenAI Compatible",
+            {"OPENAI_COMPATIBLE_BASE_URL": url, "OPENAI_COMPATIBLE_API_KEY": os.environ["OPENAI_COMPATIBLE_API_KEY"]},
+        )
+    assert len(endpoint) == 2
+
+
+def test_provider_scope_preserves_existing_registrations_on_failure():
+    """Keep unrelated and reused providers intact, including exceptional teardown."""
+    name = "Nebius Example Isolation Sentinel"
+    previous = provider_registry.get_provider_descriptor("OpenAI Compatible")
+    sentinel = provider_registry.ProviderDescriptor(
+        name=name,
+        metadata={"mapping": {"model_class": "ChatOpenAI"}},
+    )
+
+    def fail_with_nested_provider_scope():
+        """Exercise reused-provider cleanup before simulating a graph failure."""
+        with _example_provider():
+            registered = provider_registry.get_provider_descriptor("OpenAI Compatible")
+            assert registered is not None
+            with _example_provider():
+                assert provider_registry.get_provider_descriptor("OpenAI Compatible") is registered
+            assert provider_registry.get_provider_descriptor("OpenAI Compatible") is registered
+            assert provider_registry.get_provider_descriptor(name) is sentinel
+            message = "simulated graph failure"
+            raise RuntimeError(message)
+
+    assert provider_registry.register_provider(sentinel)
+    try:
+        with pytest.raises(RuntimeError, match="simulated graph failure"):
+            fail_with_nested_provider_scope()
+        assert provider_registry.get_provider_descriptor("OpenAI Compatible") is previous
+        assert provider_registry.get_provider_descriptor(name) is sentinel
+    finally:
+        provider_registry.unregister_provider(name)

--- a/src/bundles/openai-compatible/tests/test_nebius_serverless_example.py
+++ b/src/bundles/openai-compatible/tests/test_nebius_serverless_example.py
@@ -1,134 +1,15 @@
-"""Run the exported example against a local authenticated OpenAI-compatible API.
+"""Validate the exported Nebius example without starting an HTTP server."""
 
-These tests exercise real graph loading, provider configuration, HTTP clients,
-and SSE parsing. They do not provision or contact Nebius resources.
-"""
-
-from __future__ import annotations
-
-import asyncio
 import json
-import os
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from threading import Thread
 
-import pytest
-from lfx.base.models import provider_registry
-from lfx.extension import load_extension
 from lfx.graph import Graph
-from lfx.services.manager import get_service_manager
-from lfx.services.schema import ServiceType
-from lfx.services.variable.service import VariableService
-from lfx_openai_compatible.discovery import (
-    fetch_live_openai_compatible_models,
-    validate_openai_compatible_credentials,
-)
 
-_BUNDLE_ROOT = Path(__file__).resolve().parents[1]
-_EXAMPLE = _BUNDLE_ROOT / "examples" / "nebius-serverless-chat.json"
-_MODEL = "Qwen/Qwen3-0.6B"
-_TOKEN = "example-test-token"  # noqa: S105 - only used by the local test server
-_USER_ID = "11111111-1111-4111-8111-111111111111"
-
-
-@pytest.fixture
-def endpoint(monkeypatch):
-    """Serve a small authenticated API on loopback, with real HTTP/SSE framing."""
-    requests = []
-    # Standalone graph tests do not initialize Langflow's application services.
-    # Use LFX's real environment-backed variable service for user-scoped discovery.
-    monkeypatch.setitem(get_service_manager().services, ServiceType.VARIABLE_SERVICE, VariableService())
-
-    class Handler(BaseHTTPRequestHandler):
-        def log_message(self, *_args):
-            pass
-
-        def respond(self, status, data, content_type="application/json"):
-            body = data.encode() if isinstance(data, str) else json.dumps(data).encode()
-            self.send_response(status)
-            self.send_header("Content-Type", content_type)
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
-        def authorized(self):
-            if self.headers.get("Authorization") == f"Bearer {_TOKEN}":
-                return True
-            self.respond(401, {"error": {"message": "Invalid token", "type": "authentication_error"}})
-            return False
-
-        def do_GET(self):
-            requests.append(("GET", self.path, self.headers.get("Authorization"), None))
-            if not self.authorized():
-                return
-            if self.path != "/v1/models":
-                self.respond(404, {})
-                return
-            self.respond(200, {"data": [{"id": _MODEL, "object": "model"}]})
-
-        def do_POST(self):
-            data = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
-            requests.append(("POST", self.path, self.headers.get("Authorization"), data))
-            if not self.authorized():
-                return
-            if self.path != "/v1/chat/completions":
-                self.respond(404, {})
-                return
-            if data["model"] != _MODEL:
-                self.respond(400, {"error": {"message": "Unknown model"}})
-                return
-            common = {"id": "chatcmpl-example", "created": 0, "model": _MODEL}
-            if data.get("stream"):
-                chunks = [
-                    {"delta": {"role": "assistant", "content": "Hello"}, "finish_reason": None},
-                    {"delta": {"content": " from the endpoint."}, "finish_reason": None},
-                    {"delta": {}, "finish_reason": "stop"},
-                ]
-                frames = [
-                    "data: "
-                    + json.dumps({**common, "object": "chat.completion.chunk", "choices": [{"index": 0, **chunk}]})
-                    + "\n\n"
-                    for chunk in chunks
-                ]
-                self.respond(200, "".join(frames) + "data: [DONE]\n\n", "text/event-stream")
-            else:
-                self.respond(
-                    200,
-                    {
-                        **common,
-                        "object": "chat.completion",
-                        "choices": [
-                            {
-                                "index": 0,
-                                "message": {"role": "assistant", "content": "Hello from the endpoint."},
-                                "finish_reason": "stop",
-                            }
-                        ],
-                        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
-                    },
-                )
-
-    provider_registry.clear()
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-    thread = Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        result = load_extension(_BUNDLE_ROOT / "src" / "lfx_openai_compatible")
-        assert result.ok, (result.errors, result.warnings)
-        monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", f"http://127.0.0.1:{server.server_port}")
-        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", _TOKEN)
-        # Local connector access is explicitly limited to this test's loopback server.
-        monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "true")
-        yield requests
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
-        provider_registry.clear()
+_EXAMPLE = Path(__file__).resolve().parents[1] / "examples" / "nebius-serverless-chat.json"
 
 
 def test_example_contains_no_credentials_and_preserves_connections():
+    """Preserve browser edges, blank secrets and Playground message storage."""
     payload = json.loads(_EXAMPLE.read_text())
     edges = payload["data"]["edges"]
     assert len({edge["id"] for edge in edges}) == len(edges)
@@ -150,44 +31,3 @@ def test_example_contains_no_credentials_and_preserves_connections():
                 assert not field.get("value")
         if "should_store_message" in template:
             assert template["should_store_message"]["value"] is True
-
-
-@pytest.mark.parametrize("stream", [False, True])
-def test_imported_example_runs_with_authenticated_provider(endpoint, stream):
-    assert [model["name"] for model in fetch_live_openai_compatible_models(_USER_ID)] == [_MODEL]
-    payload = json.loads(_EXAMPLE.read_text())
-    for node in payload["data"]["nodes"]:
-        if node["id"] == "LanguageModelComponent-nebius":
-            node["data"]["node"]["template"]["stream"]["value"] = stream
-        if node["id"] == "ChatInput-nebius":
-            node["data"]["node"]["template"]["input_value"]["value"] = "Say hello."
-
-    # Serialize/reload again to check that no live component objects are needed.
-    graph = Graph.from_payload(json.loads(json.dumps(payload)))
-
-    async def run_graph():
-        return [result async for result in graph.async_start()]
-
-    asyncio.run(asyncio.wait_for(run_graph(), timeout=20))
-    message = graph.get_vertex("ChatOutput-nebius").results["message"]
-    assert message.text == "Hello from the endpoint."
-    posts = [request for request in endpoint if request[0] == "POST"]
-    assert len(posts) == 1
-    _, path, authorization, body = posts[0]
-    assert path == "/v1/chat/completions"
-    assert authorization == f"Bearer {_TOKEN}"
-    assert body["model"] == _MODEL
-    assert body["stream"] is stream
-    assert body["messages"][-1]["content"] == "Say hello."
-
-
-def test_wrong_endpoint_token_is_rejected(endpoint, monkeypatch):
-    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "incorrect-test-token")
-    assert fetch_live_openai_compatible_models(_USER_ID) == []
-    url = os.environ["OPENAI_COMPATIBLE_BASE_URL"]
-    with pytest.raises(ValueError, match="Authentication failed"):
-        validate_openai_compatible_credentials(
-            "OpenAI Compatible",
-            {"OPENAI_COMPATIBLE_BASE_URL": url, "OPENAI_COMPATIBLE_API_KEY": os.environ["OPENAI_COMPATIBLE_API_KEY"]},
-        )
-    assert len(endpoint) == 2

--- a/src/bundles/openai-compatible/tests/test_nebius_serverless_example.py
+++ b/src/bundles/openai-compatible/tests/test_nebius_serverless_example.py
@@ -1,0 +1,188 @@
+"""Run the exported example against a local authenticated OpenAI-compatible API.
+
+These tests exercise real graph loading, provider configuration, HTTP clients,
+and SSE parsing. They do not provision or contact Nebius resources.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import pytest
+from lfx.base.models import provider_registry
+from lfx.extension import load_extension
+from lfx.graph import Graph
+from lfx.services.manager import get_service_manager
+from lfx.services.schema import ServiceType
+from lfx.services.variable.service import VariableService
+from lfx_openai_compatible.discovery import (
+    fetch_live_openai_compatible_models,
+    validate_openai_compatible_credentials,
+)
+
+_BUNDLE_ROOT = Path(__file__).resolve().parents[1]
+_EXAMPLE = _BUNDLE_ROOT / "examples" / "nebius-serverless-chat.json"
+_MODEL = "Qwen/Qwen3-0.6B"
+_TOKEN = "example-test-token"  # noqa: S105 - only used by the local test server
+_USER_ID = "11111111-1111-4111-8111-111111111111"
+
+
+@pytest.fixture
+def endpoint(monkeypatch):
+    """Serve a small authenticated API on loopback, with real HTTP/SSE framing."""
+    requests = []
+    # Standalone graph tests do not initialize Langflow's application services.
+    # Use LFX's real environment-backed variable service for user-scoped discovery.
+    monkeypatch.setitem(get_service_manager().services, ServiceType.VARIABLE_SERVICE, VariableService())
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def respond(self, status, data, content_type="application/json"):
+            body = data.encode() if isinstance(data, str) else json.dumps(data).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def authorized(self):
+            if self.headers.get("Authorization") == f"Bearer {_TOKEN}":
+                return True
+            self.respond(401, {"error": {"message": "Invalid token", "type": "authentication_error"}})
+            return False
+
+        def do_GET(self):
+            requests.append(("GET", self.path, self.headers.get("Authorization"), None))
+            if not self.authorized():
+                return
+            if self.path != "/v1/models":
+                self.respond(404, {})
+                return
+            self.respond(200, {"data": [{"id": _MODEL, "object": "model"}]})
+
+        def do_POST(self):
+            data = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests.append(("POST", self.path, self.headers.get("Authorization"), data))
+            if not self.authorized():
+                return
+            if self.path != "/v1/chat/completions":
+                self.respond(404, {})
+                return
+            if data["model"] != _MODEL:
+                self.respond(400, {"error": {"message": "Unknown model"}})
+                return
+            common = {"id": "chatcmpl-example", "created": 0, "model": _MODEL}
+            if data.get("stream"):
+                chunks = [
+                    {"delta": {"role": "assistant", "content": "Hello"}, "finish_reason": None},
+                    {"delta": {"content": " from the endpoint."}, "finish_reason": None},
+                    {"delta": {}, "finish_reason": "stop"},
+                ]
+                frames = [
+                    "data: "
+                    + json.dumps({**common, "object": "chat.completion.chunk", "choices": [{"index": 0, **chunk}]})
+                    + "\n\n"
+                    for chunk in chunks
+                ]
+                self.respond(200, "".join(frames) + "data: [DONE]\n\n", "text/event-stream")
+            else:
+                self.respond(
+                    200,
+                    {
+                        **common,
+                        "object": "chat.completion",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "Hello from the endpoint."},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
+                    },
+                )
+
+    provider_registry.clear()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        result = load_extension(_BUNDLE_ROOT / "src" / "lfx_openai_compatible")
+        assert result.ok, (result.errors, result.warnings)
+        monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", f"http://127.0.0.1:{server.server_port}")
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", _TOKEN)
+        # Local connector access is explicitly limited to this test's loopback server.
+        monkeypatch.setenv("LANGFLOW_CONNECTOR_SSRF_ALLOW_LOOPBACK", "true")
+        yield requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        provider_registry.clear()
+
+
+def test_example_contains_no_credentials_and_preserves_connections():
+    payload = json.loads(_EXAMPLE.read_text())
+    graph = Graph.from_payload(payload)
+    assert len(graph.vertices) == 3
+    assert {(edge.source_id, edge.target_id) for edge in graph.edges} == {
+        ("ChatInput-nebius", "LanguageModelComponent-nebius"),
+        ("LanguageModelComponent-nebius", "ChatOutput-nebius"),
+    }
+    for node in payload["data"]["nodes"]:
+        if node["type"] == "noteNode":
+            continue
+        template = node["data"]["node"]["template"]
+        for field in template.values():
+            if isinstance(field, dict) and field.get("password"):
+                assert not field.get("value")
+        if "should_store_message" in template:
+            assert template["should_store_message"]["value"] is False
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_imported_example_runs_with_authenticated_provider(endpoint, stream):
+    assert [model["name"] for model in fetch_live_openai_compatible_models(_USER_ID)] == [_MODEL]
+    payload = json.loads(_EXAMPLE.read_text())
+    for node in payload["data"]["nodes"]:
+        if node["id"] == "LanguageModelComponent-nebius":
+            node["data"]["node"]["template"]["stream"]["value"] = stream
+        if node["id"] == "ChatInput-nebius":
+            node["data"]["node"]["template"]["input_value"]["value"] = "Say hello."
+
+    # Serialize/reload again to check that no live component objects are needed.
+    graph = Graph.from_payload(json.loads(json.dumps(payload)))
+
+    async def run_graph():
+        return [result async for result in graph.async_start()]
+
+    asyncio.run(asyncio.wait_for(run_graph(), timeout=20))
+    message = graph.get_vertex("ChatOutput-nebius").results["message"]
+    assert message.text == "Hello from the endpoint."
+    posts = [request for request in endpoint if request[0] == "POST"]
+    assert len(posts) == 1
+    _, path, authorization, body = posts[0]
+    assert path == "/v1/chat/completions"
+    assert authorization == f"Bearer {_TOKEN}"
+    assert body["model"] == _MODEL
+    assert body["stream"] is stream
+    assert body["messages"][-1]["content"] == "Say hello."
+
+
+def test_wrong_endpoint_token_is_rejected(endpoint, monkeypatch):
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "incorrect-test-token")
+    assert fetch_live_openai_compatible_models(_USER_ID) == []
+    url = os.environ["OPENAI_COMPATIBLE_BASE_URL"]
+    with pytest.raises(ValueError, match="Authentication failed"):
+        validate_openai_compatible_credentials(
+            "OpenAI Compatible",
+            {"OPENAI_COMPATIBLE_BASE_URL": url, "OPENAI_COMPATIBLE_API_KEY": os.environ["OPENAI_COMPATIBLE_API_KEY"]},
+        )
+    assert len(endpoint) == 2

--- a/src/bundles/openai-compatible/tests/test_nebius_serverless_example.py
+++ b/src/bundles/openai-compatible/tests/test_nebius_serverless_example.py
@@ -130,6 +130,11 @@ def endpoint(monkeypatch):
 
 def test_example_contains_no_credentials_and_preserves_connections():
     payload = json.loads(_EXAMPLE.read_text())
+    edges = payload["data"]["edges"]
+    assert len({edge["id"] for edge in edges}) == len(edges)
+    for edge in edges:
+        for handle in ("sourceHandle", "targetHandle"):
+            assert json.loads(edge[handle].replace("œ", '"')) == edge["data"][handle]
     graph = Graph.from_payload(payload)
     assert len(graph.vertices) == 3
     assert {(edge.source_id, edge.target_id) for edge in graph.edges} == {
@@ -144,7 +149,7 @@ def test_example_contains_no_credentials_and_preserves_connections():
             if isinstance(field, dict) and field.get("password"):
                 assert not field.get("value")
         if "should_store_message" in template:
-            assert template["should_store_message"]["value"] is False
+            assert template["should_store_message"]["value"] is True
 
 
 @pytest.mark.parametrize("stream", [False, True])


### PR DESCRIPTION
Users with a model deployed on a Nebius Serverless Endpoint can configure the existing OpenAI Compatible provider and import a small chat flow. The guide covers managed HTTPS, Endpoint bearer tokens, `/v1` normalization, live discovery, streaming, capability limits and explicit cleanup, linking to the vLLM provisioning guide.

The example uses Chat Input → Language Model → Chat Output with an instructions note and no embedded Endpoint URL or token. It keeps standard Langflow message storage enabled so replies appear in Playground, and documents that prompts and responses are saved. Live testing caught missing browser edge IDs/handles and suppressed Playground messages; the final export and regression checks address both.

Validation against `release-1.13.0` at `0f0cd0e934296de805b196b326dd8748538ec4c7`:

- 45 bundle tests passed; applicable pre-commit hooks, secret scanning and `git diff --check` passed. Five new cases cover graph/browser-edge schema, authenticated local HTTP chat/SSE, wrong-token rejection and provider isolation across nested scopes and failures. HTTP/SSE tests are marked `integration` and live under `tests/integration/`; the structural test stays in the regular test directory. The fixture reuses existing providers and unregisters only its own registration. All new functions have docstrings.
- The actual Langflow 1.13.0 frontend built and the example ran in Playground with nonstreaming and streaming enabled. Python 3.11.15, LFX 1.13.0, bundle 0.1.5, langchain-openai 1.4.1, OpenAI 2.48.0; dependencies from the repository lockfile.
- A real Nebius L40S Endpoint served vLLM 0.19.1 and Qwen/Qwen3-0.6B. Authenticated discovery/chat/SSE, four Base URL forms, missing/wrong token rejection, unknown-model and unsupported-embedding errors passed.
- Export/reimport excluded the actual Endpoint URL/token. Saved settings survived a backend restart, and Playground inference passed after Endpoint stop/start. The Endpoint and all managed VM/boot-disk resources were deleted and independently confirmed absent.

Import/export used Langflow's APIs because browser file-picker automation timed out; browser layout and Playground execution were checked. Direct SSE arrived in separate chunks, but browser token timing was not measured. The API-key-only `/api/v1/run` route, token rotation and forced network-failure recovery are not claimed. The small Qwen model may render empty `<think>` tags even with `/no_think`.

No provider/runtime implementation, dependencies, model catalog, icons or lifecycle code are added. This is separate from the AI Studio managed-model component in #9692 and remains a bundle-local example rather than a registered global starter template. Placement is open to maintainer guidance.
